### PR TITLE
Added --flip support for transformation of stylesheets to right-to-left equivalents

### DIFF
--- a/lib/sass/environment.rb
+++ b/lib/sass/environment.rb
@@ -21,12 +21,17 @@ module Sass
     attr_writer :options
 
     # @param parent [Environment] See \{#parent}
-    def initialize(parent = nil)
+    def initialize(parent = nil, flip = false)
       @parent = parent
       unless parent
         @stack = []
         @mixins_in_use = Set.new
         set_var("important", Script::String.new("!important"))
+        if flip
+          set_var("dir", Script::String.new("rtl"))
+        else
+          set_var("dir", Script::String.new("ltr"))
+        end
       end
     end
 

--- a/lib/sass/exec.rb
+++ b/lib/sass/exec.rb
@@ -215,6 +215,9 @@ END
             @options[:for_engine][:syntax] = :sass
           end
         end
+        opts.on('--flip', "Auto-convert prop/values to right-to-left equivalents.") do
+          @options[:for_engine][:flip] = true
+        end
         opts.on('--watch', 'Watch files or directories for changes.',
                            'The location of the generated CSS can be set using a colon:',
                            "  #{@default_syntax} --watch input.#{@default_syntax}:output.css",

--- a/lib/sass/tree/node.rb
+++ b/lib/sass/tree/node.rb
@@ -125,6 +125,13 @@ module Sass
         @options[:style]
       end
 
+      # True if the automatic right-to-left transformation has been enabled.
+      #
+      # @return [Boolean]
+      def flip
+        @options[:flip]
+      end
+
       # Computes the CSS corresponding to this static CSS tree.
       #
       # @return [String, nil] The resulting CSS

--- a/lib/sass/tree/visitors/perform.rb
+++ b/lib/sass/tree/visitors/perform.rb
@@ -3,7 +3,12 @@ class Sass::Tree::Visitors::Perform < Sass::Tree::Visitors::Base
   # @param root [Tree::Node] The root node of the tree to visit.
   # @param environment [Sass::Environment] The lexical environment.
   # @return [Tree::Node] The resulting tree of static nodes.
-  def self.visit(root, environment = Sass::Environment.new)
+  def self.visit(root)
+    if root.flip
+      environment = Sass::Environment.new nil, true
+    else
+      environment = Sass::Environment.new
+    end
     new(environment).send(:visit, root)
   end
 

--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -38,7 +38,7 @@ module Sass
     # @param arr [Array<(Object, Object)>] An array of pairs
     # @return [Hash] A hash
     def to_hash(arr)
-      Hash[arr.compact]
+      arr.compact.inject({}) {|h, (k, v)| h[k] = v; h}
     end
 
     # Maps the keys in a hash according to a block.


### PR DESCRIPTION
Hey guys,

I've added a `--flip` option to sass to automatically convert properties/values, e.g. `float`, `background-position`, etc. into their right-to-left equivalents for languages like Hebrew and Arabic.

Despite it not following the usual sass behaviour of not being catering to CSS specifics, it would be nice to have this as a core feature of sass rather than as a plugin...
