### PR TITLE
Revert change that breaks ruby 1.8.6 support

### DIFF
--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -38,7 +38,7 @@ module Sass
     # @param arr [Array<(Object, Object)>] An array of pairs
     # @return [Hash] A hash
     def to_hash(arr)
-      Hash[arr.compact]
+      arr.compact.inject({}) {|h, (k, v)| h[k] = v; h}
     end
 
     # Maps the keys in a hash according to a block.


### PR DESCRIPTION
Ruby 1.8.6 doesn't have the Hash[array] constructor,
Therefore the cosmetical change in 5cc606 breaks support
for 1.8.6 without providing any advantage (beside the neater
looking syntax).

This reverts commit 5cc60685b2d05050711fc6bb0edb393512a53dd1.
