### PR TITLE
Add a MacRuby-friendly regex syntax

### DIFF
--- a/lib/sass/scss/rx.rb
+++ b/lib/sass/scss/rx.rb
@@ -51,6 +51,8 @@ module Sass
       UNICODE  = /\\#{H}{1,6}[ \t\r\n\f]?/
       s = if Sass::Util.ruby1_8?
             '\200-\377'
+          elsif Sass::Util.macruby?
+            '/\u0080-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF'
           else
             '\u{80}-\u{D7FF}\u{E000}-\u{FFFD}\u{10000}-\u{10FFFF}'
           end

--- a/lib/sass/scss/rx.rb
+++ b/lib/sass/scss/rx.rb
@@ -52,7 +52,7 @@ module Sass
       s = if Sass::Util.ruby1_8?
             '\200-\377'
           elsif Sass::Util.macruby?
-            '/\u0080-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF'
+            '\u0080-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF'
           else
             '\u{80}-\u{D7FF}\u{E000}-\u{FFFD}\u{10000}-\u{10FFFF}'
           end

--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -465,6 +465,13 @@ module Sass
     def ruby1_8_6?
       ruby1_8? && Sass::Util::RUBY_VERSION[2] < 7
     end
+    
+    # Whether or not this is running under MacRuby.
+    #
+    # @return [Boolean]
+    def macruby?
+      RUBY_ENGINE == 'macruby'
+    end
 
     # Checks that the encoding of a string is valid in Ruby 1.9
     # and cleans up potential encoding gotchas like the UTF-8 BOM.


### PR DESCRIPTION
`require "sass"` currently fails under MacRuby (#431). We can detect MacRuby and use a regex syntax that it likes better, just as we currently use different regexes for 1.8 and 1.9.
