### PR TITLE
Glob args

### DIFF
--- a/lib/sass/script/parser.rb
+++ b/lib/sass/script/parser.rb
@@ -311,11 +311,20 @@ RUBY
 
         res = []
         must_have_default = false
+        has_glob = false
         loop do
           line = @lexer.line
           offset = @lexer.offset + 1
+          if tok = try_tok(:times)
+            if has_glob
+              raise SyntaxError.new("Function can have only one glob argument.")
+            end
+            var_class = Script::GlobVariable
+          else
+            var_class = Script::Variable
+          end
           c = assert_tok(:const)
-          var = Script::Variable.new(c.value)
+          var = var_class.new(c.value)
           if tok = try_tok(:colon)
             val = assert_expr(:space)
             must_have_default = true

--- a/lib/sass/script/variable.rb
+++ b/lib/sass/script/variable.rb
@@ -50,5 +50,9 @@ module Sass
         return val
       end
     end
+
+    # A special variable class for glob arguments in function deginitions
+    class GlobVariable < Variable
+    end
   end
 end

--- a/test/sass/conversion_test.rb
+++ b/test/sass/conversion_test.rb
@@ -837,6 +837,32 @@ SCSS
 SASS
   end
 
+  def test_mixin_definition_with_glob
+    assert_renders <<SASS, <<SCSS
+=foo-bar($baz, *$bangs)
+  baz
+    a: $baz
+    @each $bang in $bangs
+      bang: $bang
+SASS
+@mixin foo-bar($baz, *$bangs) {
+  baz {
+    a: $baz;
+    @each $bang in $bangs {
+      bang: $bang; } } }
+SCSS
+
+    assert_sass_to_scss <<SCSS, <<SASS
+@mixin foo-bar($baz, $bang: foo) {
+  baz {
+    a: $baz $bang; } }
+SCSS
+=foo-bar($baz, $bang: foo)
+  baz
+    a: $baz $bang
+SASS
+  end
+
   def test_argless_mixin_include
     assert_renders <<SASS, <<SCSS
 foo
@@ -908,6 +934,22 @@ SASS
 @function foo($var1, $var2: foo) {
   @if $var1 {
     @return $var1 + $var2; } }
+SCSS
+  end
+
+  def test_function_definition_with_glob
+    assert_renders <<SASS, <<SCSS
+@function foo($var1, *$vars)
+  $result: $var1
+  @each $i in $vars
+    $result: $result + $i
+  @return $result
+SASS
+@function foo($var1, *$vars) {
+  $result: $var1;
+  @each $i in $vars {
+    $result: $result + $i; }
+  @return $result; }
 SCSS
   end
 

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -1153,6 +1153,110 @@ bar
 SASS
   end
 
+  def test_function_arg_glob
+    assert_equal(<<CSS, render(<<SASS))
+bar {
+  a: 6; }
+CSS
+@function plus(*$args)
+  $result: 0
+  @each $i in $args
+    $result: $result + $i
+  @return $result
+
+bar
+  a: plus(1, 2, 3)
+SASS
+  end
+
+  def test_function_arg_glob_and_args
+    assert_equal(<<CSS, render(<<SASS))
+bar {
+  a: "1 5";
+  b: "1 5 4"; }
+CSS
+@function plus($arg1, *$args)
+  $result: 0
+  @each $i in $args
+    $result: $result + $i
+  @return $arg1 + ' ' + $result
+
+@function another_plus($arg1, *$args, $arg2)
+  $result: 0
+  @each $i in $args
+    $result: $result + $i
+  @return $arg1 + ' ' + $result + ' ' + $arg2
+
+bar
+  a: plus(1, 2, 3)
+  b: another_plus(1, 2, 3, 4)
+SASS
+  end
+
+  def test_function_arg_glob_and_keyword_args
+    assert_equal(<<CSS, render(<<SASS))
+bar {
+  a: "1 5 4"; }
+CSS
+@function plus($arg1, *$args, $arg2)
+  $result: 0
+  @each $i in $args
+    $result: $result + $i
+  @return $arg1 + ' ' + $result + ' ' + $arg2
+
+bar
+  a: plus(2, 3, $arg2: 4, $arg1: 1)
+SASS
+  end
+
+  def test_function_arg_glob_and_multiple_args
+    assert_equal(<<CSS, render(<<SASS))
+bar {
+  a: "3 12 13"; }
+CSS
+@function plus($arg1, $arg2, *$args, $arg3, $arg4)
+  $result: 0
+  @each $i in $args
+    $result: $result + $i
+  @return ($arg1 + $arg2) + ' ' + $result + ' ' + ($arg3 + $arg4)
+
+bar
+  a: plus(1, 2, 3, 4, 5, 6, 7)
+SASS
+  end
+
+  def test_function_arg_glob_and_multiple_keyword_args
+    assert_equal(<<CSS, render(<<SASS))
+bar {
+  a: "3 12 13"; }
+CSS
+@function plus($arg1, $arg2, *$args, $arg3, $arg4)
+  $result: 0
+  @each $i in $args
+    $result: $result + $i
+  @return ($arg1 + $arg2) + ' ' + $result + ' ' + ($arg3 + $arg4)
+
+bar
+  a: plus(3, 4, 5, $arg4: 7, $arg2: 2, $arg3: 6, $arg1: 1)
+SASS
+  end
+
+  def test_function_arg_glob_and_multiple_mixed_args
+    assert_equal(<<CSS, render(<<SASS))
+bar {
+  a: "3 12 13"; }
+CSS
+@function plus($arg1, $arg2, *$args, $arg3, $arg4)
+  $result: 0
+  @each $i in $args
+    $result: $result + $i
+  @return ($arg1 + $arg2) + ' ' + $result + ' ' + ($arg3 + $arg4)
+
+bar
+  a: plus(2, 3, $arg4: 7, 4, 5, $arg1: 1, 6)
+SASS
+  end
+
   def test_function_with_if
     assert_equal(<<CSS, render(<<SASS))
 bar {

--- a/test/sass/scss/scss_test.rb
+++ b/test/sass/scss/scss_test.rb
@@ -699,6 +699,62 @@ CSS
 SCSS
   end
 
+  def test_mixins_with_glob
+    assert_equal <<CSS, render(<<SCSS)
+.foo {
+  a: 1;
+  a: 2; }
+CSS
+@mixin foo(*$a) {
+  @each $i in $a {
+    a: $i;
+  }
+}
+
+.foo {@include foo(1, 2)}
+SCSS
+
+    assert_equal <<CSS, render(<<SCSS)
+.foo {
+  a: 1;
+  b: 2;
+  b: 3;
+  c: 4; }
+CSS
+@mixin foo($a, *$b, $c) {
+  a: $a;
+  @each $i in $b {
+    b: $i;
+  }
+  c: $c; }
+
+.foo {@include foo(1, 2, 3, 4)}
+SCSS
+
+    assert_equal <<CSS, render(<<SCSS)
+.foo {
+  a: 1;
+  b: 2;
+  c: 3;
+  c: 4;
+  c: 5;
+  d: 6;
+  e: 7; }
+CSS
+@mixin foo($a, $b, *$c, $d, $e) {
+  a: $a;
+  b: $b;
+  @each $i in $c {
+    c: $i;
+  }
+  d: $d;
+  e: $e;
+}
+
+.foo {@include foo(2, $d: 6, 3, 4, $a: 1, 5, 7)}
+SCSS
+  end
+
   ## Functions
 
   def test_basic_function


### PR DESCRIPTION
In CSS2 functions have simple signatures: fixed number of arguments or optional
trailing arguments. This was implemented in SASS for a long time now. But CSS3
intruduces some new features that require variable arguments number. For
example, linear-gradient function. It expects an optional point or angle
arguments and a set of color stops. The number of color stops is limited only on
the lower end.

The need for variable argument number is expressed in Compass
framework. For example, take a lok at gradients implementation in v0.11.
Currently mixins have signaures of 10 arguments for color stops. And you're in
trouble if you want to have more.

This commit implements variable arguments number only for _functions_. It's more a
proof of concept. I plan to implement it for mixins too.

WIP
