### PR TITLE
Support for a block of styles to mixins.

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -5,12 +5,12 @@
 
 ## 3.2.0 (Unreleased)
 
-* A mixin include can now accept a block of styles ({file:SASS_REFERENCE.md#mixin-children Reference Documentation}).
-  The style block will be passed to the mixin and can be placed at the point @children is used. E.g.:
+* A mixin include can now accept a block of content ({file:SASS_REFERENCE.md#mixin-content Reference Documentation}).
+  The style block will be passed to the mixin and can be placed at the point @content is used. E.g.:
   
       @mixin iphone {
         @media only screen and (max-width: 480px) {
-          @children;
+          @content;
         }
       }
       
@@ -22,7 +22,7 @@
   
       =iphone
         @media only screen and (max-width: 480px)
-          @children
+          @content
       
       +iphone
         body
@@ -35,7 +35,7 @@
       }
   
   Note that the contents passed to the mixin are evaluated in the scope they are used,
-  not the scope of the mixin. {file:SASS_REFERENCE.md#variable_scope_and_style_blocks More on variable scoping.}
+  not the scope of the mixin. {file:SASS_REFERENCE.md#variable_scope_and_content_blocks More on variable scoping.}
 
 ## `:any` Support
 

--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -13,16 +13,26 @@
           @children;
         }
       }
-
+      
       @include iphone {
         body { color: red }
       }
+
+  Or in `.sass` syntax:
   
+      =iphone
+        @media only screen and (max-width: 480px)
+          @children
+      
+      +iphone
+        body
+          color: red
+
   Produces:
   
-    @media only screen and (max-width: 480px) {
-      body { color: red }
-    }
+      @media only screen and (max-width: 480px) {
+        body { color: red }
+      }
   
   Note that the contents passed to the mixin are evaluated in the scope they are used,
   not the scope of the mixin.

--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -5,8 +5,8 @@
 
 ## 3.2.0 (Unreleased)
 
-* A mixin include can now accept a block of styles that will be passed to the mixin
-  and can be placed at the point @children is used. E.g.:
+* A mixin include can now accept a block of styles ({file:SASS_REFERENCE.md#mixin-children Reference Documentation}).
+  The style block will be passed to the mixin and can be placed at the point @children is used. E.g.:
   
       @mixin iphone {
         @media only screen and (max-width: 480px) {
@@ -35,7 +35,7 @@
       }
   
   Note that the contents passed to the mixin are evaluated in the scope they are used,
-  not the scope of the mixin.
+  not the scope of the mixin. {file:SASS_REFERENCE.md#variable_scope_and_style_blocks More on variable scoping.}
 
 ### Backwards Incompatibilities -- Must Read!
 

--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -5,6 +5,27 @@
 
 ## 3.2.0 (Unreleased)
 
+* A mixin include can now accept a block of styles that will be passed to the mixin
+  and can be placed at the point @children is used. E.g.:
+  
+      @mixin iphone {
+        @media only screen and (max-width: 480px) {
+          @children;
+        }
+      }
+
+      @include iphone {
+        body { color: red }
+      }
+  
+  Produces:
+  
+    @media only screen and (max-width: 480px) {
+      body { color: red }
+    }
+  
+  Note that the contents passed to the mixin are evaluated in the scope they are used,
+  not the scope of the mixin.
 
 ### Backwards Incompatibilities -- Must Read!
 

--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -1873,6 +1873,18 @@ Compiles to:
       border-color: blue;
     }
 
+Additionally, this makes it clear that the variables and mixins that are used within the
+passed block are related to the other styles around where the block is defined. For example:
+
+    #sidebar {
+      $sidebar-width: 300px;
+      width: $sidebar-width;
+      @include iphone {
+        width: $sidebar-width / 3;
+      }
+    }
+
+
 ## Function Directives {#functions}
 
 It is possible to define your own functions in sass and use them in any

--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -1812,17 +1812,17 @@ providing many arguments without becoming difficult to call.
 Named arguments can be passed in any order, and arguments with default values can be omitted.
 Since the named arguments are variable names, underscores and dashes can be used interchangeably.
 
-### Passing Style Blocks to a Mixin {#mixin-children}
+### Passing Content Blocks to a Mixin {#mixin-content}
 
 It is possible to pass a block of styles to the mixin for placement within the styles included by
-the mixin. The styles will appear at the location of any `@children` directives found within the mixin. This makes is possible to define abstractions relating to the construction of
+the mixin. The styles will appear at the location of any `@content` directives found within the mixin. This makes is possible to define abstractions relating to the construction of
 selectors and directives.
 
 For example:
 
     @mixin apply-to-ie6-only {
       * html {
-        @children;
+        @content;
       }
     }
     @include apply-to-ie6-only {
@@ -1841,24 +1841,24 @@ The same mixins can be done in the `.sass` shorthand syntax:
 
     =apply-to-ie6-only
       * html
-        @children
+        @content
     
     +apply-to-ie6-only
       #logo
         background-image: url(/logo.gif)
 
-**Note:** when the `@children` directive is specified more than once or in a loop, the style block will be duplicated with each invocation.
+**Note:** when the `@content` directive is specified more than once or in a loop, the style block will be duplicated with each invocation.
 
-#### Variable Scope and Style Blocks
+#### Variable Scope and Content Blocks
 
-The block of styles passed to a mixin are evaluated in the scope where the block is defined,
+The block of content passed to a mixin are evaluated in the scope where the block is defined,
 not in the scope of the mixin. This means that variables local to the mixin **cannot** be used
 within the passed style block and variables will resolve to the global value:
 
     $color: white;
     @mixin colors($color: blue) {
       background-color: $color;
-      @children;
+      @content;
       border-color: $color;
     }
     .colors {

--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -1812,6 +1812,67 @@ providing many arguments without becoming difficult to call.
 Named arguments can be passed in any order, and arguments with default values can be omitted.
 Since the named arguments are variable names, underscores and dashes can be used interchangeably.
 
+### Passing Style Blocks to a Mixin {#mixin-children}
+
+It is possible to pass a block of styles to the mixin for placement within the styles included by
+the mixin. The styles will appear at the location of any `@children` directives found within the mixin. This makes is possible to define abstractions relating to the construction of
+selectors and directives.
+
+For example:
+
+    @mixin apply-to-ie6-only {
+      * html {
+        @children;
+      }
+    }
+    @include apply-to-ie6-only {
+      #logo {
+        background-image: url(/logo.gif);
+      }
+    }
+
+Generates:
+
+    * html #logo {
+      background-image: url(/logo.gif);
+    }
+
+The same mixins can be done in the `.sass` shorthand syntax:
+
+    =apply-to-ie6-only
+      * html
+        @children
+    
+    +apply-to-ie6-only
+      #logo
+        background-image: url(/logo.gif)
+
+**Note:** when the `@children` directive is specified more than once or in a loop, the style block will be duplicated with each invocation.
+
+#### Variable Scope and Style Blocks
+
+The block of styles passed to a mixin are evaluated in the scope where the block is defined,
+not in the scope of the mixin. This means that variables local to the mixin **cannot** be used
+within the passed style block and variables will resolve to the global value:
+
+    $color: white;
+    @mixin colors($color: blue) {
+      background-color: $color;
+      @children;
+      border-color: $color;
+    }
+    .colors {
+      @include colors { color: $color; }
+    }
+
+Compiles to:
+
+    .colors {
+      background-color: blue;
+      color: white;
+      border-color: blue;
+    }
+
 ## Function Directives {#functions}
 
 It is possible to define your own functions in sass and use them in any

--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -32,6 +32,7 @@ require 'sass/tree/visitors/to_css'
 require 'sass/tree/visitors/deep_copy'
 require 'sass/tree/visitors/set_options'
 require 'sass/tree/visitors/check_nesting'
+require 'sass/tree/visitors/grep'
 require 'sass/selector'
 require 'sass/environment'
 require 'sass/script'
@@ -59,7 +60,17 @@ module Sass
   #
   # `tree`: `Array<Tree::Node>`
   # : The parse tree for the mixin/function.
-  Callable = Struct.new(:name, :args, :environment, :tree)
+  class Callable < Struct.new(:name, :args, :environment, :tree)
+    def accepts_style_block?
+      if @accepts_style_block.nil?
+        @accepts_style_block = Sass::Tree::Visitors::Grep.visit(self) {|n| n.is_a?(Tree::ChildrenNode) }.any?
+      end
+      @accepts_style_block
+    end
+    def children
+      tree
+    end
+  end
 
   # This class handles the parsing and compilation of the Sass template.
   # Example usage:

--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -798,10 +798,12 @@ WARNING
       Tree::MixinDefNode.new(name, args)
     end
 
-    CHILDREN_RE = /^(?:@children)\s(.*)$/
+    CHILDREN_RE = /^(?:@children)\s*(.+)?$/
     def parse_children_directive(line)
-      trailing = line.text.scan(CHILDREN_RE).first
+      trailing = line.text.scan(CHILDREN_RE).first.first
       raise SyntaxError.new("Invalid children directive. Trailing characters found: \"#{trailing}\".") unless trailing.nil?
+      raise SyntaxError.new("Illegal nesting: Nothing may be nested beneath @children directives.",
+        :line => line.index + 1) unless line.children.empty?
       Tree::ChildrenNode.new
     end
 

--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -12,7 +12,7 @@ require 'sass/tree/media_node'
 require 'sass/tree/variable_node'
 require 'sass/tree/mixin_def_node'
 require 'sass/tree/mixin_node'
-require 'sass/tree/children_node'
+require 'sass/tree/content_node'
 require 'sass/tree/function_node'
 require 'sass/tree/return_node'
 require 'sass/tree/extend_node'
@@ -63,7 +63,7 @@ module Sass
   class Callable < Struct.new(:name, :args, :environment, :tree)
     def accepts_style_block?
       if @accepts_style_block.nil?
-        @accepts_style_block = Sass::Tree::Visitors::Grep.visit(self) {|n| n.is_a?(Tree::ChildrenNode) }.any?
+        @accepts_style_block = Sass::Tree::Visitors::Grep.visit(self) {|n| n.is_a?(Tree::ContentNode) }.any?
       end
       @accepts_style_block
     end
@@ -632,8 +632,8 @@ WARNING
         parse_import(line, value)
       elsif directive == "mixin"
         parse_mixin_definition(line)
-      elsif directive == "children"
-        parse_children_directive(line)
+      elsif directive == "content"
+        parse_content_directive(line)
       elsif directive == "include"
         parse_mixin_include(line, root)
       elsif directive == "function"
@@ -798,13 +798,13 @@ WARNING
       Tree::MixinDefNode.new(name, args)
     end
 
-    CHILDREN_RE = /^(?:@children)\s*(.+)?$/
-    def parse_children_directive(line)
-      trailing = line.text.scan(CHILDREN_RE).first.first
-      raise SyntaxError.new("Invalid children directive. Trailing characters found: \"#{trailing}\".") unless trailing.nil?
-      raise SyntaxError.new("Illegal nesting: Nothing may be nested beneath @children directives.",
+    CONTENT_RE = /^(?:@content)\s*(.+)?$/
+    def parse_content_directive(line)
+      trailing = line.text.scan(CONTENT_RE).first.first
+      raise SyntaxError.new("Invalid content directive. Trailing characters found: \"#{trailing}\".") unless trailing.nil?
+      raise SyntaxError.new("Illegal nesting: Nothing may be nested beneath @content directives.",
         :line => line.index + 1) unless line.children.empty?
-      Tree::ChildrenNode.new
+      Tree::ContentNode.new
     end
 
     MIXIN_INCLUDE_RE = /^(?:\+|@include)\s*(#{Sass::SCSS::RX::IDENT})(.*)$/

--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -798,7 +798,7 @@ WARNING
       Tree::MixinDefNode.new(name, args)
     end
 
-    CHILDREN_RE = /^(?:=|@children)\s(.*)$/
+    CHILDREN_RE = /^(?:@children)\s(.*)$/
     def parse_children_directive(line)
       trailing = line.text.scan(CHILDREN_RE).first
       raise SyntaxError.new("Invalid children directive. Trailing characters found: \"#{trailing}\".") unless trailing.nil?

--- a/lib/sass/environment.rb
+++ b/lib/sass/environment.rb
@@ -77,6 +77,14 @@ module Sass
       mixins_in_use.delete(popped[:mixin]) if popped && popped[:mixin]
     end
 
+    def current_mixin_caller_env
+      stack.find{|frame| frame[:mixin_caller_env] }[:mixin_caller_env]
+    end
+
+    def current_mixin_content
+      stack.find{|frame| frame[:mixin_content] }[:mixin_content]
+    end
+
     # A list of stack frames in the mixin/include stack.
     # The last element in the list is the most deeply-nested frame.
     #

--- a/lib/sass/scss/parser.rb
+++ b/lib/sass/scss/parser.rb
@@ -101,7 +101,7 @@ module Sass
       end
 
       DIRECTIVES = Set[:mixin, :include, :function, :return, :debug, :warn, :for,
-        :each, :while, :if, :else, :extend, :import, :media, :charset]
+        :each, :while, :if, :else, :extend, :import, :media, :charset, :children]
 
       def directive
         return unless tok(/@/)
@@ -143,7 +143,17 @@ module Sass
         name = tok! IDENT
         args, keywords = sass_script(:parse_mixin_include_arglist)
         ss
-        node(Sass::Tree::MixinNode.new(name, args, keywords))
+        include_node = Sass::Tree::MixinNode.new(name, args, keywords)
+        if tok?(/\{/)
+          block(node(include_node), :directive)
+        else
+          node(include_node)
+        end
+      end
+
+      def children_directive
+        ss
+        node(Sass::Tree::ChildrenNode.new)
       end
 
       def function_directive

--- a/lib/sass/scss/parser.rb
+++ b/lib/sass/scss/parser.rb
@@ -101,7 +101,7 @@ module Sass
       end
 
       DIRECTIVES = Set[:mixin, :include, :function, :return, :debug, :warn, :for,
-        :each, :while, :if, :else, :extend, :import, :media, :charset, :children]
+        :each, :while, :if, :else, :extend, :import, :media, :charset, :content]
 
       def directive
         return unless tok(/@/)
@@ -151,9 +151,9 @@ module Sass
         end
       end
 
-      def children_directive
+      def content_directive
         ss
-        node(Sass::Tree::ChildrenNode.new)
+        node(Sass::Tree::ContentNode.new)
       end
 
       def function_directive

--- a/lib/sass/tree/children_node.rb
+++ b/lib/sass/tree/children_node.rb
@@ -1,0 +1,9 @@
+module Sass
+  module Tree
+    # A node representing the placement within a mixin of the include statement's children.
+    #
+    # @see Sass::Tree
+    class ChildrenNode < Node
+    end
+  end
+end

--- a/lib/sass/tree/children_node.rb
+++ b/lib/sass/tree/children_node.rb
@@ -1,9 +1,0 @@
-module Sass
-  module Tree
-    # A node representing the placement within a mixin of the include statement's children.
-    #
-    # @see Sass::Tree
-    class ChildrenNode < Node
-    end
-  end
-end

--- a/lib/sass/tree/content_node.rb
+++ b/lib/sass/tree/content_node.rb
@@ -1,0 +1,9 @@
+module Sass
+  module Tree
+    # A node representing the placement within a mixin of the include statement's content.
+    #
+    # @see Sass::Tree
+    class ContentNode < Node
+    end
+  end
+end

--- a/lib/sass/tree/visitors/base.rb
+++ b/lib/sass/tree/visitors/base.rb
@@ -34,9 +34,9 @@ module Sass::Tree::Visitors
     def visit(node)
       method = "visit_#{node_name node}"
       if self.respond_to?(method)
-        self.send(method, node) {visit_children(node)}
+        self.send(method, node) {visit_child_nodes(node)}
       else
-        visit_children(node)
+        visit_child_nodes(node)
       end
     end
 
@@ -49,7 +49,7 @@ module Sass::Tree::Visitors
     #
     # @param parent [Tree::Node] The parent node of the children to visit.
     # @return [Array<Object>] The return values of the `visit_*` methods for the children.
-    def visit_children(parent)
+    def visit_child_nodes(parent)
       parent.children.map {|c| visit(c)}
     end
 

--- a/lib/sass/tree/visitors/base.rb
+++ b/lib/sass/tree/visitors/base.rb
@@ -20,8 +20,8 @@ module Sass::Tree::Visitors
     #
     # @param root [Tree::Node] The root node of the Sass tree.
     # @return [Object] The return value of \{#visit} for the root node.
-    def self.visit(root)
-      new.send(:visit, root)
+    def self.visit(root, &block)
+      new.send(:visit, root, &block)
     end
 
     protected

--- a/lib/sass/tree/visitors/check_nesting.rb
+++ b/lib/sass/tree/visitors/check_nesting.rb
@@ -24,11 +24,11 @@ class Sass::Tree::Visitors::CheckNesting < Sass::Tree::Visitors::Base
     check!(@real_parent, @parent, node) { super }
   end
 
-  TRANS_PARENT_CLASSES = [ Sass::Tree::EachNode,   Sass::Tree::ForNode,   Sass::Tree::IfNode,
-                           Sass::Tree::ImportNode, Sass::Tree::WhileNode]
+  PARENT_CLASSES = [ Sass::Tree::EachNode,   Sass::Tree::ForNode,   Sass::Tree::IfNode,
+                     Sass::Tree::ImportNode, Sass::Tree::WhileNode]
   def visit_child_nodes(parent)
     old_parent = @parent
-    @parent = parent unless is_any_of?(parent, TRANS_PARENT_CLASSES)
+    @parent = parent unless is_any_of?(parent, PARENT_CLASSES)
     old_real_parent, @real_parent = @real_parent, parent
     super
   ensure

--- a/lib/sass/tree/visitors/check_nesting.rb
+++ b/lib/sass/tree/visitors/check_nesting.rb
@@ -51,6 +51,22 @@ class Sass::Tree::Visitors::CheckNesting < Sass::Tree::Visitors::Base
     raise e
   end
 
+  def visit_mixindef(node)
+    @inside_mixindef = true
+    yield
+  ensure
+    @inside_mixindef = false
+  end
+
+  def visit_children(node)
+    unless @inside_mixindef
+      raise Sass::SyntaxError, "@children may only be used within a mixin."
+    end
+  rescue Sass::SyntaxError => e
+    e.modify_backtrace(:filename => node.filename, :line => node.line)
+    raise e
+  end
+
   def invalid_charset_parent?(parent, child)
     "@charset may only be used at the root of a document." unless parent.is_a?(Sass::Tree::RootNode)
   end

--- a/lib/sass/tree/visitors/check_nesting.rb
+++ b/lib/sass/tree/visitors/check_nesting.rb
@@ -58,9 +58,9 @@ class Sass::Tree::Visitors::CheckNesting < Sass::Tree::Visitors::Base
     @inside_mixindef = false
   end
 
-  def visit_children(node)
+  def visit_content(node)
     unless @inside_mixindef
-      raise Sass::SyntaxError, "@children may only be used within a mixin."
+      raise Sass::SyntaxError, "@content may only be used within a mixin."
     end
   rescue Sass::SyntaxError => e
     e.modify_backtrace(:filename => node.filename, :line => node.line)

--- a/lib/sass/tree/visitors/check_nesting.rb
+++ b/lib/sass/tree/visitors/check_nesting.rb
@@ -11,6 +11,7 @@ class Sass::Tree::Visitors::CheckNesting < Sass::Tree::Visitors::Base
             try_send("invalid_#{node_name node}_real_parent?", real_parent, node)))
         raise Sass::SyntaxError.new(error)
       end
+      yield if block_given?
     rescue Sass::SyntaxError => e
       e.modify_backtrace(:filename => node.filename, :line => node.line)
       raise e
@@ -20,8 +21,7 @@ class Sass::Tree::Visitors::CheckNesting < Sass::Tree::Visitors::Base
   protected
 
   def visit(node)
-    check!(@real_parent, @parent, node)
-    super
+    check!(@real_parent, @parent, node) { super }
   end
 
   TRANS_PARENT_CLASSES = [ Sass::Tree::EachNode,   Sass::Tree::ForNode,   Sass::Tree::IfNode,

--- a/lib/sass/tree/visitors/convert.rb
+++ b/lib/sass/tree/visitors/convert.rb
@@ -18,7 +18,7 @@ class Sass::Tree::Visitors::Convert < Sass::Tree::Visitors::Base
     @tabs = 0
   end
 
-  def visit_children(parent)
+  def visit_child_nodes(parent)
     @tabs += 1
     return @format == :sass ? "\n" : " {}\n" if parent.children.empty?
     (@format == :sass ? "\n" : " {\n") + super.join.rstrip + (@format == :sass ? "\n" : " }\n")
@@ -175,7 +175,11 @@ class Sass::Tree::Visitors::Convert < Sass::Tree::Visitors::Base
       keywords = node.keywords.map {|k, v| "$#{dasherize(k)}: #{v.to_sass(@options)}"}.join(', ')
       arglist = "(#{args}#{', ' unless args.empty? || keywords.empty?}#{keywords})"
     end
-    "#{tab_str}#{@format == :sass ? '+' : '@include '}#{dasherize(node.name)}#{arglist}#{semi}\n"
+    "#{tab_str}#{@format == :sass ? '+' : '@include '}#{dasherize(node.name)}#{arglist}#{node.children.any? ? yield : semi}\n"
+  end
+
+  def visit_children(node)
+    "#{tab_str}@children#{semi}\n"
   end
 
   def visit_prop(node)

--- a/lib/sass/tree/visitors/convert.rb
+++ b/lib/sass/tree/visitors/convert.rb
@@ -178,8 +178,8 @@ class Sass::Tree::Visitors::Convert < Sass::Tree::Visitors::Base
     "#{tab_str}#{@format == :sass ? '+' : '@include '}#{dasherize(node.name)}#{arglist}#{node.children.any? ? yield : semi}\n"
   end
 
-  def visit_children(node)
-    "#{tab_str}@children#{semi}\n"
+  def visit_content(node)
+    "#{tab_str}@content#{semi}\n"
   end
 
   def visit_prop(node)

--- a/lib/sass/tree/visitors/cssize.rb
+++ b/lib/sass/tree/visitors/cssize.rb
@@ -3,9 +3,7 @@ class Sass::Tree::Visitors::Cssize < Sass::Tree::Visitors::Base
   # @param root [Tree::Node] The root node of the tree to visit.
   # @return [(Tree::Node, Sass::Util::SubsetMap)] The resulting tree of static nodes
   #   *and* the extensions defined for this tree
-  def self.visit(root)
-    super
-  end
+  def self.visit(root); super; end
 
   protected
 

--- a/lib/sass/tree/visitors/cssize.rb
+++ b/lib/sass/tree/visitors/cssize.rb
@@ -3,7 +3,9 @@ class Sass::Tree::Visitors::Cssize < Sass::Tree::Visitors::Base
   # @param root [Tree::Node] The root node of the tree to visit.
   # @return [(Tree::Node, Sass::Util::SubsetMap)] The resulting tree of static nodes
   #   *and* the extensions defined for this tree
-  def self.visit(root); super; end
+  def self.visit(root)
+    super
+  end
 
   protected
 
@@ -24,7 +26,7 @@ class Sass::Tree::Visitors::Cssize < Sass::Tree::Visitors::Base
   end
 
   # Keeps track of the current parent node.
-  def visit_children(parent)
+  def visit_child_nodes(parent)
     with_parent parent do
       parent.children = super.flatten
       parent
@@ -93,7 +95,7 @@ class Sass::Tree::Visitors::Cssize < Sass::Tree::Visitors::Base
 
   # Modifies exception backtraces to include the imported file.
   def visit_import(node)
-    # Don't use #visit_children to avoid adding the import node to the list of parents.
+    # Don't use #visit_child_nodes to avoid adding the import node to the list of parents.
     node.children.map {|c| visit(c)}.flatten
   rescue Sass::SyntaxError => e
     e.modify_backtrace(:filename => node.children.first.filename)
@@ -123,8 +125,11 @@ class Sass::Tree::Visitors::Cssize < Sass::Tree::Visitors::Base
 
   # Asserts that all the mixin's children are valid in their new location.
   def visit_mixin(node)
-    # Don't use #visit_children to avoid adding the mixin node to the list of parents.
-    node.children.map {|c| visit(c)}.flatten
+    checker = Sass::Tree::Visitors::CheckNesting.new
+    # double checks that including the mixin won't create an invalid tree
+    children = node.children.map {|c| visit(c) }.flatten
+    children.each {|c| checker.check!(self, parent, c) }
+    children
   rescue Sass::SyntaxError => e
     e.modify_backtrace(:mixin => node.name, :filename => node.filename, :line => node.line)
     e.add_backtrace(:filename => node.filename, :line => node.line)

--- a/lib/sass/tree/visitors/deep_copy.rb
+++ b/lib/sass/tree/visitors/deep_copy.rb
@@ -6,7 +6,7 @@ class Sass::Tree::Visitors::DeepCopy < Sass::Tree::Visitors::Base
     super(node.dup)
   end
 
-  def visit_children(parent)
+  def visit_child_nodes(parent)
     parent.children = parent.children.map {|c| visit(c)}
     parent
   end

--- a/lib/sass/tree/visitors/grep.rb
+++ b/lib/sass/tree/visitors/grep.rb
@@ -1,0 +1,13 @@
+# A visitor for copying the full structure of a Sass tree.
+class Sass::Tree::Visitors::Grep < Sass::Tree::Visitors::Base
+  protected
+
+  def visit(node, &block)
+    found = []
+    found << node if yield(node)
+    node.children.each do |child|
+      found += visit(child, &block)
+    end
+    found
+  end
+end

--- a/lib/sass/tree/visitors/perform.rb
+++ b/lib/sass/tree/visitors/perform.rb
@@ -163,7 +163,7 @@ class Sass::Tree::Visitors::Perform < Sass::Tree::Visitors::Base
   def visit_mixin(node)
     handle_include_loop!(node) if @environment.mixins_in_use.include?(node.name)
 
-    @current_mixin_children, old_mixin_children = node.children, @current_mixin_children
+    @current_mixin_content, old_mixin_content = node.children, @current_mixin_content
     @current_mixin_env, old_mixin_env = @environment, @current_mixin_env
     original_env = @environment
     original_env.push_frame(:filename => node.filename, :line => node.line)
@@ -171,7 +171,7 @@ class Sass::Tree::Visitors::Perform < Sass::Tree::Visitors::Base
     raise Sass::SyntaxError.new("Undefined mixin '#{node.name}'.") unless mixin = @environment.mixin(node.name)
 
     if node.children.any? && !mixin.accepts_style_block?
-      raise Sass::SyntaxError, %Q{Mixin "#{node.name}" does not accept a style block.}
+      raise Sass::SyntaxError, %Q{Mixin "#{node.name}" does not accept a content block.}
     end
 
     passed_args = node.args.dup
@@ -213,13 +213,13 @@ END
     raise e
   ensure
     original_env.pop_frame if original_env
-    @current_mixin_children = old_mixin_children
+    @current_mixin_content = old_mixin_content
     @current_mixin_env = old_mixin_env
   end
 
-  def visit_children(node)
+  def visit_content(node)
     with_environment(@current_mixin_env) do
-      (@current_mixin_children || []).map{|c| visit(c.dup) }
+      (@current_mixin_content || []).map{|c| visit(c.dup) }
     end
   end
 

--- a/lib/sass/tree/visitors/perform.rb
+++ b/lib/sass/tree/visitors/perform.rb
@@ -163,7 +163,6 @@ class Sass::Tree::Visitors::Perform < Sass::Tree::Visitors::Base
   def visit_mixin(node)
     handle_include_loop!(node) if @environment.mixins_in_use.include?(node.name)
 
-    @current_mixin, old_mixin = node.name, @current_mixin
     @current_mixin_children, old_mixin_children = node.children, @current_mixin_children
     @current_mixin_env, old_mixin_env = @environment, @current_mixin_env
     original_env = @environment
@@ -215,7 +214,6 @@ END
   ensure
     original_env.pop_frame if original_env
     @current_mixin_children = old_mixin_children
-    @current_mixin = old_mixin
     @current_mixin_env = old_mixin_env
   end
 

--- a/lib/sass/tree/visitors/perform.rb
+++ b/lib/sass/tree/visitors/perform.rb
@@ -165,7 +165,7 @@ class Sass::Tree::Visitors::Perform < Sass::Tree::Visitors::Base
 
     @current_mixin, old_mixin = node.name, @current_mixin
     @current_mixin_children, old_mixin_children = node.children, @current_mixin_children
-    @current_mixin_env = @environment
+    @current_mixin_env, old_mixin_env = @environment, @current_mixin_env
     original_env = @environment
     original_env.push_frame(:filename => node.filename, :line => node.line)
     original_env.prepare_frame(:mixin => node.name)
@@ -216,6 +216,7 @@ END
     original_env.pop_frame if original_env
     @current_mixin_children = old_mixin_children
     @current_mixin = old_mixin
+    @current_mixin_env = old_mixin_env
   end
 
   def visit_children(node)

--- a/lib/sass/tree/visitors/perform.rb
+++ b/lib/sass/tree/visitors/perform.rb
@@ -171,6 +171,10 @@ class Sass::Tree::Visitors::Perform < Sass::Tree::Visitors::Base
     original_env.prepare_frame(:mixin => node.name)
     raise Sass::SyntaxError.new("Undefined mixin '#{node.name}'.") unless mixin = @environment.mixin(node.name)
 
+    if node.children.any? && !mixin.accepts_style_block?
+      raise Sass::SyntaxError, %Q{Mixin "#{node.name}" does not accept a style block.}
+    end
+
     passed_args = node.args.dup
     passed_keywords = node.keywords.dup
 

--- a/test/sass/conversion_test.rb
+++ b/test/sass/conversion_test.rb
@@ -1152,6 +1152,35 @@ SASS
 SCSS
   end
 
+  def test_children_conversion
+    assert_renders(<<SASS, <<SCSS)
+$color: blue
+
+=context($class, $color: red)
+  .\#{$class}
+    background-color: $color
+    @children
+    border-color: $color
+
++context(parent)
+  +context(child, $color: yellow)
+    color: $color
+SASS
+$color: blue;
+
+@mixin context($class, $color: red) {
+  .\#{$class} {
+    background-color: $color;
+    @children;
+    border-color: $color; } }
+
+@include context(parent) {
+  @include context(child, $color: yellow) {
+    color: $color; } }
+SCSS
+
+  end
+
   private
 
   def assert_sass_to_sass(sass, options = {})

--- a/test/sass/conversion_test.rb
+++ b/test/sass/conversion_test.rb
@@ -1159,7 +1159,7 @@ $color: blue
 =context($class, $color: red)
   .\#{$class}
     background-color: $color
-    @children
+    @content
     border-color: $color
 
 +context(parent)
@@ -1171,7 +1171,7 @@ $color: blue;
 @mixin context($class, $color: red) {
   .\#{$class} {
     background-color: $color;
-    @children;
+    @content;
     border-color: $color; } }
 
 @include context(parent) {

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -142,6 +142,7 @@ MSG
     "foo\n  &a\n    b: c" => ["Invalid CSS after \"&\": expected \"{\", was \"a\"\n\n\"a\" may only be used at the beginning of a selector.", 2],
     "foo\n  &1\n    b: c" => ["Invalid CSS after \"&\": expected \"{\", was \"1\"\n\n\"1\" may only be used at the beginning of a selector.", 2],
     "=foo\n  @children error" => "Invalid children directive. Trailing characters found: \"error\".",
+    "=foo\n  @children\n    b: c" => "Illegal nesting: Nothing may be nested beneath @children directives.",
     "@children" => '@children may only be used within a mixin.',
     "=simple\n  .simple\n    color: red\n+simple\n  color: blue" => ['Mixin "simple" does not accept a style block.', 4],
 

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -2558,6 +2558,40 @@ $color: blue
 SASS
   end
 
+  def test_nested_content_blocks
+    assert_equal <<CSS, render(<<SASS)
+.foo {
+  a: foo; }
+  .foo .bar {
+    a: bar; }
+    .foo .bar .baz {
+      a: baz; }
+      .foo .bar .baz .outside {
+        a: outside;
+        color: red; }
+CSS
+$a: outside
+=baz($a: baz)
+  .baz
+    a: $a
+    @content
+=bar($a: bar)
+  .bar
+    a: $a
+    +baz
+      @content
+=foo($a: foo)
+  .foo
+    a: $a
+    +bar
+      @content
++foo
+  .outside
+    a: $a
+    color: red
+SASS
+  end
+
   private
 
   def assert_hash_has(hash, expected)

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -141,10 +141,10 @@ MSG
     "@mixin foo\n  @extend .bar\n@include foo" => ["Extend directives may only be used within rules.", 2],
     "foo\n  &a\n    b: c" => ["Invalid CSS after \"&\": expected \"{\", was \"a\"\n\n\"a\" may only be used at the beginning of a selector.", 2],
     "foo\n  &1\n    b: c" => ["Invalid CSS after \"&\": expected \"{\", was \"1\"\n\n\"1\" may only be used at the beginning of a selector.", 2],
-    "=foo\n  @children error" => "Invalid children directive. Trailing characters found: \"error\".",
-    "=foo\n  @children\n    b: c" => "Illegal nesting: Nothing may be nested beneath @children directives.",
-    "@children" => '@children may only be used within a mixin.',
-    "=simple\n  .simple\n    color: red\n+simple\n  color: blue" => ['Mixin "simple" does not accept a style block.', 4],
+    "=foo\n  @content error" => "Invalid content directive. Trailing characters found: \"error\".",
+    "=foo\n  @content\n    b: c" => "Illegal nesting: Nothing may be nested beneath @content directives.",
+    "@content" => '@content may only be used within a mixin.',
+    "=simple\n  .simple\n    color: red\n+simple\n  color: blue" => ['Mixin "simple" does not accept a content block.', 4],
 
     # Regression tests
     "a\n  b:\n    c\n    d" => ["Illegal nesting: Only properties may be nested beneath properties.", 3],
@@ -2479,7 +2479,7 @@ SASS
     end
   end
 
-  def test_children
+  def test_content
     assert_equal <<CSS, render(<<SASS)
 .children {
   background-color: red;
@@ -2490,14 +2490,14 @@ $color: blue
 =context($class, $color: red)
   .\#{$class}
     background-color: $color
-    @children
+    @content
     border-color: $color
 +context(children)
   color: $color
 SASS
   end
 
-  def test_selector_in_children
+  def test_selector_in_content
     assert_equal <<CSS, render(<<SASS)
 .parent {
   background-color: red;
@@ -2509,7 +2509,7 @@ $color: blue
 =context($class, $color: red)
   .\#{$class}
     background-color: $color
-    @children
+    @content
     border-color: $color
 +context(parent)
   .children
@@ -2517,7 +2517,7 @@ $color: blue
 SASS
   end
 
-  def test_using_parent_mixin_in_children
+  def test_using_parent_mixin_in_content
     assert_equal <<CSS, render(<<SASS)
 .parent {
   background-color: red;
@@ -2531,7 +2531,7 @@ $color: blue
 =context($class, $color: red)
   .\#{$class}
     background-color: $color
-    @children
+    @content
     border-color: $color
 +context(parent)
   +context(child, $color: yellow)
@@ -2539,7 +2539,7 @@ $color: blue
 SASS
   end
 
-  def test_children_more_than_once
+  def test_content_more_than_once
     assert_equal <<CSS, render(<<SASS)
 .once {
   color: blue; }
@@ -2550,9 +2550,9 @@ CSS
 $color: blue
 =context($class, $color: red)
   .once
-    @children
+    @content
   .twice
-    @children
+    @content
 +context(parent)
   color: $color
 SASS

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -142,6 +142,7 @@ MSG
     "foo\n  &a\n    b: c" => ["Invalid CSS after \"&\": expected \"{\", was \"a\"\n\n\"a\" may only be used at the beginning of a selector.", 2],
     "foo\n  &1\n    b: c" => ["Invalid CSS after \"&\": expected \"{\", was \"1\"\n\n\"1\" may only be used at the beginning of a selector.", 2],
     "=foo\n  @children error" => "Invalid children directive. Trailing characters found: \"error\".",
+    "@children" => '@children may only be used within a mixin.',
 
     # Regression tests
     "a\n  b:\n    c\n    d" => ["Illegal nesting: Only properties may be nested beneath properties.", 3],

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -143,6 +143,7 @@ MSG
     "foo\n  &1\n    b: c" => ["Invalid CSS after \"&\": expected \"{\", was \"1\"\n\n\"1\" may only be used at the beginning of a selector.", 2],
     "=foo\n  @children error" => "Invalid children directive. Trailing characters found: \"error\".",
     "@children" => '@children may only be used within a mixin.',
+    "=simple\n  .simple\n    color: red\n+simple\n  color: blue" => ['Mixin "simple" does not accept a style block.', 4],
 
     # Regression tests
     "a\n  b:\n    c\n    d" => ["Illegal nesting: Only properties may be nested beneath properties.", 3],

--- a/test/sass/scss/scss_test.rb
+++ b/test/sass/scss/scss_test.rb
@@ -1244,6 +1244,32 @@ foo {
 SCSS
   end
 
+  def test_mixin_children
+    assert_equal <<CSS, render(<<SASS)
+.parent {
+  background-color: red;
+  border-color: red; }
+  .parent .child {
+    background-color: yellow;
+    color: blue;
+    border-color: yellow; }
+CSS
+$color: blue;
+@mixin context($class, $color: red) {
+  .\#{$class} {
+    background-color: $color;
+    @children;
+    border-color: $color;
+  }
+}
+@include context(parent) {
+  @include context(child, $color: yellow) {
+    color: $color;
+  }
+}
+SASS
+  end
+
   def test_options_passed_to_script
     assert_equal <<CSS, render(<<SCSS, :style => :compressed)
 foo{color:#000}

--- a/test/sass/scss/scss_test.rb
+++ b/test/sass/scss/scss_test.rb
@@ -1244,7 +1244,7 @@ foo {
 SCSS
   end
 
-  def test_mixin_children
+  def test_mixin_content
     assert_equal <<CSS, render(<<SASS)
 .parent {
   background-color: red;
@@ -1258,7 +1258,7 @@ $color: blue;
 @mixin context($class, $color: red) {
   .\#{$class} {
     background-color: $color;
-    @children;
+    @content;
     border-color: $color;
   }
 }


### PR DESCRIPTION
This patch allows passing a ruleset to mixins for placement by the new `@children` directive. It is useful when abstracting a concept associated with selectors or directives.
