### PR TITLE
Ruby 1.9.2 compatibility

### DIFF
--- a/lib/sass/plugin/staleness_checker.rb
+++ b/lib/sass/plugin/staleness_checker.rb
@@ -121,7 +121,7 @@ module Sass
       end
 
       def dependency_updated?(css_mtime)
-        lambda do |uri, importer|
+        Proc.new do |uri, importer|
           mtime(uri, importer) > css_mtime ||
             dependencies_stale?(uri, importer, css_mtime)
         end


### PR DESCRIPTION
We ran into issues with the alpha build of Sass in a ruby 1.9 environment.  The tests were failing in ruby 1.9.2.  This pull request fixes that.  It's a trivial fix, but see the commit for more detail.  I confirmed the tests still pass in ruby 1.8.7 too
