### PR TITLE
Sass::Plugin#force_update_stylesheets mutates options hash

### DIFF
--- a/lib/sass/plugin.rb
+++ b/lib/sass/plugin.rb
@@ -92,14 +92,13 @@ module Sass
     #   the second is the location of the CSS file that it should be compiled to.
     # @see #update_stylesheets
     def force_update_stylesheets(individual_files = [])
-      old_options = options
-      self.options = options.dup
+      old_options = options.dup
       options[:never_update] = false
       options[:always_update] = true
       options[:cache] = false
       update_stylesheets(individual_files)
     ensure
-      self.options = old_options
+      compiler.instance_variable_set(:@options, old_options)
     end
 
     # All other method invocations are proxied to the \{#compiler}.

--- a/test/sass/plugin_test.rb
+++ b/test/sass/plugin_test.rb
@@ -178,6 +178,14 @@ CSS
     assert_doesnt_need_update "more1", "more_"
     assert_needs_update "basic"
   end
+  
+  def test_force_update_stylesheets
+#    Sass::Plugin.options[:never_update] = true
+    orig_options = Sass::Plugin.options.dup
+    Sass::Util.silence_sass_warnings{ Sass::Plugin.force_update_stylesheets }
+    current_options = Sass::Plugin.options.dup    
+    assert_equal orig_options, current_options
+  end
 
   # Callbacks
 


### PR DESCRIPTION
Sass::Plugin#force_update_stylesheets modified compiler.options, but didn't set it back correctly.

If Sass::Plugin.options[:never_update] = true and
force_update_stylesheets was called it could result in options[:never_update] being set to false and later requests could cause compiler.update_stylesheets to be called.

Test included.
