### PR TITLE
'Functions' and 'Function Directives' are using the same anchor

### DIFF
--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -1994,7 +1994,7 @@ passed block are related to the other styles around where the block is defined. 
     }
 
 
-## Function Directives {#functions}
+## Function Directives {#function_directives}
 
 It is possible to define your own functions in sass and use them in any
 value or script context. For example:


### PR DESCRIPTION
'Functions' and 'Function Directives' were both using the #functions anchor, which made it impossible to jump to the 'Function Directives' section in the documentation. I've changed these to be #functions and #function_directives respectively.
