### PR TITLE
https://github.com/nex3/sass/issues/476

### DIFF
--- a/lib/sass/css.rb
+++ b/lib/sass/css.rb
@@ -276,7 +276,7 @@ module Sass
         if first_simple_sel(child).is_a?(Sass::Selector::Parent)
           rule.parsed_rules = child.parsed_rules.resolve_parent_refs(rule.parsed_rules)
         else
-          rule.parsed_rules = make_seq(first_sseq(rule), *first_seq(child).members)
+          rule.parsed_rules = make_seq(rule.parsed_rules, *first_seq(child).members)
         end
 
         rule.children = child.children

--- a/test/sass/css2sass_test.rb
+++ b/test/sass/css2sass_test.rb
@@ -20,6 +20,15 @@ h1
 SASS
   end
 
+  def test_basic_css_multi_selectors
+    assert_equal <<SASS, css2sass(<<CSS)
+sel1 sel2 sel3
+  p: v
+SASS
+sel1 sel2 sel3 {p:v;}
+CSS
+  end
+
   def test_nesting
     assert_equal(<<SASS, css2sass(<<CSS))
 li


### PR DESCRIPTION
Instead of only returning the first member of the current rule, we return the entire parsed rule
