### PR TITLE
Fix recursive mode (by passing block from Sass::Util.glob to Dir.glob)

### DIFF
--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -439,9 +439,9 @@ module Sass
     # Like `Dir.glob`, but works with backslash-separated paths on Windows.
     #
     # @param path [String]
-    def glob(path)
+    def glob(path, &block)
       path = path.gsub('\\', '/') if windows?
-      Dir.glob(path)
+      Dir.glob(path, &block)
     end
 
     ## Cross-Ruby-Version Compatibility


### PR DESCRIPTION
This commit fixes the recursive mode which exits silentlty without doing any conversion at all.
