### PR TITLE
allow people to opt-out of sass initialization -> save 1s load time and not apply monkeypatches/middleware

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,18 +1,20 @@
-begin
-  require File.join(File.dirname(__FILE__), 'lib', 'sass') # From here
-rescue LoadError
+unless defined?(Sass::RAILS_LOADED)
   begin
-    require 'sass' # From gem
-  rescue LoadError => e
-    # gems:install may be run to install Haml with the skeleton plugin
-    # but not the gem itself installed.
-    # Don't die if this is the case.
-    raise e unless defined?(Rake) &&
-      (Rake.application.top_level_tasks.include?('gems') ||
-        Rake.application.top_level_tasks.include?('gems:install'))
+    require File.join(File.dirname(__FILE__), 'lib', 'sass') # From here
+  rescue LoadError
+    begin
+      require 'sass' # From gem
+    rescue LoadError => e
+      # gems:install may be run to install Haml with the skeleton plugin
+      # but not the gem itself installed.
+      # Don't die if this is the case.
+      raise e unless defined?(Rake) &&
+        (Rake.application.top_level_tasks.include?('gems') ||
+          Rake.application.top_level_tasks.include?('gems:install'))
+    end
   end
-end
 
-# Load Sass.
-# Sass may be undefined if we're running gems:install.
-require 'sass/plugin' if defined?(Sass)
+  # Load Sass.
+  # Sass may be undefined if we're running gems:install.
+  require 'sass/plugin' if defined?(Sass)
+end


### PR DESCRIPTION
atm I'm forced to load all of sass, just because I added it to my Gemfile, which is kind of painful since it takes long and adds a middleware/monkeypatches.

I'd like to skip that, since my asset loading is handled by sprockets.
