### PR TITLE
Clarify documentation of `@for`.

### DIFF
--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -1662,19 +1662,10 @@ is compiled to:
 
 ### `@for`
 
-The `@for` directive has two forms:
-`@for $var from <start> to <end>` or
-`@for $var from <start> through <end>`.
-`$var` can be any variable name, like `$i`,
-and `<start>` and `<end>` are SassScript expressions
-that should return integers.
+The `@for` directive repeatedly outputs a set of styles. For each repetition, a counter variable is used to adjust the output. The directive has two forms:
+`@for $var from <start> through <end>` and `@for $var from <start> to <end>`. Note the difference in the keywords `through` and `to`. `$var` can be any variable name, like `$i`; `<start>` and `<end>` are SassScript expressions that should return integers.
 
-The `@for` statement sets `$var` to each number
-from `<start>` to `<end>`,
-including `<end>` if `through` is used.
-Then it outputs the nested styles
-using that value of `$var`.
-For example:
+The `@for` statement sets `$var` to each successive number in the specified range and each time outputs the nested styles using that value of `$var`. For the form `from…through`, the range *includes* the values of `<start>` and `<end>`, but the form `from…to` runs up to *but not including* the value of `<end>`. Using the `through` syntax, 
 
     @for $i from 1 through 3 {
       .item-#{$i} { width: 2em * $i; }


### PR DESCRIPTION
Some users might miss the distinction between the two forms of the
`@for` syntax, resulting in off-by-one errors that may be hard to debug. 
Attempt to make the documentation more explicit and generally clearer.
