### PR TITLE
Change mixin name from "iphone" to "smartphone"

### DIFF
--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -2164,7 +2164,7 @@ passed block are related to the other styles around where the block is defined. 
     #sidebar {
       $sidebar-width: 300px;
       width: $sidebar-width;
-      @include iphone {
+      @include smartphone {
         width: $sidebar-width / 3;
       }
     }


### PR DESCRIPTION
While mixin content blocks is an awesome feature, detecting specific devices/OS:s in CSS is error prone and a practice that should not be encouraged.

The example in the change log suggests detecting the iPhone by checking the viewport width, which is an incorrect approach. Even if examples are not meant to be used as is in production, it is still likely that they will influence developers.

Maybe smartphone is not the best name either, but at least it's better in my opinion.
