### PR TITLE
Flush STDOUT when printing an action

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -7,6 +7,8 @@
 
 * Fix a performance issue with `@import` that only appears when
   ActiveSupport is loaded.
+* Fix flushing of actions to stdout. Thanks to [Russell Davis]
+  (http://github.com/russelldavis).
 
 ## 3.2.1 (15 August 2012)
 

--- a/lib/sass/exec.rb
+++ b/lib/sass/exec.rb
@@ -125,6 +125,7 @@ module Sass
       def puts_action(name, color, arg)
         return if @options[:for_engine][:quiet]
         printf color(color, "%11s %s\n"), name, arg
+        STDOUT.flush
       end
 
       # Same as \{Kernel.puts}, but doesn't print anything if the `--quiet` option is set.


### PR DESCRIPTION
This is necessary for the output to get immediately flushed when running sass --watch and outputting to a pipe (on OS X 10.8.2).
