### PR TITLE
command line option '--always-update'

### DIFF
--- a/lib/sass/exec.rb
+++ b/lib/sass/exec.rb
@@ -82,6 +82,10 @@ module Sass
           @options[:unix_newlines] = true if ::Sass::Util.windows?
         end
 
+        opts.on('--always-update', 'Always generate files, even if there is no change.') do
+          @options[:always_update] = true
+        end
+
         opts.on_tail("-?", "-h", "--help", "Show this message") do
           puts opts
           exit
@@ -349,6 +353,7 @@ END
         require 'sass/plugin'
         ::Sass::Plugin.options.merge! @options[:for_engine]
         ::Sass::Plugin.options[:unix_newlines] = @options[:unix_newlines]
+        ::Sass::Plugin.options[:always_update] = @options[:always_update]
 
         raise <<MSG if @args.empty?
 What files should I watch? Did you mean something like:


### PR DESCRIPTION
Made the option _always_update_ available for command line use. This is usefull, if you have two shell scripts one for production and one for development, that output to the same css file. Without this option sass will not update the css file, if there was no modification in the source files.

As this option already existed inside sass, I supposed that it was not necessary to write a test for this case. If one is needed, please point me to the location where to add the test.
