### PR TITLE
Source range computation implementation for the SASS parser

### DIFF
--- a/lib/sass/exec.rb
+++ b/lib/sass/exec.rb
@@ -338,8 +338,8 @@ END
 
           if sourcemap.is_a? File
             relative_sourcemap_path = Pathname.new(@options[:sourcemap_filename]).
-              relative_path_from(Pathname.new(@options[:output_filename]))
-            rendered, mapping = engine.render_with_sourcemap(relative_sourcemap_path)
+              relative_path_from(Pathname.new(@options[:output_filename]).dirname)
+            rendered, mapping = engine.render_with_sourcemap(relative_sourcemap_path.to_s)
             output.write(rendered)
             sourcemap.puts(mapping.to_json(@options[:output_filename]))
           else

--- a/lib/sass/scss/parser.rb
+++ b/lib/sass/scss/parser.rb
@@ -5,6 +5,10 @@ module Sass
     # The parser for SCSS.
     # It parses a string of code into a tree of {Sass::Tree::Node}s.
     class Parser
+
+      # Expose for the SASS parser.
+      attr_accessor :offset
+
       # @param str [String, StringScanner] The source document to parse.
       #   Note that `Parser` *won't* raise a nice error message if this isn't properly parsed;
       #   for that, you should use the higher-level {Sass::Engine} or {Sass::CSS}.

--- a/lib/sass/tree/visitors/perform.rb
+++ b/lib/sass/tree/visitors/perform.rb
@@ -213,7 +213,9 @@ class Sass::Tree::Visitors::Perform < Sass::Tree::Visitors::Base
   # or parses and includes the imported Sass file.
   def visit_import(node)
     if path = node.css_import?
-      return Sass::Tree::CssImportNode.resolved("url(#{path})")
+      resolved_node = Sass::Tree::CssImportNode.resolved("url(#{path})")
+      resolved_node.source_range = node.source_range
+      return resolved_node
     end
     file = node.imported_file
     handle_import_loop!(node) if @stack.any? {|e| e[:filename] == file.options[:filename]}


### PR DESCRIPTION
NB: This branch is based off of `sourcemap_fix_relpath`, otherwise it would not make any sense.

Sourcemaps can now be constructed for nodes built while parsing SASS (`engine.rb`). A few fixes to the existing code have been made. All SCSS sourcemap tests have received their SASS counterparts.
