### PR TITLE
added directory support for cli

### DIFF
--- a/lib/sass.rb
+++ b/lib/sass.rb
@@ -76,7 +76,9 @@ module Sass
   def self.compile_file(filename, *args)
     options = args.last.is_a?(Hash) ? args.pop : {}
     css_filename = args.shift
+
     result = Sass::Engine.for_file(filename, options).render
+
     if css_filename
       options[:css_filename] ||= css_filename
       open(css_filename,"w") {|css_file| css_file.write(result)}

--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -212,6 +212,22 @@ module Sass
 
       Sass::Engine.new(File.read(filename), options.merge(:filename => filename))
     end
+    
+    def self.for_directory(directory, options)
+      results = []
+      Dir.glob(File.join(directory, '**')).grep(/\.(sass)|(scss)$/).each do |file|
+        _options = options
+
+        if file =~ /\.scss$/
+          _options.merge!(:syntax => :scss)
+        elsif file =~ /\.sass$/
+          _options.merge!(:syntax => :sass)
+        end
+        results << self.for_file(file, _options)
+      end
+      
+      results
+    end
 
     # The options for the Sass engine.
     # See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.


### PR DESCRIPTION
I added directory support for cli because we use a lot of file in the same subdirectory (eg: src/ and want to make a single file like application.css and application.min.css) and we felt us naked without this =) If I added this then I think send a pull request.

If the given "file" is a directory
  then :syntax option will be skipped and guessing from file extension.

Example: sass src/ assets/application.css

I know not a perfect and nice additional but works. If i will have time (and someone else don't make it) I make a better solution. If this solution is not ok then please tell me what is the problem.

Thanks: Balazs Nadasdi
