### PR TITLE
Prevent long strings from causing a regexp buffer overflow exception.

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -15,6 +15,8 @@
   been successfully compiled. Thanks to [Christian Peters](https://github.com/ChristianPeters).
 * Allow absolute paths to be used in an importer with a different root.
 * Don't destructively modify the options when running `Sass::Plugin.force_update`.
+* Prevent Regexp buffer overflows when parsing long strings.
+  Thanks to [Agworld](https://github.com/Agworld).
 
 ### Deprecations -- Must Read!
 

--- a/lib/sass/scss/rx.rb
+++ b/lib/sass/scss/rx.rb
@@ -112,7 +112,7 @@ module Sass
       INTERP_START = /#\{/
       MOZ_ANY = quote(":-moz-any(", Regexp::IGNORECASE)
 
-      IDENT_HYPHEN_INTERP = /-(?=#\{)/
+      IDENT_HYPHEN_INTERP = /-(#\{)/
       STRING1_NOINTERP = /\"((?:[^\n\r\f\\"#]|#(?!\{)|\\#{NL}|#{ESCAPE})*)\"/
       STRING2_NOINTERP = /\'((?:[^\n\r\f\\'#]|#(?!\{)|\\#{NL}|#{ESCAPE})*)\'/
       STRING_NOINTERP = /#{STRING1_NOINTERP}|#{STRING2_NOINTERP}/
@@ -120,9 +120,9 @@ module Sass
       # We could use it for 1.9 only, but I don't want to introduce a cross-version
       # behavior difference.
       # In any case, almost all CSS idents will be matched by this.
-      STATIC_VALUE = /(-?#{NMSTART}|#{STRING_NOINTERP}|\s(?!%)|#[a-f0-9]|[,%]|#{NUM}|\!important)+(?=[;}])/i
+      STATIC_VALUE = /(-?#{NMSTART}|#{STRING_NOINTERP}|\s(?!%)|#[a-f0-9]|[,%]|#{NUM}|\!important)+([;}])/i
 
-      STATIC_SELECTOR = /(#{NMCHAR}|\s|[,>+*]|[:#.]#{NMSTART})+(?=[{])/i
+      STATIC_SELECTOR = /(#{NMCHAR}|\s|[,>+*]|[:#.]#{NMSTART})+([{])/i
     end
   end
 end

--- a/test/sass/scss/scss_test.rb
+++ b/test/sass/scss/scss_test.rb
@@ -1270,4 +1270,29 @@ CSS
 foo {color: darken(black, 10%)}
 SCSS
   end
+
+  # ref: https://github.com/nex3/sass/issues/104
+  def test_no_buffer_overflow
+    template = render <<SCSS
+.aaa {
+  background-color: white;
+}
+.aaa .aaa .aaa {
+  background-color: black;
+}   
+.bbb {
+  @extend .aaa;
+} 
+.xxx {
+  @extend .bbb;
+}
+.yyy {
+  @extend .bbb;
+}
+.zzz {
+  @extend .bbb;
+}
+SCSS
+    Sass::SCSS::Parser.new(template, "test.scss").parse
+  end
 end


### PR DESCRIPTION
This bug was reported here: https://github.com/nex3/sass/issues/104
