### PR TITLE
Fixes to respond_to? and warning tests for Ruby 2.0.0-preview1

### DIFF
--- a/lib/sass/tree/visitors/check_nesting.rb
+++ b/lib/sass/tree/visitors/check_nesting.rb
@@ -140,7 +140,7 @@ class Sass::Tree::Visitors::CheckNesting < Sass::Tree::Visitors::Base
   end
 
   def try_send(method, *args)
-    return unless respond_to?(method)
+    return unless respond_to?(method, true)
     send(method, *args)
   end
 end

--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -379,7 +379,7 @@ module Sass
     #
     # @param msg [String]
     def sass_warn(msg)
-      Sass.logger.warn(msg)
+      Sass.logger.warn(msg.strip)
     end
 
     ## Cross Rails Version Compatibility

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -2038,7 +2038,6 @@ SASS
   expected_warning = <<EXPECTATION
 WARNING: this is a warning
          on line 4 of test_warn_directive_inline.sass
-
 WARNING: this is a mixin warning
          on line 2 of test_warn_directive_inline.sass, in `foo'
          from line 7 of test_warn_directive_inline.sass
@@ -2072,11 +2071,9 @@ SASS
     expected_warning = <<WARN
 WARNING: In the main file
          on line 1 of #{File.dirname(__FILE__)}/templates/warn.sass
-
 WARNING: Imported
          on line 1 of #{File.dirname(__FILE__)}/templates/warn_imported.sass
          from line 2 of #{File.dirname(__FILE__)}/templates/warn.sass
-
 WARNING: In an imported mixin
          on line 4 of #{File.dirname(__FILE__)}/templates/warn_imported.sass, in `emits-a-warning'
          from line 3 of #{File.dirname(__FILE__)}/templates/warn.sass

--- a/test/sass/scss/scss_test.rb
+++ b/test/sass/scss/scss_test.rb
@@ -119,7 +119,6 @@ SCSS
     expected_warning = <<EXPECTATION
 WARNING: this is a warning
          on line 2 of test_warn_directive_inline.scss
-
 WARNING: this is a mixin
          on line 1 of test_warn_directive_inline.scss, in `foo'
          from line 3 of test_warn_directive_inline.scss


### PR DESCRIPTION
In Ruby 2.0, respond_to? no longer returns true for protected methods unless you explicitly pass `true` as a second argument. This causes try_send to fail for @content blocks, keeping sass from knowing that a mixin supports blocks.

Also, Kernel.warn behaves slightly differently. Since the difference is in number of newlines, I figure it's a cosmetic change and made the most expedient fix I could think of.

Let me know if you see any issues!
