### PR TITLE
fssm, indenting, version fix

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -68,7 +68,7 @@ at_exit { File.delete(scope('REVISION')) rescue nil }
 
 desc "Install Sass as a gem. Use SUDO=1 to install with sudo."
 task :install => [:package] do
-  gem  = RUBY_PLATFORM =~ /java/  ? 'jgem' : 'gem' 
+  gem  = RUBY_PLATFORM =~ /java/  ? 'jgem' : 'gem'
   sh %{#{'sudo ' if ENV["SUDO"]}#{gem} install --no-ri pkg/sass-#{get_version}}
 end
 
@@ -147,7 +147,7 @@ def get_version
   version.map! {|n| n =~ /^[0-9]+$/ ? n.to_i : n}
   return written_version unless version.size == 5 && version[3] == "alpha" # prerelease
 
-  return written_version if (commit_count = `git log --pretty=oneline --first-parent stable.. | wc -l`).empty?
+  return written_version if (commit_count = `git log --pretty=oneline --first-parent origin/stable.. | wc -l`).empty?
   version[4] = commit_count.strip
   version.join('.')
 end
@@ -279,7 +279,7 @@ END
     file = File.read(scope("test/sass/templates/#{file || 'complex'}.sass"))
     result = RubyProf.profile { times.times { Sass::Engine.new(file).render } }
 
-    RubyProf.const_get("#{(ENV['OUTPUT'] || 'Flat').capitalize}Printer").new(result).print 
+    RubyProf.const_get("#{(ENV['OUTPUT'] || 'Flat').capitalize}Printer").new(result).print
   end
 rescue LoadError; end
 

--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -144,7 +144,8 @@ module Sass
       :cache => true,
       :cache_location => './.sass-cache',
       :syntax => :sass,
-      :filesystem_importer => Sass::Importers::Filesystem
+      :filesystem_importer => Sass::Importers::Filesystem,
+      :indent_with => '  '
     }.freeze
 
     # Converts a Sass options hash into a standard form, filling in

--- a/lib/sass/tree/node.rb
+++ b/lib/sass/tree/node.rb
@@ -125,6 +125,10 @@ module Sass
         @options[:style]
       end
 
+      def indent_with
+        @options[:indent_with] || '  '
+      end
+
       # Computes the CSS corresponding to this static CSS tree.
       #
       # @return [String, nil] The resulting CSS

--- a/lib/sass/tree/visitors/to_css.rb
+++ b/lib/sass/tree/visitors/to_css.rb
@@ -57,7 +57,7 @@ class Sass::Tree::Visitors::ToCss < Sass::Tree::Visitors::Base
 
   def visit_comment(node)
     return if node.invisible?
-    spaces = ('  ' * [@tabs - node.value[/^ */].size, 0].max)
+    spaces = (node.indent_with * [@tabs - node.value[/^ */].size, 0].max)
 
     content = node.value.gsub(/^/, spaces)
     content.gsub!(/\n +(\* *(?!\/))?/, ' ') if node.style == :compact
@@ -70,7 +70,7 @@ class Sass::Tree::Visitors::ToCss < Sass::Tree::Visitors::Base
     result = if node.style == :compressed
                "#{node.value}{"
              else
-               "#{'  ' * @tabs}#{node.value} {" + (node.style == :compact ? ' ' : "\n")
+               "#{node.indent_with * @tabs}#{node.value} {" + (node.style == :compact ? ' ' : "\n")
              end
     was_prop = false
     first = true
@@ -108,7 +108,7 @@ class Sass::Tree::Visitors::ToCss < Sass::Tree::Visitors::Base
   end
 
   def visit_prop(node)
-    tab_str = '  ' * (@tabs + node.tabs)
+    tab_str = node.indent_with * (@tabs + node.tabs)
     if node.style == :compressed
       "#{tab_str}#{node.resolved_name}:#{node.resolved_value}"
     else
@@ -125,7 +125,7 @@ class Sass::Tree::Visitors::ToCss < Sass::Tree::Visitors::Base
           when :compressed; ""
           else; " "
         end
-      rule_indent = '  ' * @tabs
+      rule_indent = node.indent_with * @tabs
       per_rule_indent, total_indent = [:nested, :expanded].include?(node.style) ? [rule_indent, ''] : ['', rule_indent]
 
       joined_rules = node.resolved_rules.members.map do |seq|
@@ -139,8 +139,8 @@ class Sass::Tree::Visitors::ToCss < Sass::Tree::Visitors::Base
       total_rule = total_indent << joined_rules
 
       to_return = ''
-      old_spaces = '  ' * @tabs
-      spaces = '  ' * (@tabs + 1)
+      old_spaces = node.indent_with * @tabs
+      spaces = node.indent_with * (@tabs + 1)
       if node.style != :compressed
         if node.options[:debug_info]
           to_return << visit(debug_info_rule(node.debug_info, node.options)) << "\n"


### PR DESCRIPTION
This contains the latest FSSM, a new option for specifying what to indent generated css with, and a fix for creating gems with the right version info when you don't have a local copy of the stable branch (switches from using local 'stable' to 'origin/stable' for determining alpha version number).
