### PR TITLE
EvaluationContext takes the environment as argument and then extracts options from it

### DIFF
--- a/lib/sass/script/funcall.rb
+++ b/lib/sass/script/funcall.rb
@@ -103,7 +103,7 @@ module Sass
         unless Functions.callable?(ruby_name)
           opts(to_literal(args))
         else
-          opts(Functions::EvaluationContext.new(environment.options).send(ruby_name, *args))
+          opts(Functions::EvaluationContext.new(environment).send(ruby_name, *args))
         end
       rescue ArgumentError => e
         # If this is a legitimate Ruby-raised argument error, re-raise it.

--- a/lib/sass/script/funcall.rb
+++ b/lib/sass/script/funcall.rb
@@ -103,7 +103,8 @@ module Sass
         unless Functions.callable?(ruby_name)
           opts(to_literal(args))
         else
-          opts(Functions::EvaluationContext.new(environment).send(ruby_name, *args))
+          local_environment = Environment.new(environment)
+          opts(Functions::EvaluationContext.new(local_environment).send(ruby_name, *args))
         end
       rescue ArgumentError => e
         # If this is a legitimate Ruby-raised argument error, re-raise it.

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -309,14 +309,21 @@ module Sass::Script
     class EvaluationContext
       include Functions
 
+
+      # The environment of the {Sass::Engine}
+      #
+      # @return [Environment]
+      attr_reader :environment
+
       # The options hash for the {Sass::Engine} that is processing the function call
       #
       # @return [{Symbol => Object}]
       attr_reader :options
 
-      # @param options [{Symbol => Object}] See \{#options}
-      def initialize(options)
-        @options = options
+      # @param environment [Environment] See \{#environment}
+      def initialize(environment)
+        @environment = environment
+        @options = environment.options
       end
 
       # Asserts that the type of a given SassScript value

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -11,6 +11,11 @@ module Sass::Script::Functions::UserFunctions
   def option(name)
     Sass::Script::String.new(@options[name.value.to_sym].to_s)
   end
+
+  def set_a_local_variable
+    environment.set_var('variable', Sass::Script::Number.new(5))
+    return Sass::Script::Null.new
+  end
 end
 
 class SassEngineTest < Test::Unit::TestCase
@@ -1364,6 +1369,29 @@ CSS
 
 bar
   a: foo(1, 2)
+SASS
+  end
+
+  def test_user_defined_function_variable_scope
+    puts render(<<SASS)
+bar
+  -no-op: set_a_local_variable()
+  a: $variable
+SASS
+    flunk("Exception not raised for test_user_defined_function_variable_scope")
+  rescue Sass::SyntaxError => e
+    assert_equal('Undefined variable: "$variable".', e.message)
+  end
+
+  def test_user_defined_function_can_change_global_variable
+    assert_equal(<<CSS, render(<<SASS))
+bar {
+  a: 5; }
+CSS
+$variable: 0
+bar
+  -no-op: set_a_local_variable()
+  a: $variable
 SASS
   end
 

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -1116,11 +1116,11 @@ MSG
   end
 
   def evaluate(value, environment = env)
-    Sass::Script::Parser.parse(value, 0, 0).perform(environment).to_s
+    perform(value, environment).to_s
   end
 
-  def perform(value)
-    Sass::Script::Parser.parse(value, 0, 0).perform(env)
+  def perform(value, environment = env)
+    Sass::Script::Parser.parse(value, 0, 0).perform(environment)
   end
 
   def assert_error_message(message, value)

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -33,6 +33,10 @@ module Sass::Script::Functions::UserFunctions
   def _preceding_underscore
     Sass::Script::String.new("I'm another user-defined string!")
   end
+
+  def fetch_the_variable
+    environment.var('variable')
+  end
 end
 
 module Sass::Script::Functions
@@ -873,6 +877,11 @@ class SassFunctionTest < Test::Unit::TestCase
     assert_equal("I'm another user-defined string!", evaluate("-preceding-underscore()"))
   end
 
+  def test_user_defined_function_using_environment
+    environment = env('variable' => Sass::Script::String.new('The variable'))
+    assert_equal("The variable", evaluate("fetch_the_variable()", environment))
+  end
+
   def test_options_on_new_literals_fails
     assert_error_message(<<MSG, "call-options-on-new-literal()")
 The #options attribute is not set on this Sass::Script::String.
@@ -1100,13 +1109,18 @@ MSG
   end
 
   private
+  def env(hash = {})
+    env = Sass::Environment.new
+    hash.each {|k, v| env.set_var(k, v)}
+    env
+  end
 
-  def evaluate(value)
-    Sass::Script::Parser.parse(value, 0, 0).perform(Sass::Environment.new).to_s
+  def evaluate(value, environment = env)
+    Sass::Script::Parser.parse(value, 0, 0).perform(environment).to_s
   end
 
   def perform(value)
-    Sass::Script::Parser.parse(value, 0, 0).perform(Sass::Environment.new)
+    Sass::Script::Parser.parse(value, 0, 0).perform(env)
   end
 
   def assert_error_message(message, value)


### PR DESCRIPTION
Hi there!

I encountered a similiar example to the one shown here, and realized that there really wasn't an easy way to do this in ruby as a SASS extension. So I thought it could be a good idea to make the environment accessible to the EvaluationContext.

``` scss
$variable: 5;

@function more() {
  @return $variable + 3;
}
```

With my addition this would now be possible:

``` ruby
def more
  environment.var('variable')
end
```
