### PR TITLE
[Regression] Using adjacent sibling selector without spaces causes errors

### DIFF
--- a/test/sass/scss/css_test.rb
+++ b/test/sass/scss/css_test.rb
@@ -800,6 +800,12 @@ SCSS
     assert_selector_parses('E*:hover')
   end
 
+  def test_spaceless_combo_selectors
+    assert_equal "E > F {\n  a: b; }\n", render("E>F { a: b;} ")
+    assert_equal "E ~ F {\n  a: b; }\n", render("E~F { a: b;} ")
+    assert_equal "E + F {\n  a: b; }\n", render("E+F { a: b;} ")
+  end
+
   ## Errors
 
   def test_invalid_directives


### PR DESCRIPTION
Prior to version 3.1.8, the following CSS had no problems:

```
li+li{padding-top:2px;}
```

After version 3.1.8, it causes the following error:

```
Invalid CSS after "li+": expected number or function, was "li"
```

I've added failing tests to manifest the problem, but I don't understand the code enough to fix the problem.
