### PR TITLE
Shouldn't install on Ruby 1.8.6

### DIFF
--- a/sass.gemspec
+++ b/sass.gemspec
@@ -18,6 +18,7 @@ SASS_GEMSPEC = Gem::Specification.new do |spec|
       command line tool or a web-framework plugin.
     END
 
+  spec.required_ruby_version = '>= 1.8.7'
   spec.add_development_dependency 'yard', '>= 0.5.3'
   spec.add_development_dependency 'maruku', '>= 0.5.9'
 


### PR DESCRIPTION
It's broken so why let it install? :)
