### PR TITLE
Fix `undefined method 'to_tree' for nil:NilClass` in staleness checker when using compass sprites

### DIFF
--- a/lib/sass/plugin/staleness_checker.rb
+++ b/lib/sass/plugin/staleness_checker.rb
@@ -159,7 +159,7 @@ module Sass
         tree(uri, importer).grep(Tree::ImportNode) do |n|
           next if n.css_import?
           file = n.imported_file
-          key = [file.options[:filename], file.options[:importer]]
+          key = [n.imported_filename, file.options[:importer]]
           @parse_trees[key] = file.to_tree
           key
         end.compact


### PR DESCRIPTION
The staleness checker used the filename of the sass_options from the importer as the cache key. Normally this is not a problem, since `imported_filename` and `:filename` are the same when importing regular files (`@import "foobar";`)

Compass uses "magic" syntax for the sprite generation, though:

```
@import "icon/*.png";
```

which leads to `importer.options[:filename] = "icon"` (the SpriteImporter returns its own `@name`), but `importer.imported_filename = "icon/*.png"`. Using the :filename for caching breaks on the next load because then the StalenessChecker asks Compass::SpriteEngine to load "icon", which the SpriteEngine promptly denies because it does not match the expected format of "icon/*.png", so it returns nil, and then to_tree breaks in compute_dependencies.
