### PR TITLE
Add `nil` literal

### DIFF
--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -627,12 +627,13 @@ this still works, but it's deprecated and prints a warning.
 
 ### Data Types
 
-SassScript supports four main data types:
+SassScript supports six main data types:
 
 * numbers (e.g. `1.2`, `13`, `10px`)
 * strings of text, with and without quotes (e.g. `"foo"`, `'bar'`, `baz`)
 * colors (e.g. `blue`, `#04a3f9`, `rgba(255, 0, 0, 0.5)`)
 * booleans (e.g. `true`, `false`)
+* nil values (e.g. `nil`)
 * lists of values, separated by spaces or commas (e.g. `1.5em 1em 0 2em`, `Helvetica, Arial, sans-serif`)
 
 SassScript also supports all other types of CSS property value,
@@ -1025,25 +1026,29 @@ is compiled to:
 
 You can assign to variables if they aren't already assigned
 by adding the `!default` flag to the end of the value.
-This means that if the variable has already been assigned to,
-it won't be re-assigned,
-but if it doesn't have a value yet, it will be given one.
+This means that if the variable has already been assigned a non-nil value,
+it won't be re-assigned. If it doesn't have a value yet (or it is nil),
+it will be given one.
 
 For example:
 
     $content: "First content";
     $content: "Second content?" !default;
-    $new_content: "First time reference" !default;
+    $non-nil-content: nil;
+    $non-nil-content: "Non-nil content" !default;
+    $new-content: "First time reference" !default;
 
     #main {
       content: $content;
-      new-content: $new_content;
+      non-nil-content: $non-nil-content;
+      new-content: $new-content;
     }
 
 is compiled to:
 
     #main {
       content: "First content";
+      non-nil-content: "Non-nil content";
       new-content: "First time reference"; }
 
 ## `@`-Rules and Directives {#directives}

--- a/lib/sass/script/lexer.rb
+++ b/lib/sass/script/lexer.rb
@@ -90,6 +90,7 @@ module Sass
         :number => /(-)?(?:(\d*\.\d+)|(\d+))([a-zA-Z%]+)?/,
         :color => HEXCOLOR,
         :bool => /(true|false)\b/,
+        :nil => /(nil)\b/,
         :ident_op => %r{(#{Regexp.union(*IDENT_OP_NAMES.map{|s| Regexp.new(Regexp.escape(s) + "(?!#{NMCHAR}|\Z)")})})},
         :op => %r{(#{Regexp.union(*OP_NAMES)})},
       }
@@ -234,7 +235,7 @@ module Sass
         end
 
         variable || string(:double, false) || string(:single, false) || number ||
-          color || bool || string(:uri, false) || raw(UNICODERANGE) ||
+          color || bool || nil_value || string(:uri, false) || raw(UNICODERANGE) ||
           special_fun || special_val || ident_op || ident || op
       end
 
@@ -290,6 +291,11 @@ MESSAGE
       def bool
         return unless s = scan(REGULAR_EXPRESSIONS[:bool])
         [:bool, Script::Bool.new(s == 'true')]
+      end
+
+      def nil_value
+        return unless s = scan(REGULAR_EXPRESSIONS[:nil])
+        [:nil, Script::Nil.new]
       end
 
       def special_fun

--- a/lib/sass/script/literal.rb
+++ b/lib/sass/script/literal.rb
@@ -9,6 +9,7 @@ module Sass::Script
     require 'sass/script/number'
     require 'sass/script/color'
     require 'sass/script/bool'
+    require 'sass/script/nil'
     require 'sass/script/list'
 
     # Returns the Ruby value of the literal.

--- a/lib/sass/script/nil.rb
+++ b/lib/sass/script/nil.rb
@@ -1,0 +1,32 @@
+require 'sass/script/literal'
+
+module Sass::Script
+  # A SassScript object representing a boolean (true or false) value.
+  class Nil < Literal
+    # The Ruby value of the boolean.
+    #
+    # @return [NilClass]
+    attr_reader :value
+
+    # Creates a new nil literal.
+    def initialize
+      super nil
+    end
+
+    # @return [Boolean] `false` (the Ruby boolean value)
+    def to_bool
+      false
+    end
+
+    # @return [Boolean] `true`
+    def nil?
+      true
+    end
+
+    # @return [String] '' (An empty string)
+    def to_s(opts = {})
+      @value.to_s
+    end
+    alias_method :to_sass, :to_s
+  end
+end

--- a/lib/sass/script/parser.rb
+++ b/lib/sass/script/parser.rb
@@ -453,7 +453,7 @@ RUBY
       end
 
       def literal
-        (t = try_tok(:color, :bool)) && (return t.value)
+        (t = try_tok(:color, :bool, :nil)) && (return t.value)
       end
 
       # It would be possible to have unified #assert and #try methods,

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -1100,6 +1100,7 @@ SASS
   def test_guarded_assign
     assert_equal("foo {\n  a: b; }\n", render(%Q{$foo: b\n$foo: c !default\nfoo\n  a: $foo}))
     assert_equal("foo {\n  a: b; }\n", render(%Q{$foo: b !default\nfoo\n  a: $foo}))
+    assert_equal("foo {\n  a: b; }\n", render(%Q{$foo: nil\n$foo: b !default\nfoo\n  a: $foo}))
   end
   
   def test_mixins

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -871,6 +871,7 @@ MSG
     assert_equal("bool", evaluate("type-of(true)"))
     assert_equal("color", evaluate("type-of(#fff)"))
     assert_equal("color", evaluate("type-of($value: #fff)"))
+    assert_equal("nil", evaluate("type-of(nil)"))
   end
 
   def test_unit
@@ -1011,6 +1012,7 @@ MSG
   def test_if
     assert_equal("1px", evaluate("if(true, 1px, 2px)"))
     assert_equal("2px", evaluate("if(false, 1px, 2px)"))
+    assert_equal("2px", evaluate("if(nil, 1px, 2px)"))
   end
 
   def test_keyword_args_rgb


### PR DESCRIPTION
Here's a common use use case for a `nil` literal:

``` scss
@mixin block-colors($background-color, $border-color: nil) {
  $border-color: darken($background-color, 10%) !default;

  background-color: $background-color;
  border-color: $border-color;
}
```

This is semantically different than using `false` in conjunction with an `@if` directive. Plus, guarded assignment can be used to set a dynamic default value.
