### PR TITLE
Updated documentation examples for "opacify" and "transparentize"

### DIFF
--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -850,8 +850,8 @@ For example:
 
     $translucent-red: rgba(255, 0, 0, 0.5);
     p {
-      color: opacify($translucent-red, 0.8);
-      background-color: transparentize($translucent-red, 50%);
+      color: opacify($translucent-red, 0.3);
+      background-color: transparentize($translucent-red, 0.25);
     }
 
 is compiled to:


### PR DESCRIPTION
The example for transparentize previously used a percentage to express the adjustment amount whereas the function actually accepts a number between 0 and 1. Updated example to match the expected output.

The previous example for opacify actually would have compiled to "color: red". Also updated the example here to match the expected output.
