### PR TITLE
fixed hash initialization error on ruby 1.8.6

### DIFF
--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -38,7 +38,12 @@ module Sass
     # @param arr [Array<(Object, Object)>] An array of pairs
     # @return [Hash] A hash
     def to_hash(arr)
-      Hash[arr.compact]
+      arr=arr.compact
+      hash=Hash.new
+      arr.each do |i|
+        hash[i[0]]=i[1]
+      end
+      return hash
     end
 
     # Maps the keys in a hash according to a block.


### PR DESCRIPTION
Even though I'm aware that ruby 1.8.6 is not supported anymore I'm sending this patch, which fixes the following issue: https://github.com/nex3/haml/issues/388

Background: We are running an old version of ruby where the array-to-hash conversion doesn't seem to work so well. It is replaced by a workaround that emulates the desired behaviour.

All tests pass.
