### PR TITLE
Don't die if a UTF encoding isn't supported.

### DIFF
--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -568,7 +568,7 @@ MSG
             Regexp.new(/\A(?:#{_enc("\uFEFF", e)})?#{
               _enc('@charset "', e)}(.*?)#{_enc('"', e)}|\A(#{
               _enc("\uFEFF", e)})/)
-          rescue Encoding::ConverterNotFound => _
+          rescue Encoding::ConverterNotFoundError => _
             nil # JRuby on Java 5 doesn't support UTF-32
           rescue
             # /\A@charset "(.*?)"/


### PR DESCRIPTION
sha: f1a7936a025c145363041dcb939aa6909e67432b incorrectly introduced a missing constant. It should be Encoding::ConverterNotFoundError.
