### PR TITLE
:cache_location option is ignored

### DIFF
--- a/lib/sass/plugin/configuration.rb
+++ b/lib/sass/plugin/configuration.rb
@@ -10,13 +10,18 @@ module Sass
       #
       # @return [{Symbol => Object}]
       def default_options
-        @default_options ||= {
+        return @default_options if @default_options
+        @default_options = {
           :css_location       => './public/stylesheets',
           :always_update      => false,
           :always_check       => true,
           :full_exception     => true,
-          :cache_location     => ".sass-cache"
-        }.freeze
+          :cache_location     => ".sass-cache",
+          # This is bad. See Sass::Plugin::Configuration#default_options_default_proc.
+          # :cache_store      => Sass::CacheStores::Filesystem.new(options[:cache_location]),
+        }
+        @default_options.default_proc = Sass::Plugin::Configuration.default_options_default_proc
+        @default_options.freeze
       end
 
       # Resets the options and {Sass::Callbacks::InstanceMethods#clear_callbacks! clears all callbacks}.
@@ -31,8 +36,6 @@ module Sass
       # @return [{Symbol => Object}]
       def options
         @options ||= default_options.dup
-        @options[:cache_store] ||= Sass::CacheStores::Filesystem.new(@options[:cache_location])
-        @options
       end
 
       # Sets the options hash.
@@ -105,6 +108,23 @@ module Sass
         options[:template_location]
       ensure
         options[:template_location] = old_template_location
+      end
+
+      class << self
+
+        # Delay instantiating default cache store until the last possible moment when it is needed.
+        # The :cache_store option should not be set by default as commented above.
+        # The above example would immediately use the :cache_location option value even before
+        # a user even has a chance to set :cache_location.
+        # This fixes that by not instantiating it until it is accessed for the first time.
+        def default_options_default_proc
+          proc do |hash, key|
+            if key == :cache_store
+              hash[key] = Sass::CacheStores::Filesystem.new(Sass::Plugin.options[:cache_location])
+            end
+          end
+        end
+
       end
 
       private

--- a/lib/sass/plugin/merb.rb
+++ b/lib/sass/plugin/merb.rb
@@ -4,7 +4,8 @@ unless defined?(Sass::MERB_LOADED)
   module Sass::Plugin::Configuration
     # Different default options in a m envirionment.
     def default_options
-      @default_options ||= begin
+      return @default_options if @default_options
+      @default_options = begin
         version = Merb::VERSION.split('.').map { |n| n.to_i }
         if version[0] <= 0 && version[1] < 5
           root = MERB_ROOT
@@ -21,8 +22,12 @@ unless defined?(Sass::MERB_LOADED)
           :cache_location    => root + '/tmp/sass-cache',
           :always_check      => env != "production",
           :quiet             => env != "production",
-          :full_exception    => env != "production"
-        }.freeze
+          :full_exception    => env != "production",
+          # This is bad. See Sass::Plugin::Configuration#default_options_default_proc.
+          # :cache_store      => Sass::CacheStores::Filesystem.new(options[:cache_location]),
+        }
+        @default_options.default_proc = Sass::Plugin::Configuration.default_options_default_proc
+        @default_options.freeze
       end
     end
   end

--- a/lib/sass/plugin/rack.rb
+++ b/lib/sass/plugin/rack.rb
@@ -9,7 +9,7 @@ module Sass
     #
     # ## Customize
     #
-    #     Sass::Plugin.options.merge(
+    #     Sass::Plugin.options.merge!(
     #       :cache_location => './tmp/sass-cache',
     #       :never_update => environment != :production,
     #       :full_exception => environment != :production)

--- a/lib/sass/plugin/rails.rb
+++ b/lib/sass/plugin/rails.rb
@@ -8,15 +8,16 @@ unless defined?(Sass::RAILS_LOADED)
       opts = {
         :quiet             => Sass::Util.rails_env != "production",
         :full_exception    => Sass::Util.rails_env != "production",
-        :cache_location    => Sass::Util.rails_root + '/tmp/sass-cache'
-      }
-
-      opts.merge!(
+        :cache_location    => Sass::Util.rails_root + '/tmp/sass-cache',
         :always_update     => false,
         :template_location => Sass::Util.rails_root + '/public/stylesheets/sass',
         :css_location      => Sass::Util.rails_root + '/public/stylesheets',
-        :always_check      => Sass::Util.rails_env == "development")
+        :always_check      => Sass::Util.rails_env == "development",
+        # This is bad. See Sass::Plugin::Configuration#default_options_default_proc.
+        # :cache_store     => Sass::CacheStores::Filesystem.new(Sass::Plugin.options[:cache_location])
+      }
 
+      @default_options.default_proc = Sass::Plugin::Configuration.default_options_default_proc
       @default_options = opts.freeze
     end
   end

--- a/test/sass/plugin_configuration_test.rb
+++ b/test/sass/plugin_configuration_test.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+require File.dirname(__FILE__) + '/../test_helper'
+require File.dirname(__FILE__) + '/test_helper'
+require 'sass/plugin'
+
+class PluginConfigurationTest < Test::Unit::TestCase
+
+  # This test cannot be put in plugin_test.rb because the setup phase sets cache_store.
+  # This needs to be tested without cache_store being set initially.
+  def test_cache_store_option_allows_cache_location_option_to_be_set
+    cache_location = 'somewhere'
+    Sass::Plugin.options.merge!(:cache_location => cache_location)
+    assert_equal cache_location, Sass::Plugin.options[:cache_store].cache_location
+  end
+
+end

--- a/test/sass/plugin_rails_test.rb
+++ b/test/sass/plugin_rails_test.rb
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+require File.dirname(__FILE__) + '/../test_helper'
+require File.dirname(__FILE__) + '/test_helper'
+require 'sass/plugin'
+
+class PluginRailsTest < Test::Unit::TestCase
+
+  def setup
+    # Putting this here just to be a bit more explicit and clear about what's going on here.
+    require 'sass/plugin/rails'
+    assert Sass::RAILS_LOADED
+  end
+
+  # See plugin_configuration_test.
+  def test_cache_store_option_allows_cache_location_option_to_be_set
+    cache_location = 'somewhere'
+    Sass::Plugin.options.merge!(:cache_location => cache_location)
+    assert_equal cache_location, Sass::Plugin.options[:cache_store].cache_location
+  end
+
+end
+


### PR DESCRIPTION
I used the instructions in the docs for Sass::Plugin::Rack to set the :cache_location option to something other than '.sass-cache'. But the cache_location was being ignored and the default '.sass-cache' was being used. I dug into the code and found out why: Sass::Plugin::Configuration#options was prematurely instantiating a new Sass::CacheStores::Filesystem object with the value of options[:cache_location]. The problem with this is that when I set the :cache_location like in the Sass::Plugin::Rack docs, calling options() immediately instantiates the Filesystem cache store even before I have a chance to change :cache_location. So setting :cache_location is useless.

To fix this, I set the default_proc in the default_options hash to set and instantiate the Sass::CacheStores::Filesystem object. This effectively delays the instantiation until it is needed. By that time, the :cache_location option can be set to something else.

I added the default_proc to the Rails and Merb plugins as well. I wrote tests for them in separate files for each. They were just copies of plugin_configuration_test.rb, but requiring the respective plugin file beforehand. But the Merb plugin required the Merb constant to be defined, which I didn't know how to do, so I removed that test.

So that's 1 commit. The other commit is a small one in the Sass::Plugin::Rack docs where 'merge' should be 'merge!'.
