### PR TITLE
Support @import inline(file.css) for sass 3.2

### DIFF
--- a/lib/sass/importers/filesystem.rb
+++ b/lib/sass/importers/filesystem.rb
@@ -73,7 +73,15 @@ module Sass
       #
       # @return [{String => Symbol}]
       def extensions
-        {'sass' => :sass, 'scss' => :scss}
+        {'sass' => :sass, 'scss' => :scss, 'css' => :scss}
+      end
+
+      # The keys of the extensions hash, ordered by their import priority.
+      #
+      # @return [Array{string}] all the keys of the extensions hash, sorted in
+      #   the order used by import to resolve names without extensions.
+      def sorted_extensions
+        ['sass', 'scss', 'css']
       end
 
       # Given an `@import`ed path, returns an array of possible
@@ -86,11 +94,10 @@ module Sass
       def possible_files(name)
         name = escape_glob_characters(name)
         dirname, basename, extname = split(name)
-        sorted_exts = extensions.sort
         syntax = extensions[extname]
 
-        return [["#{dirname}/{_,}#{basename}.#{extensions.invert[syntax]}", syntax]] if syntax
-        sorted_exts.map {|ext, syn| ["#{dirname}/{_,}#{basename}.#{ext}", syn]}
+        return [["#{dirname}/{_,}#{basename}.#{extname}", syntax]] if syntax
+        sorted_extensions.map {|ext| ["#{dirname}/{_,}#{basename}.#{ext}", extensions[ext]]}
       end
 
       def escape_glob_characters(name)

--- a/lib/sass/scss/parser.rb
+++ b/lib/sass/scss/parser.rb
@@ -304,7 +304,7 @@ module Sass
       end
 
       def import_arg
-        return unless (str = tok(STRING)) || (uri = tok?(/url\(/i))
+        return unless (str = tok(STRING)) || (inline = tok(INLINE)) || (uri = tok?(/url\(/i))
         if uri
           str = sass_script(:parse_string)
           media = media_query_list
@@ -312,7 +312,7 @@ module Sass
           return node(Tree::CssImportNode.new(str, media.to_a))
         end
 
-        path = @scanner[1] || @scanner[2]
+        path = @scanner[1] || @scanner[2] || @scanner[3]
         ss
 
         media = media_query_list
@@ -320,7 +320,11 @@ module Sass
           return node(Sass::Tree::CssImportNode.new(str, media.to_a))
         end
 
-        node(Sass::Tree::ImportNode.new(path.strip))
+        if inline
+          return node(Sass::Tree::ImportNode.new(path.strip, true))
+        end
+
+        node(Sass::Tree::ImportNode.new(path.strip))    
       end
 
       def use_css_import?; false; end

--- a/lib/sass/scss/rx.rb
+++ b/lib/sass/scss/rx.rb
@@ -99,6 +99,7 @@ module Sass
       NUMBER = /#{NUM}(?:#{IDENT}|%)?/
 
       URI = /url\(#{W}(?:#{STRING}|#{URL})#{W}\)/i
+      INLINE = /inline\(#{W}(?:#{STRING}|#{URL})#{W}\)/i
       FUNCTION = /#{IDENT}\(/
 
       UNICODERANGE = /u\+(?:#{H}{1,6}-#{H}{1,6}|#{RANGE})/i

--- a/lib/sass/tree/import_node.rb
+++ b/lib/sass/tree/import_node.rb
@@ -9,9 +9,15 @@ module Sass
       # @return [String]
       attr_reader :imported_filename
 
+      # True if the imported file is wrapped by an inline() directive.
+      # 
+      # @return [Boolean]
+      attr_reader :inline_directive
+
       # @param imported_filename [String] The name of the imported file
-      def initialize(imported_filename)
+      def initialize(imported_filename, inline_directive = false)
         @imported_filename = imported_filename
+        @inline_directive = inline_directive
         super(nil)
       end
 
@@ -29,6 +35,8 @@ module Sass
       #
       # @return [Boolean] Whether or not this is a simple CSS @import declaration.
       def css_import?
+        return false if @inline_directive
+
         if @imported_filename =~ /\.css$/
           @imported_filename
         elsif imported_file.is_a?(String) && imported_file =~ /\.css$/

--- a/test/sass/importer_test.rb
+++ b/test/sass/importer_test.rb
@@ -36,7 +36,11 @@ class ImporterTest < Test::Unit::TestCase
   # This class proves that you can override the extension scheme for importers
   class ReversedExtImporter < Sass::Importers::Filesystem
     def extensions
-      {"sscs" => :scss, "ssas" => :sass}
+      {'sscs' => :scss, 'ssas' => :sass, 'css' => :scss}
+    end
+
+    def sorted_extensions
+      ['sscs', 'ssas', 'css']
     end
   end
 

--- a/test/sass/results/scss_import.css
+++ b/test/sass/results/scss_import.css
@@ -26,6 +26,8 @@ body { font: Arial; background: blue; }
 #content.user.show #container.top #column.right { width: 600px; }
 #content.user.show #container.bottom { background: brown; }
 
+.inlined_css_rule { color: red; }
+
 #foo { background-color: #bbaaff; }
 
 nonimported { myconst: hello; otherconst: goodbye; post-mixin: here; }

--- a/test/sass/scss/scss_test.rb
+++ b/test/sass/scss/scss_test.rb
@@ -270,6 +270,13 @@ SCSS
     assert_equal "@import url(foo.css);\n", render('@import url(foo.css);')
   end
 
+  def test_inline_import
+    imported = ".inlined_css_rule {\n  color: red; }\n"
+    assert_equal imported, render('@import inline(test/sass/templates/inlined.css);')
+    assert_equal imported, render('@import inline("test/sass/templates/inlined.css");')
+    assert_equal imported, render("@import inline('test/sass/templates/inlined.css');")
+  end
+
   def test_media_import
     assert_equal("@import \"./fonts.sass\" all;\n", render("@import \"./fonts.sass\" all;"))
   end

--- a/test/sass/templates/inlined.css
+++ b/test/sass/templates/inlined.css
@@ -1,0 +1,2 @@
+.inlined_css_rule { color: red; }
+

--- a/test/sass/templates/scss_import.scss
+++ b/test/sass/templates/scss_import.scss
@@ -2,7 +2,7 @@ $preconst: hello;
 
 @mixin premixin {pre-mixin: here}
 
-@import "importee.sass", "scss_importee", "basic.sass", "basic.css", "../results/complex.css";
+@import "importee.sass", "scss_importee", "basic.sass", "basic.css", "../results/complex.css", inline(inlined.css);
 @import "partial.sass";
 
 nonimported {


### PR DESCRIPTION
Currently, `@import "file.scss"` inlines the contents of the SCSS file into the output, but `@import "file.css"` generates an `@import url(file.css)` CSS directive.

This inconsistency is surprising, and the surprise is compounded by the fact that Chrome/Firefox and IE resolve relative @import URLs differently (unsurprisingly, IE gets it wrong), so a developer might not even realize what's going on when testing in Chrome/Firefox.

Although renaming the offending file to use the `.scss` or `.sass` extension seems to be the obvious solution, renaming can be undesirable for  3rd-party files, such as jquery.js, as it slightly obscures the origin of the code.

This change adds a new syntax, `@import inline(file.css)`, that can be used to express the desire of inlining the imported file. `@import inline()` has the behavior no matter what the imported file's extension is. Together with `@import url()`, it offers a decent path for migrating away from `@import "*.css"`, which can be deprecated later down the line.

I don't have a good understanding of the sass codebase, and I look forward to your feedback on how I can make this change better. I hope you'll consider including it, so other developers won't bump into this problem like I did.

Thank you very, very much for the awesomeness that is sass!
