### PR TITLE
Fix the Listen plugin

### DIFF
--- a/lib/sass/plugin/listener.rb
+++ b/lib/sass/plugin/listener.rb
@@ -14,20 +14,20 @@ class Sass::Plugin::Listener
   end
 
   def directory(path, events)
-    (@directories[path] ||= []) << events
+    (@directories[File.expand_path(path)] ||= []) << events
   end
 
   def file(path, events)
     file_base = File.basename(path)
     directory(File.dirname(path), {
-        :modified => file_event_fn(events[:modified], file_base),
-        :added => file_event_fn(events[:added], file_base),
-        :removed => file_event_fn(events[:removed], file_base)
-      })
+      :modified => file_event_fn(events[:modified], file_base),
+      :added => file_event_fn(events[:added], file_base),
+      :removed => file_event_fn(events[:removed], file_base)
+    })
   end
 
   def start!
-    listener = Listen::MultiListener.new(*@directories.keys) do |modified, added, removed|
+    listener = Listen::MultiListener.new(*@directories.keys, :force_polling => Sass::Util.windows?) do |modified, added, removed|
       modified = modified.group_by {|path| File.dirname(path)}
       added = added.group_by {|path| File.dirname(path)}
       removed = removed.group_by {|path| File.dirname(path)}


### PR DESCRIPTION
Greetings,

[Multiple](https://github.com/nex3/sass/issues/362) [bugs](https://github.com/nex3/sass/issues/370) have been reported when watching relative paths after converting to Listen. The reason was a bug in Listen, but it has recently been fixed. Also, the polling adapter of Listen is faster on Windows, we'll address this issue shortly, but for now using the polling adapter would allow you to release a patch to fix sass.
