### PR TITLE
Fixes potential issue when parsing comments

### DIFF
--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -629,7 +629,7 @@ WARNING
         type = if silent then :silent elsif loud then :loud else :normal end
         Tree::CommentNode.new(value, type)
       else
-        Tree::RuleNode.new(parse_interp(line))
+        Tree::RuleNode.new(parse_interp(line.text))
       end
     end
 


### PR DESCRIPTION
As far as I can tell, using `line` rather than `line.text` is going to result in an error as the `line` variable will cascade down and attempted to be passed to `StringScanner` where it will blow up.

I was having this issue, then fixed it and can't seem to cause it to blow up anymore by reverting my code, but I thought commenting on it still may be helpful.

(I also hope I got the formatting correct above).
