### PR TITLE
Extend warnings

### DIFF
--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -676,7 +676,12 @@ WARNING
         raise SyntaxError.new("Illegal nesting: Nothing may be nested beneath extend directives.",
           :line => @line + 1) unless line.children.empty?
         offset = line.offset + line.text.index(value).to_i
-        Tree::ExtendNode.new(parse_interp(value, offset))
+        optional = false
+        if value =~ /\!optional\s*$/
+          optional = true
+          value = value.gsub(/\s*!optional\s*$/,'')
+        end
+        Tree::ExtendNode.new(parse_interp(value, offset), optional)
       when 'warn'
         raise SyntaxError.new("Invalid warn directive '@warn': expected expression.") unless value
         raise SyntaxError.new("Illegal nesting: Nothing may be nested beneath warn directives.",

--- a/lib/sass/scss/parser.rb
+++ b/lib/sass/scss/parser.rb
@@ -289,7 +289,7 @@ module Sass
       end
 
       def extend_directive
-        node(Sass::Tree::ExtendNode.new(expr!(:selector_sequence)))
+        node(Sass::Tree::ExtendNode.new(expr!(:selector_sequence), !!tok(OPTIONAL)))
       end
 
       def import_directive

--- a/lib/sass/scss/rx.rb
+++ b/lib/sass/scss/rx.rb
@@ -93,6 +93,7 @@ module Sass
 
       IMPORTANT = /!#{W}important/i
       DEFAULT = /!#{W}default/i
+      OPTIONAL = /!#{W}optional/i
 
       NUMBER = /#{NUM}(?:#{IDENT}|%)?/
 

--- a/lib/sass/selector/abstract_sequence.rb
+++ b/lib/sass/selector/abstract_sequence.rb
@@ -82,6 +82,16 @@ module Sass
         _specificity(members)
       end
 
+      # Marks this selector as extended.
+      def extended!
+        @extended = true
+      end
+
+      # Checks whether this selector has been extended
+      def extended?
+        @extended
+      end
+
       protected
 
       def _specificity(arr)
@@ -89,6 +99,7 @@ module Sass
         arr.map {|m| spec += m.is_a?(String) ? 0 : m.specificity}
         spec
       end
+
     end
   end
 end

--- a/lib/sass/selector/abstract_sequence.rb
+++ b/lib/sass/selector/abstract_sequence.rb
@@ -82,6 +82,16 @@ module Sass
         _specificity(members)
       end
 
+      # Marks this selector as not requiring the base selector to exist.
+      def extension_optional!
+        @extension_optional = true
+      end
+
+      # Checks whether this selector has been extended
+      def extension_optional?
+        @extension_optional
+      end
+
       # Marks this selector as extended.
       def extended!
         @extended = true

--- a/lib/sass/selector/sequence.rb
+++ b/lib/sass/selector/sequence.rb
@@ -9,6 +9,7 @@ module Sass
       # @param line [Fixnum]
       # @return [Fixnum]
       def line=(line)
+        @line = line
         members.each {|m| m.line = line if m.is_a?(SimpleSequence)}
         line
       end
@@ -20,6 +21,7 @@ module Sass
       # @param filename [String, nil]
       # @return [String, nil]
       def filename=(filename)
+        @filename = filename
         members.each {|m| m.filename = filename if m.is_a?(SimpleSequence)}
         filename
       end

--- a/lib/sass/selector/simple.rb
+++ b/lib/sass/selector/simple.rb
@@ -103,6 +103,16 @@ module Sass
         @extended
       end
 
+      # Marks this selector as not requiring the base selector to exist.
+      def extension_optional!
+        @extension_optional = true
+      end
+
+      # Checks whether this selector has been extended
+      def extension_optional?
+        @extension_optional
+      end
+
       protected
 
       # Unifies two namespaces,

--- a/lib/sass/selector/simple.rb
+++ b/lib/sass/selector/simple.rb
@@ -93,6 +93,16 @@ module Sass
         return sels[0...i] + [self] + sels[i..-1]
       end
 
+      # Marks this selector as extended.
+      def extended!
+        @extended = true
+      end
+
+      # Checks whether this selector has been extended
+      def extended?
+        @extended
+      end
+
       protected
 
       # Unifies two namespaces,

--- a/lib/sass/selector/simple_sequence.rb
+++ b/lib/sass/selector/simple_sequence.rb
@@ -85,6 +85,7 @@ module Sass
           # seq is A, sels is B, and self is C
 
           self_without_sel = self.members - sels
+          sels.each {|s| s.extended!}
           next unless unified = seq.members.last.unify(self_without_sel)
           new_seq = Sequence.new(seq.members[0...-1] + [unified])
           new_seq.add_sources!(sources + [seq])

--- a/lib/sass/tree/extend_node.rb
+++ b/lib/sass/tree/extend_node.rb
@@ -17,12 +17,19 @@ module Sass::Tree
     # @return [Array<String, Sass::Script::Node>]
     attr_accessor :selector
 
+    # Whether this extends is optional.
+    # Optional extends do not issue a warning when the base selector is not found.
+    #
+    # @return [Boolean]
+    attr_accessor :optional
+
     # @param selector [Array<String, Sass::Script::Node>]
     #   The CSS selector to extend,
     #   interspersed with {Sass::Script::Node}s
     #   representing `#{}`-interpolation.
-    def initialize(selector)
+    def initialize(selector, optional)
       @selector = selector
+      @optional = optional
       super()
     end
   end

--- a/lib/sass/tree/root_node.rb
+++ b/lib/sass/tree/root_node.rb
@@ -27,7 +27,7 @@ module Sass
         return self if extends.empty?
         result = super
         extends.each do |e, by|
-          unless e.extended?
+          unless e.extended? || by.extension_optional?
             Sass::Util.sass_warn <<WARN
 WARNING on line #{by.line}#{" of #{by.filename}" if by.filename}:
   Missing selector #{e.inspect} not found for @extend of #{by.inspect}.

--- a/lib/sass/tree/root_node.rb
+++ b/lib/sass/tree/root_node.rb
@@ -26,14 +26,16 @@ module Sass
       def do_extend(extends)
         return self if extends.empty?
         result = super
-        extends.each do |e, by|
-          unless e.extended? || by.extension_optional?
+        extends.each_by_value do |by, es|
+          next if es.all?{|e| e.extended?}
+          unless by.extension_optional?
+            selector = es.map{|e| e.inspect}.join
             Sass::Util.sass_warn <<WARN
 WARNING on line #{by.line}#{" of #{by.filename}" if by.filename}:
-  Missing selector #{e.inspect} not found for @extend of #{by.inspect}.
+  Missing selector #{selector} not found for @extend of #{by.inspect}.
   This will become an error in a future release.
   To allow this condition, change to:
-    @extend #{e.inspect} !optional
+    @extend #{selector} !optional
 WARN
           end
         end

--- a/lib/sass/tree/root_node.rb
+++ b/lib/sass/tree/root_node.rb
@@ -20,8 +20,24 @@ module Sass
         result = Visitors::Perform.visit(self)
         Visitors::CheckNesting.visit(result) # Check again to validate mixins
         result, extends = Visitors::Cssize.visit(result)
-        result = result.do_extend(extends) unless extends.empty?
-        result.to_s
+        result.do_extend(extends).to_s
+      end
+
+      def do_extend(extends)
+        return self if extends.empty?
+        result = super
+        extends.each do |e, by|
+          unless e.extended?
+            Sass::Util.sass_warn <<WARN
+WARNING on line #{by.line}#{" of #{by.filename}" if by.filename}:
+  Missing selector #{e.inspect} not found for @extend of #{by.inspect}.
+  This will become an error in a future release.
+  To allow this condition, change to:
+    @extend #{e.inspect} !optional
+WARN
+          end
+        end
+        result
       end
     end
   end

--- a/lib/sass/tree/visitors/cssize.rb
+++ b/lib/sass/tree/visitors/cssize.rb
@@ -102,6 +102,7 @@ class Sass::Tree::Visitors::Cssize < Sass::Tree::Visitors::Base
         end
         seq.line = node.line
         seq.filename = node.filename
+        seq.extension_optional! if node.optional
         @extends[sel] = seq
       end
     end

--- a/lib/sass/tree/visitors/cssize.rb
+++ b/lib/sass/tree/visitors/cssize.rb
@@ -100,7 +100,8 @@ class Sass::Tree::Visitors::Cssize < Sass::Tree::Visitors::Base
         if !seq.members.last.is_a?(Sass::Selector::SimpleSequence)
           raise Sass::SyntaxError.new("#{seq} can't extend: invalid selector")
         end
-
+        seq.line = node.line
+        seq.filename = node.filename
         @extends[sel] = seq
       end
     end

--- a/lib/sass/util/subset_map.rb
+++ b/lib/sass/util/subset_map.rb
@@ -46,7 +46,6 @@ module Sass
       # @raise [ArgumentError] If `set` is empty.
       def []=(set, value)
         raise ArgumentError.new("SubsetMap keys may not be empty.") if set.empty?
-
         index = @vals.size
         @vals << value
         set.each do |k|
@@ -95,6 +94,14 @@ module Sass
       # @see #get
       def [](set)
         get(set).map {|v, _| v}
+      end
+
+      def each
+        @hash.each do |k,v|
+          v.each do |(_,_,i)|
+            yield k, @vals[i]
+          end
+        end
       end
     end
   end

--- a/lib/sass/util/subset_map.rb
+++ b/lib/sass/util/subset_map.rb
@@ -96,12 +96,26 @@ module Sass
         get(set).map {|v, _| v}
       end
 
+      # Iterate over each key and the values to which it maps
+      #
+      # @yield [key, values] Yields the key and an array of values to which it is mapped.
       def each
         @hash.each do |k,v|
-          v.each do |(_,_,i)|
-            yield k, @vals[i]
+          yield(k, v.map{|(_,_,i)| @vals[i]})
+        end
+      end
+
+      # Iterate over each value the keys which are mapped to it.
+      #
+      # @yield [value, keys] Yields the value and an array of keys.
+      def each_by_value
+        value_map = {}
+        each do |k,values|
+          values.each do |v|
+            (value_map[v] ||= []) << k
           end
         end
+        value_map.each {|v,k| yield v, k}
       end
     end
   end

--- a/test/sass/extend_test.rb
+++ b/test/sass/extend_test.rb
@@ -318,7 +318,13 @@ SCSS
   end
 
   def test_long_extendee_requires_all_selectors
-    assert_extends '.foo', '.baz {@extend .foo.bar}', '.foo'
+    assert_warning(<<MESSAGE) { assert_extends '.foo', '.baz {@extend .foo.bar}', '.foo' }
+WARNING on line 2 of test_long_extendee_requires_all_selectors_inline.scss:
+  Missing selector .foo.bar not found for @extend of .baz.
+  This will become an error in a future release.
+  To allow this condition, change to:
+    @extend .foo.bar !optional
+MESSAGE
   end
 
   def test_long_extendee_matches_supersets

--- a/test/sass/extend_test.rb
+++ b/test/sass/extend_test.rb
@@ -914,7 +914,18 @@ MESSAGE
   end
 
   def test_extend_does_not_warn_when_base_class_is_found
-    assert_warning("") { render(".base {a:b;} .foo { @extend .base; }") }
+    assert_no_warnings { render(".base {a:b;} .foo { @extend .base; }") }
+  end
+
+  def test_extend_does_not_warn_when_optional
+    assert_no_warnings { render(".foo { @extend .base !optional; }") }
+  end
+
+  def test_extend_does_not_warn_when_optional_in_sass
+    assert_no_warnings { render(<<SASS, :syntax => :sass) }
+.foo
+  @extend .base !optional
+SASS
   end
 
   private

--- a/test/sass/extend_test.rb
+++ b/test/sass/extend_test.rb
@@ -903,6 +903,20 @@ a d {@extend %y}
 SCSS
   end
 
+  def test_extend_warns_when_base_class_not_found
+    assert_warning(<<MESSAGE) { render(".foo { @extend .base; }") }
+WARNING on line 1 of test_extend_warns_when_base_class_not_found_inline.scss:
+  Missing selector .base not found for @extend of .foo.
+  This will become an error in a future release.
+  To allow this condition, change to:
+    @extend .base !optional
+MESSAGE
+  end
+
+  def test_extend_does_not_warn_when_base_class_is_found
+    assert_warning("") { render(".base {a:b;} .foo { @extend .base; }") }
+  end
+
   private
 
   def assert_unification(selector, extension, unified)
@@ -924,7 +938,8 @@ SCSS
   end
 
   def render(sass, options = {})
+    options = {:syntax => :scss}.merge(options)
     munge_filename options
-    Sass::Engine.new(sass, {:syntax => :scss}.merge(options)).render
+    Sass::Engine.new(sass, options).render
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,6 +47,10 @@ class Test::Unit::TestCase
     $stderr = the_real_stderr
   end
 
+  def assert_no_warnings(&block)
+    assert_warning("", &block)
+  end
+
   def silence_warnings(&block)
     Sass::Util.silence_warnings(&block)
   end


### PR DESCRIPTION
In porting from base classes to placeholder selectors, I really needed this.

In 3.2 we will warn if a selector being extended is not found. In 3.3/4.0 it will become an error.

The warning can be silenced by placing `!optional` at the end of an `@extend statement`. This maybe useful for libraries and partial re-use.
