### PR TITLE
Ruby 2.0 support: check for private visitor methods

### DIFF
--- a/lib/sass/tree/visitors/base.rb
+++ b/lib/sass/tree/visitors/base.rb
@@ -33,7 +33,7 @@ module Sass::Tree::Visitors
     # @return [Object] The return value of the `visit_*` method for this node.
     def visit(node)
       method = "visit_#{node_name node}"
-      if self.respond_to?(method)
+      if self.respond_to?(method, true)
         self.send(method, node) {visit_children(node)}
       else
         visit_children(node)


### PR DESCRIPTION
Visitor methods are private, so we should pass the second `include_private` arg to `#respond_to?`

`include_private` was true by default in Ruby 1.8 & 1.9; now it's false. So this is backward compatible.
