### PR TITLE
One template in a jar @importing another breaks under JRuby

### DIFF
--- a/lib/sass/importers/filesystem.rb
+++ b/lib/sass/importers/filesystem.rb
@@ -91,8 +91,13 @@ module Sass
         sorted_exts = extensions.sort
         syntax = extensions[extname]
 
-        return [["#{dirname}/{_,}#{basename}.#{extensions.invert[syntax]}", syntax]] if syntax
-        sorted_exts.map {|ext, syn| ["#{dirname}/{_,}#{basename}.#{ext}", syn]}
+        if syntax
+          ret = [["#{dirname}/{_,}#{basename}.#{extensions.invert[syntax]}", syntax]]
+        else
+          ret = sorted_exts.map {|ext, syn| ["#{dirname}/{_,}#{basename}.#{ext}", syn]}
+        end
+
+        ret.map {|f, s| [f.sub(%r{^\./}, ''), s]}
       end
 
       def escape_glob_characters(name)
@@ -118,7 +123,7 @@ module Sass
         end
         found = Sass::Util.flatten(found, 1)
         return if found.empty?
-  
+
         if found.size > 1 && !@same_name_warnings.include?(found.first.first)
           found.each {|(f, _)| @same_name_warnings << f}
           relative_to = Pathname.new(dir)


### PR DESCRIPTION
When a Sass template (such as the ones in Compass) is inside a jar file, and Sass is running on JRuby, that template importing another inside the same jar file will currently fail.

It appears that this is because JRuby doesn't properly handle a jar path containing `./`, and `Sass::Importers::Filesystem#possible_files` was generating them. This patch (or, rather, doing the same thing by reopening the class in my own code) appears to fix the issue in my test environment.

(Sorry about my previous, broken pull request. It's late and I'm not really familiar with GitHub.)
