### PR TITLE
Added --indent option to sass-convert

### DIFF
--- a/lib/sass/css.rb
+++ b/lib/sass/css.rb
@@ -25,6 +25,9 @@ module Sass
     #     (`:color blue` as opposed to `color: blue`).
     #     This is only meaningful when generating Sass code,
     #     rather than SCSS.
+    # @option options :indent [String] (2)
+    #     Customize the indent size in written files. 2 by default.
+    #     Use "t" if you want to use real tab.
     def initialize(template, options = {})
       if template.is_a? IO
         template = template.read

--- a/lib/sass/exec.rb
+++ b/lib/sass/exec.rb
@@ -515,6 +515,17 @@ END
           @options[:for_tree][:dasherize] = true
         end
 
+        opts.on('--indent indent',
+          'Customize the indent size in written files. 2 by default.',
+          'Use "t" if you want to use real tab.') do |indent|
+
+          if indent == 't'
+            @options[:for_tree][:indent] = "\t"
+          else
+            @options[:for_tree][:indent] = " " * indent.to_i
+          end
+        end
+
         opts.on('--old', 'Output the old-style ":prop val" property syntax.',
                          'Only meaningful when generating Sass.') do
           @options[:for_tree][:old] = true

--- a/lib/sass/tree/visitors/convert.rb
+++ b/lib/sass/tree/visitors/convert.rb
@@ -23,7 +23,7 @@ class Sass::Tree::Visitors::Convert < Sass::Tree::Visitors::Base
   def visit_children(parent)
     @tabs += 1
     return @format == :sass ? "\n" : " {}\n" if parent.children.empty?
-    (@format == :sass ? "\n" : " {\n") + super.join.rstrip + (@format == :sass ? "\n" : " }\n")
+    (@format == :sass ? "\n" : " {\n") + super.join.rstrip + (@format == :sass ? "\n" : "\n#{ @tab_chars * (@tabs-1)}}\n")
   ensure
     @tabs -= 1
   end

--- a/lib/sass/tree/visitors/convert.rb
+++ b/lib/sass/tree/visitors/convert.rb
@@ -16,6 +16,8 @@ class Sass::Tree::Visitors::Convert < Sass::Tree::Visitors::Base
     @options = options
     @format = format
     @tabs = 0
+    # 2 spaces by default
+    @tab_chars = @options[:indent] ? @options[:indent] : "  "
   end
 
   def visit_children(parent)
@@ -247,7 +249,7 @@ class Sass::Tree::Visitors::Convert < Sass::Tree::Visitors::Base
   end
 
   def tab_str
-    '  ' * @tabs
+    @tab_chars * @tabs
   end
 
   def dasherize(s)

--- a/test/sass/conversion_test.rb
+++ b/test/sass/conversion_test.rb
@@ -10,7 +10,8 @@ foo bar
 SASS
 foo bar {
   baz: bang;
-  bip: bop; }
+  bip: bop;
+}
 SCSS
     assert_renders <<SASS, <<SCSS, :old => true
 foo bar
@@ -19,7 +20,8 @@ foo bar
 SASS
 foo bar {
   baz: bang;
-  bip: bop; }
+  bip: bop;
+}
 SCSS
   end
 
@@ -47,8 +49,10 @@ SASS
 foo bar {
   baz bang {
     baz: bang;
-    bip: bop; }
-  blat: boo; }
+    bip: bop;
+  }
+  blat: boo;
+}
 SCSS
   end
 
@@ -60,7 +64,9 @@ foo bar
 SASS
 foo bar {
   &:hover {
-    baz: bang; } }
+    baz: bang;
+  }
+}
 SCSS
   end
 
@@ -70,7 +76,8 @@ foo \#{$bar + "baz"}.bip
   baz: bang
 SASS
 foo \#{$bar + "baz"}.bip {
-  baz: bang; }
+  baz: bang;
+}
 SCSS
   end
 
@@ -82,7 +89,8 @@ baz bang
 SASS
 foo bar,
 baz bang {
-  baz: bang; }
+  baz: bang;
+}
 SCSS
 
     assert_renders <<SASS, <<SCSS
@@ -94,7 +102,9 @@ SASS
 blat {
   foo bar,
   baz bang {
-    baz: bang; } }
+    baz: bang;
+  }
+}
 SCSS
   end
 
@@ -111,7 +121,8 @@ SCSS
     assert_scss_to_scss <<SCSS
 foo bar
 baz bang {
-  baz: bang; }
+  baz: bang;
+}
 SCSS
   end
 
@@ -123,7 +134,9 @@ foo bar
 SASS
 foo bar {
   :hover {
-    baz: bang; } }
+    baz: bang;
+  }
+}
 SCSS
   end
 
@@ -133,7 +146,8 @@ foo bar
   baz\#{$bang}bip\#{$bop}: 12
 SASS
 foo bar {
-  baz\#{$bang}bip\#{$bop}: 12; }
+  baz\#{$bang}bip\#{$bop}: 12;
+}
 SCSS
   end
 
@@ -143,7 +157,8 @@ foo bar
   baz\#{$bang}bip\#{$bop}: 12
 SASS
 foo bar {
-  baz\#{$bang}bip\#{$bop}: 12; }
+  baz\#{$bang}bip\#{$bop}: 12;
+}
 SCSS
   end
 
@@ -153,7 +168,8 @@ foo bar
   baz: 12 \#{$bang} bip \#{"bop"} blat
 SASS
 foo bar {
-  baz: 12 \#{$bang} bip \#{"bop"} blat; }
+  baz: 12 \#{$bang} bip \#{"bop"} blat;
+}
 SCSS
   end
 
@@ -163,7 +179,8 @@ foo bar
   baz: 12 $bang "bip"
 SASS
 foo bar {
-  baz: 12 $bang "bip"; }
+  baz: 12 $bang "bip";
+}
 SCSS
   end
 
@@ -173,7 +190,8 @@ foo bar
   :baz 12 $bang "bip"
 SASS
 foo bar {
-  baz: 12 $bang "bip"; }
+  baz: 12 $bang "bip";
+}
 SCSS
   end
 
@@ -191,7 +209,8 @@ SCSS
 
     assert_scss_to_scss <<OUT, <<IN
 foo bar {
-  baz: bip bam boon; }
+  baz: bip bam boon;
+}
 OUT
 foo bar {
   baz:
@@ -215,7 +234,8 @@ SCSS
 
     assert_scss_to_scss <<OUT, <<IN
 foo bar {
-  baz: $bip "bam" 12px; }
+  baz: $bip "bam" 12px;
+}
 OUT
 foo bar {
   baz:
@@ -243,7 +263,8 @@ SASS
 // baz
 
 foo bar {
-  a: b; }
+  a: b;
+}
 SCSS
 
     assert_renders <<SASS, <<SCSS
@@ -261,7 +282,8 @@ SASS
 // bang
 
 foo bar {
-  a: b; }
+  a: b;
+}
 SCSS
 
     assert_sass_to_scss <<SCSS, <<SASS
@@ -271,7 +293,8 @@ SCSS
 // bang
 
 foo bar {
-  a: b; }
+  a: b;
+}
 SCSS
 // foo
 // bar
@@ -345,7 +368,8 @@ SASS
 /* baz */
 
 foo bar {
-  a: b; }
+  a: b;
+}
 SCSS
 
     assert_scss_to_sass <<SASS, <<SCSS
@@ -373,7 +397,8 @@ SCSS
    bang */
 
 foo bar {
-  a: b; }
+  a: b;
+}
 SCSS
 
     assert_renders <<SASS, <<SCSS
@@ -391,7 +416,8 @@ SASS
  * bang */
 
 foo bar {
-  a: b; }
+  a: b;
+}
 SCSS
   end
 
@@ -411,7 +437,8 @@ foo {
    * beep boop */
   bang: bizz;
   /* bubble bubble
-   * toil trouble */ }
+   * toil trouble */
+}
 SCSS
 
     assert_sass_to_scss <<SCSS, <<SASS
@@ -423,7 +450,8 @@ foo {
   bang: bizz;
   /* bubble bubble
    * toil trouble
-   *    gorp */ }
+   *    gorp */
+}
 SCSS
 foo
   bar: baz
@@ -457,7 +485,8 @@ foo {
   /*      foo
    * bar
    *     baz */
-  a: b; }
+  a: b;
+}
 SCSS
 foo
   /*      foo
@@ -479,7 +508,8 @@ SASS
  * Bar
  * Baz */
 .foo#bar {
-  a: b; }
+  a: b;
+}
 SCSS
 
     assert_renders <<SASS, <<SCSS
@@ -493,7 +523,8 @@ SASS
 // Bar
 // Baz
 @mixin foo {
-  a: b; }
+  a: b;
+}
 SCSS
   end
 
@@ -505,7 +536,8 @@ foo
 SASS
 foo {
   @debug 12px;
-  bar: baz; }
+  bar: baz;
+}
 SCSS
   end
 
@@ -517,7 +549,8 @@ foo
 SASS
 foo {
   @foo #bar "baz";
-  bar: baz; }
+  bar: baz;
+}
 SCSS
   end
 
@@ -533,9 +566,11 @@ SASS
 foo {
   @foo #bar "baz" {
     a: b;
-    c: d; }
+    c: d;
+  }
 
-  bar: baz; }
+  bar: baz;
+}
 SCSS
   end
 
@@ -554,12 +589,16 @@ SASS
 foo {
   @foo #bar "baz" {
     #blat {
-      a: b; }
+      a: b;
+    }
     .bang {
       c: d;
-      e: f; } }
+      e: f;
+    }
+  }
 
-  bar: baz; }
+  bar: baz;
+}
 SCSS
   end
 
@@ -581,13 +620,17 @@ foo {
   @foo #bar "baz" {
     g: h;
     #blat {
-      a: b; }
+      a: b;
+    }
     .bang {
       c: d;
-      e: f; }
-    i: j; }
+      e: f;
+    }
+    i: j;
+  }
 
-  bar: baz; }
+  bar: baz;
+}
 SCSS
   end
 
@@ -610,10 +653,13 @@ foo
 SASS
 foo {
   @for $a from $b to $c {
-    a: b; }
+    a: b;
+  }
   @for $c from 1 to 16 {
     d: e;
-    f: g; } }
+    f: g;
+  }
+}
 SCSS
   end
 
@@ -628,10 +674,13 @@ foo
 SASS
 foo {
   @while flaz($a + $b) {
-    a: b; }
+    a: b;
+  }
   @while 1 {
     d: e;
-    f: g; } }
+    f: g;
+  }
+}
 SCSS
   end
 
@@ -649,13 +698,18 @@ foo
 SASS
 foo {
   @if $foo or $bar {
-    a: b; }
+    a: b;
+  }
   @if $baz {
-    d: e; }
+    d: e;
+  }
   @else if $bang {
-    f: g; }
+    f: g;
+  }
   @else {
-    h: i; } }
+    h: i;
+  }
+}
 SCSS
   end
 
@@ -671,11 +725,15 @@ c
 SASS
 a {
   @each $number in 1px 2px 3px 4px {
-    b: $number; } }
+    b: $number;
+  }
+}
 
 c {
   @each $str in foo, bar, baz, bang {
-    d: $str; } }
+    d: $str;
+  }
+}
 SCSS
   end
 
@@ -693,7 +751,8 @@ SASS
 @import url(bar.css);
 
 foo {
-  bar: baz; }
+  bar: baz;
+}
 SCSS
 
     assert_renders <<SASS, <<SCSS
@@ -709,7 +768,8 @@ SASS
 @import url(bar.css);
 
 foo {
-  bar: baz; }
+  bar: baz;
+}
 SCSS
   end
 
@@ -767,7 +827,8 @@ SCSS
 SASS
 .foo {
   @extend .bar;
-  @extend .baz:bang; }
+  @extend .baz:bang;
+}
 SCSS
   end
 
@@ -779,7 +840,9 @@ SCSS
 SASS
 @mixin foo-bar {
   baz {
-    a: b; } }
+    a: b;
+  }
+}
 SCSS
 
     assert_scss_to_sass <<SASS, <<SCSS
@@ -795,7 +858,9 @@ SCSS
     assert_sass_to_scss <<SCSS, <<SASS
 @mixin foo-bar {
   baz {
-    a: b; } }
+    a: b;
+  }
+}
 SCSS
 =foo-bar()
   baz
@@ -811,7 +876,9 @@ SASS
 SASS
 @mixin foo-bar($baz, $bang) {
   baz {
-    a: $baz $bang; } }
+    a: $baz $bang;
+  }
+}
 SCSS
   end
 
@@ -823,13 +890,17 @@ SCSS
 SASS
 @mixin foo-bar($baz, $bang: 12px) {
   baz {
-    a: $baz $bang; } }
+    a: $baz $bang;
+  }
+}
 SCSS
 
     assert_sass_to_scss <<SCSS, <<SASS
 @mixin foo-bar($baz, $bang: foo) {
   baz {
-    a: $baz $bang; } }
+    a: $baz $bang;
+  }
+}
 SCSS
 =foo-bar($baz, $bang: foo)
   baz
@@ -845,7 +916,8 @@ foo
 SASS
 foo {
   @include foo-bar;
-  a: blip; }
+  a: blip;
+}
 SCSS
   end
 
@@ -857,7 +929,8 @@ foo
 SASS
 foo {
   @include foo-bar(12px, "blaz");
-  a: blip; }
+  a: blip;
+}
 SCSS
   end
 
@@ -871,7 +944,8 @@ SASS
 foo {
   @include foo-bar(12px, "blaz", $blip: blap, $bloop: blop);
   @include foo-bar($blip: blap, $bloop: blop);
-  a: blip; }
+  a: blip;
+}
 SCSS
   end
 
@@ -883,7 +957,8 @@ SCSS
 SASS
 @function foo() {
   $var: 1 + 1;
-  @return $var; }
+  @return $var;
+}
 SCSS
   end
 
@@ -895,7 +970,9 @@ SCSS
 SASS
 @function foo($var1, $var2) {
   @if $var1 {
-    @return $var1 + $var2; } }
+    @return $var1 + $var2;
+  }
+}
 SCSS
   end
 
@@ -907,7 +984,9 @@ SCSS
 SASS
 @function foo($var1, $var2: foo) {
   @if $var1 {
-    @return $var1 + $var2; } }
+    @return $var1 + $var2;
+  }
+}
 SCSS
   end
 
@@ -923,7 +1002,8 @@ $var1: 12px + 15px;
 
 foo {
   $var2: flaz(#abcdef);
-  val: $var1 $var2; }
+  val: $var1 $var2;
+}
 SCSS
   end
 
@@ -939,7 +1019,8 @@ $var1: 12px + 15px !default;
 
 foo {
   $var2: flaz(#abcdef) !default;
-  val: $var1 $var2; }
+  val: $var1 $var2;
+}
 SCSS
   end
 
@@ -967,7 +1048,8 @@ foo
   a: (1px / 2px)
 SASS
 foo {
-  a: (1px / 2px); }
+  a: (1px / 2px);
+}
 SCSS
   end
 
@@ -981,7 +1063,8 @@ SASS
 $var: 1px / 2px;
 
 foo {
-  a: $var; }
+  a: $var;
+}
 SCSS
 
     assert_renders <<SASS, <<SCSS
@@ -993,7 +1076,8 @@ SASS
 $var: 1px;
 
 foo {
-  a: $var / 2px; }
+  a: $var / 2px;
+}
 SCSS
 
     assert_renders <<SASS, <<SCSS
@@ -1001,7 +1085,8 @@ foo
   a: 1 + 1px / 2px
 SASS
 foo {
-  a: 1 + 1px / 2px; }
+  a: 1 + 1px / 2px;
+}
 SCSS
   end
 
@@ -1011,7 +1096,8 @@ foo
   a: 1px / 2px
 SASS
 foo {
-  a: 1px / 2px; }
+  a: 1px / 2px;
+}
 SCSS
   end
 
@@ -1035,7 +1121,8 @@ foo {
   .name: val;
   name/**/: val;
   name/*\\**/: val;
-  name: val; }
+  name: val;
+}
 SCSS
   end
 
@@ -1053,7 +1140,8 @@ foo {
   *name: val;
   #name: val;
   .name: val;
-  name: val; }
+  name: val;
+}
 SCSS
   end
 
@@ -1064,7 +1152,8 @@ SCSS
   a: b
 SASS
 #{s} {
-  a: b; }
+  a: b;
+}
 SCSS
     end
 
@@ -1097,8 +1186,10 @@ div {
   before: before;
   background: {
     color: blue;
-    repeat: no-repeat; };
-  after: after; }
+    repeat: no-repeat;
+  };
+  after: after;
+}
 
 SCSS
   end
@@ -1106,17 +1197,22 @@ SCSS
   def test_dasherize
     assert_sass_to_scss(<<SCSS, <<SASS, :dasherize => true)
 @mixin under-scored-mixin($under-scored-arg: $under-scored-default) {
-  bar: $under-scored-arg; }
+  bar: $under-scored-arg;
+}
 
 div {
   foo: under-scored-fn($under-scored-var + "before\#{$another-under-scored-var}after");
   @include under-scored-mixin($passed-arg);
-  selector-\#{$under-scored-interp}: bold; }
+  selector-\#{$under-scored-interp}: bold;
+}
 
 @if $under-scored {
   @for $for-var from $from-var to $to-var {
     @while $while-var == true {
-      $while-var: false; } } }
+      $while-var: false;
+    }
+  }
+}
 SCSS
 =under_scored_mixin($under_scored_arg: $under_scored_default)
   bar: $under_scored_arg
@@ -1159,8 +1255,10 @@ SASS
 foo bar {
     baz bang {
         baz: bang;
-        bip: bop; }
-    blat: boo; }
+        bip: bop;
+    }
+    blat: boo;
+}
 SCSS
 
     assert_renders <<SASS, <<SCSS, :indent => "\t"
@@ -1173,16 +1271,20 @@ SASS
 foo bar {
 	baz bang {
 		baz: bang;
-		bip: bop; }
-	blat: boo; }
+		bip: bop;
+	}
+	blat: boo;
+}
 SCSS
 
     assert_sass_to_scss <<SCSS, <<SASS, :indent => "    "
 foo bar {
     baz bang {
         baz: bang;
-        bip: bop; }
-    blat: boo; }
+        bip: bop;
+    }
+    blat: boo;
+}
 SCSS
 foo bar
   baz bang
@@ -1195,8 +1297,10 @@ SASS
 foo bar {
 	baz bang {
 		baz: bang;
-		bip: bop; }
-	blat: boo; }
+		bip: bop;
+	}
+	blat: boo;
+}
 SCSS
 foo bar
   baz bang
@@ -1215,8 +1319,10 @@ SASS
 foo bar {
   baz bang {
     baz: bang;
-    bip: bop; }
-  blat: boo; }
+    bip: bop;
+  }
+  blat: boo;
+}
 SCSS
 
     assert_scss_to_sass <<SASS, <<SCSS, :indent => "\t"
@@ -1229,8 +1335,10 @@ SASS
 foo bar {
   baz bang {
     baz: bang;
-    bip: bop; }
-  blat: boo; }
+    bip: bop;
+  }
+  blat: boo;
+}
 SCSS
   end
 

--- a/test/sass/conversion_test.rb
+++ b/test/sass/conversion_test.rb
@@ -1148,6 +1148,93 @@ SASS
 SCSS
   end
 
+  def test_indent
+    assert_renders <<SASS, <<SCSS, :indent => "    "
+foo bar
+    baz bang
+        baz: bang
+        bip: bop
+    blat: boo
+SASS
+foo bar {
+    baz bang {
+        baz: bang;
+        bip: bop; }
+    blat: boo; }
+SCSS
+
+    assert_renders <<SASS, <<SCSS, :indent => "\t"
+foo bar
+	baz bang
+		baz: bang
+		bip: bop
+	blat: boo
+SASS
+foo bar {
+	baz bang {
+		baz: bang;
+		bip: bop; }
+	blat: boo; }
+SCSS
+
+    assert_sass_to_scss <<SCSS, <<SASS, :indent => "    "
+foo bar {
+    baz bang {
+        baz: bang;
+        bip: bop; }
+    blat: boo; }
+SCSS
+foo bar
+  baz bang
+    baz: bang
+    bip: bop
+  blat: boo
+SASS
+
+    assert_sass_to_scss <<SCSS, <<SASS, :indent => "\t"
+foo bar {
+	baz bang {
+		baz: bang;
+		bip: bop; }
+	blat: boo; }
+SCSS
+foo bar
+  baz bang
+    baz: bang
+    bip: bop
+  blat: boo
+SASS
+
+    assert_scss_to_sass <<SASS, <<SCSS, :indent => "    "
+foo bar
+    baz bang
+        baz: bang
+        bip: bop
+    blat: boo
+SASS
+foo bar {
+  baz bang {
+    baz: bang;
+    bip: bop; }
+  blat: boo; }
+SCSS
+
+    assert_scss_to_sass <<SASS, <<SCSS, :indent => "\t"
+foo bar
+	baz bang
+		baz: bang
+		bip: bop
+	blat: boo
+SASS
+foo bar {
+  baz bang {
+    baz: bang;
+    bip: bop; }
+  blat: boo; }
+SCSS
+  end
+
+
   private
 
   def assert_sass_to_sass(sass, options = {})


### PR DESCRIPTION
It should fix https://github.com/nex3/sass/issues/107
- sass-convert --indent 4 uses 4 spaces
- sass-convert --indent t uses real tabs

There is no option to make the close parenthesis sitting in the same line of last rule, because I think it is hard to use and should be avoid.
