### PR TITLE
Add `clamp` as a built-in number function

### DIFF
--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -133,6 +133,9 @@ module Sass::Script
   # \{#max max($x1, $x2, ...)\}
   # : Finds the maximum of several values.
   #
+  # \{#clamp clamp($value, $min, $max)\}
+  # : Returns a number between minimum and maximum allowed values.
+  #
   # ## List Functions {#list-functions}
   #
   # \{#length length($list)}
@@ -1240,6 +1243,23 @@ module Sass::Script
       values.inject {|max, val| max.gt(val).to_bool ? max : val}
     end
     declare :max, [], :var_args => :true
+
+    # Returns a number between minimum and maximum allowed values.
+    #
+    # @example
+    #   clamp(-10px, 1px, 10px) => 1px
+    #   clamp(5px, 0px, 10px) => 5px
+    #   clamp(110%, 0%, 100%) => 100%
+    # @return [Number] The number between minimum and maximum values.
+    # @raise [ArgumentError] if any argument isn't a number, or if not all of
+    #   the arguments have comparable units
+    def clamp(value, min, max)
+      assert_type value, :Number
+      assert_type min, :Number
+      assert_type max, :Number
+      (value.lt(min).to_bool ? min : (value.gt(max).to_bool ? max : value))
+    end
+    declare :clamp, [:value, :min, :max]
 
     # Return the length of a list.
     #

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -178,6 +178,32 @@ class SassFunctionTest < Test::Unit::TestCase
     assert_error_message("Incompatible units: 'px' and 'em'.", "max(3em, 4em, 1px)")
   end
 
+  def test_clamp
+    assert_equal("1", evaluate("clamp(0, 1, 3)"))
+    assert_equal("1", evaluate("clamp(1, 1, 3)"))
+    assert_equal("2", evaluate("clamp(2, 1, 3)"))
+    assert_equal("3", evaluate("clamp(3, 1, 3)"))
+    assert_equal("3", evaluate("clamp(4, 1, 3)"))
+
+    assert_equal("1.11", evaluate("clamp(0.00, 1.11, 3.33)"))
+    assert_equal("1.11", evaluate("clamp(1.11, 1.11, 3.33)"))
+    assert_equal("2.22", evaluate("clamp(2.22, 1.11, 3.33)"))
+    assert_equal("3.33", evaluate("clamp(3.33, 1.11, 3.33)"))
+    assert_equal("3.33", evaluate("clamp(4.44, 1.11, 3.33)"))
+
+    assert_equal("100%", evaluate("clamp(110%, 0%, 100%)"))
+    assert_equal("10em", evaluate("clamp(1em, 10em, 100em)"))
+
+    assert_equal("1in", evaluate("clamp(1cm, 1in, 2in)"))
+    assert_equal("2in", evaluate("clamp(10cm, 1in, 2in)"))
+
+    assert_error_message("#000000 is not a number for `clamp'", "clamp(0, #000000, #ffffff)")
+    assert_error_message("#cccccc is not a number for `clamp'", "clamp(#cccccc, #000000, #ffffff)")
+    assert_error_message("#ffffff is not a number for `clamp'", "clamp(0, 0, #ffffff)")
+
+    assert_error_message("Incompatible units: 'em' and 'px'.", "clamp(1px, 0em, 2em)")
+  end
+
   def test_rgb
     assert_equal("#123456", evaluate("rgb(18, 52, 86)"))
     assert_equal("#beaded", evaluate("rgb(190, 173, 237)"))


### PR DESCRIPTION
> A safeguard is very often needed when working with built-in functions, e.g, `lighten`, `saturate`, etc. where an `$amount` is expected to be between '0%' and '100%'.

Although it is trivial to implement in Sass using `@-function`s:

``` scss
// Return a value between min and max.
@function clamp($value, $min, $max) {
  @return if($value > $max, $max, if($value < $min, $min, $value));
}
```

not every User is a Sass expert.

This commit defines a single `clamp(..)` function whose arguments are:
- `$value` - the number being clamped
- `$min` - the minimum allowed/accepted value
- `$max` - the maximum allowed/accepted value

It behaves very much the same way as `min(..)` or `max(..)` and throws exceptions when arguments are not numbers or cannot be compared (tests included).

Example:

``` scss
@import 'constants';

html {
  background: saturate($theme, clamp($base-exposure * 2, 0%, 100%));
  // ^ $theme and $base-exposure defined within '_constants.scss'.
}
```
