### PR TITLE
Correctly compute relative_sourcemap_path and pass it as String

### DIFF
--- a/lib/sass/exec.rb
+++ b/lib/sass/exec.rb
@@ -338,8 +338,8 @@ END
 
           if sourcemap.is_a? File
             relative_sourcemap_path = Pathname.new(@options[:sourcemap_filename]).
-              relative_path_from(Pathname.new(@options[:output_filename]))
-            rendered, mapping = engine.render_with_sourcemap(relative_sourcemap_path)
+              relative_path_from(Pathname.new(@options[:output_filename]).dirname)
+            rendered, mapping = engine.render_with_sourcemap(relative_sourcemap_path.to_s)
             output.write(rendered)
             sourcemap.puts(mapping.to_json(@options[:output_filename]))
           else


### PR DESCRIPTION
0bea4d6b ("Add sourceMappingURL annotations to the sourcemap tests.") broke the sourcemap interchange:
- It was passed as `Pathname` rather than `String` expected by `Engine.render_with_sourcemap`
- `Pathname.relative_path_from()` expects a directory as an argument but received plain sourcemap filename instead
