### PR TITLE
Added decimal() function to convert percentage value into decimal value

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ## 3.2.0 (Unreleased)
 
+* Added `decimal` function to convert percentage value into decimal value
+  (thanks to [Beau Smith](http://about.me/beau))
 
 ### Backwards Incompatibilities -- Must Read!
 

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -1135,6 +1135,21 @@ module Sass::Script
     end
     declare :percentage, [:value]
 
+    # Converts a percentage to a decimal number.
+    #
+    # @example
+    #   decimal(44%) => 0.44
+    # @param value [Number] The percentage to convert to a decimal number
+    # @return [Number] The decimal number
+    # @raise [ArgumentError] If `value` isn't a unitless number
+    def decimal(value)
+      unless value.is_a?(Sass::Script::Number) && value.unit_str == "%"
+        raise ArgumentError.new("#{value.inspect} is not a percentage")
+      end
+      Sass::Script::Number.new(value.value / 100.0)
+    end
+    declare :decimal, [:value]
+
     # Rounds a number to the nearest whole number.
     #
     # @example

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -119,6 +119,20 @@ class SassFunctionTest < Test::Unit::TestCase
     assert_error_message("\"string\" is not a unitless number for `percentage'", %Q{percentage("string")})
   end
 
+  def test_decimal
+    assert_equal("0.5",   evaluate("decimal(50%)"))
+    assert_equal("1",     evaluate("decimal(100%)"))
+    assert_equal("0.333", evaluate("decimal(33.333%)"))
+    assert_equal("0.25",  evaluate("decimal((25px / 100px) * 100%)"))
+    assert_equal("0.5",   evaluate("decimal($value: 50%)"))
+  end
+
+  def test_decimal_checks_types
+    assert_error_message("50px is not a percentage value for `decimal'", "decimal(50px)")
+    assert_error_message("#cccccc is not a percentage value for `decimal'", "decimal(#ccc)")
+    assert_error_message("\"string\"is not a percentage value for `decimal'", %Q{decimal("string")})
+  end
+
   def test_round
     assert_equal("5",   evaluate("round(4.8)"))
     assert_equal("5px", evaluate("round(4.8px)"))


### PR DESCRIPTION
While a percentage can be converted into a decimal value in plain SASS, a dedicated function is more explicit.
