### PR TITLE
Add Sass::Script::Functions#ie_hex_str to convert colors to IE compatible colors for filters.

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -5,17 +5,27 @@
 
 ## 3.2.0 (Unreleased)
 
+### Functions `ie-hex-str`
+
+A function that returns an IE compatible hex string for a color.
+Accepts color and upcases the hex string and adds the alpha layer as required by IE filters. E.g.:
+
+    ie-hex-str(#1Ab) => #FF11AABB
+
+    $translucent-green: rgba(0, 255, 0, 0.5);
+    ie-hex-str($translucent-green) => #8000FF00
+
 ### `@content`
 
 A mixin include can now accept a block of content ({file:SASS_REFERENCE.md#mixin-content Reference Documentation}).
 The style block will be passed to the mixin and can be placed at the point @content is used. E.g.:
-  
+
     @mixin iphone {
       @media only screen and (max-width: 480px) {
         @content;
       }
     }
-    
+
     @include iphone {
       body { color: red }
     }
@@ -25,7 +35,7 @@ Or in `.sass` syntax:
     =iphone
       @media only screen and (max-width: 480px)
         @content
-    
+
     +iphone
       body
         color: red
@@ -314,11 +324,11 @@ For example:
 
     $grid-width: 40px;
     $gutter-width: 10px;
-    
+
     @function grid-width($n) {
       @return $n * $grid-width + ($n - 1) * $gutter-width;
     }
-    
+
     #sidebar { width: grid-width(5); }
 
 Becomes:
@@ -2118,7 +2128,7 @@ the previous arguments in the declaration. For example:
     !default_width = 10px
     .small-default-box
       +my-fancy-mixin
-    
+
 
 compiles to:
 
@@ -2137,7 +2147,7 @@ compiles to:
     .small-default-box {
       width: 10px;
       height: 10px; }
-    
+
 
 ### Sass, Interactive
 
@@ -2467,7 +2477,7 @@ During compilation the following will be printed:
 
 #### Ruby 1.9 Support
 
-Sass now fully supports Ruby 1.9.1. 
+Sass now fully supports Ruby 1.9.1.
 
 #### Sass Cache
 

--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -860,6 +860,24 @@ is compiled to:
       color: rgba(255, 0, 0, 0.9);
       background-color: rgba(255, 0, 0, 0.25); }
 
+IE filters require all colors include the alpha layer, and be in
+the strict format of #AABBCCDD. You can more easily convert the
+color using the {Sass::Script::Functions#ie_hex_str ie_hex_str}
+function.
+For example:
+
+    $translucent-red: rgba(255, 0, 0, 0.5);
+    $green: #00ff00;
+    div {
+      filter: progid:DXImageTransform.Microsoft.gradient(enabled='false', startColorstr='#{ie-hex-str($green)}', endColorstr='#{ie-hex-str($translucent-red)}');
+    }
+
+is compiled to:
+
+    div {
+      filter: progid:DXImageTransform.Microsoft.gradient(enabled='false', startColorstr=#FF00FF00, endColorstr=#80FF0000);
+    }
+
 #### String Operations
 
 The `+` operation can be used to concatenate strings:
@@ -1931,7 +1949,7 @@ The same mixins can be done in the `.sass` shorthand syntax:
     =apply-to-ie6-only
       * html
         @content
-    
+
     +apply-to-ie6-only
       #logo
         background-image: url(/logo.gif)
@@ -1981,11 +1999,11 @@ value or script context. For example:
 
     $grid-width: 40px;
     $gutter-width: 10px;
-    
+
     @function grid-width($n) {
       @return $n * $grid-width + ($n - 1) * $gutter-width;
     }
-    
+
     #sidebar { width: grid-width(5); }
 
 Becomes:

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -241,7 +241,7 @@ module Sass::Script
     #   to {Sass::Script::Literal}s as the last argument.
     #   In addition, if this is true and `:var_args` is not,
     #   Sass will ensure that the last argument passed is a hash.
-    # 
+    #
     # @example
     #   declare :rgba, [:hex, :alpha]
     #   declare :rgba, [:red, :green, :blue, :alpha]
@@ -732,6 +732,24 @@ module Sass::Script
       color.with(:hue => color.hue + degrees.value)
     end
     declare :adjust_hue, [:color, :degrees]
+
+    # Returns an IE hex string for a color with an alpha channel
+    # suitable for passing to IE filters.
+    #
+    # @example
+    #   ie-hex-str(#abc) => #FFAABBCC
+    #   ie-hex-str(#3322BB) => #FF3322BB
+    #   ie-hex-str(rgba(0, 255, 0, 0.5)) => #8000FF00
+    # @param color[Color]
+    # @return [String]
+    # @raise [ArgumentError] if `color` is not a color
+    def ie_hex_str(color)
+      assert_type color, :Color
+      alpha = (color.alpha * 255).round
+      alphastr = alpha.to_s(16).rjust(2, '0')
+      Sass::Script::String.new("##{alphastr}#{color.send(:hex_str)[1..-1]}".upcase)
+    end
+    declare :ie_hex_str, [:color]
 
     # Adjusts one or more properties of a color.
     # This can change the red, green, blue, hue, saturation, value, and alpha properties.

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -735,6 +735,13 @@ class SassFunctionTest < Test::Unit::TestCase
       "change-color(blue, $lightness: 10%, $red: 120)");
   end
 
+  def test_ie_hex_str
+    assert_equal("#FFAA11CC", evaluate('ie-hex-str(#aa11cc)'))
+    assert_equal("#FFAA11CC", evaluate('ie-hex-str(#a1c)'))
+    assert_equal("#FFAA11CC", evaluate('ie-hex-str(#A1c)'))
+    assert_equal("#80FF0000", evaluate('ie-hex-str(rgba(255, 0, 0, 0.5))'))
+  end
+
   def test_mix
     assert_equal("#7f007f", evaluate("mix(#f00, #00f)"))
     assert_equal("#7f7f7f", evaluate("mix(#f00, #0ff)"))


### PR DESCRIPTION
For more information on this pull request please see issue #231.
