### PR TITLE
make sure Number.round outputs a float instead of rational when mathn is included

### DIFF
--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -968,7 +968,7 @@ module Sass::Script
       #
       # Finally, the weight of color1 is renormalized to be within [0, 1]
       # and the weight of color2 is given by 1 minus the weight of color1.
-      p = weight.value/100.0
+      p = (weight.value/100.0).to_f
       w = p*2 - 1
       a = color1.alpha - color2.alpha
 

--- a/lib/sass/script/number.rb
+++ b/lib/sass/script/number.rb
@@ -360,7 +360,7 @@ module Sass::Script
       elsif num % 1 == 0.0
         num.to_i
       else
-        (num * self.precision_factor).round / self.precision_factor
+        ((num * self.precision_factor).round / self.precision_factor).to_f
       end
     end
 


### PR DESCRIPTION
When sass is used in a rails project that also uses the mathn standard library and ruby 1.9.3 Sass::Script::Number.round output a Rational when fed a float.  The result of this was rgba(0,0,0,0.5) producing  rgba(0,0,0,500/1000) in the output css.   Also a divide by zero error occurred during the tests in the mix function.   Ensuring floats are used rather than Rationals fixes these issues
I'm not sure how to have tests of the functions run with and without mathn included so havent updated the test cases
