### PR TITLE
Allow pathnames with template locations

### DIFF
--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -174,7 +174,7 @@ module Sass::Plugin
 
         Dir.glob(File.join(template_location, "**", "[^_]*.s[ca]ss")).sort.each do |file|
           # Get the relative path to the file
-          name = file.sub(template_location.sub(/\/*$/, '/'), "")
+          name = file.sub(template_location.to_s.sub(/\/*$/, '/'), "")
           css = css_filename(name, css_location)
 
           if options[:always_update] || staleness_checker.stylesheet_needs_update?(css, file)


### PR DESCRIPTION
This line of code raises an exception when sass is supplied an array containing one or more pathnames as locations for templates. A simple to_s seems to resolve the issue as it is expecting a string reference.
