### PR TITLE
Fixed a broken link.

### DIFF
--- a/src/pages/about.haml
+++ b/src/pages/about.haml
@@ -9,7 +9,7 @@
 
   ## The Sass Team
 
-  Sass was originally created by **[Hampton Catlin](http://hamptoncatlin.com)**.
+  Sass was originally created by **[Hampton Catlin](http://www.hamptoncatlin.com)**.
   He and [Nathan Weizenbaum](http://nex-3.com) designed Sass through version 2.0.
   Hampton lives in Jacksonville, Florida and is the lead mobile developer for Wikimedia.
 


### PR DESCRIPTION
Minor fix for a broken link. The old http://hamptoncatlin.com link would redirect to the www version occasionally.  However it was very inconsistent.  Changing the link to be the permanent http://www.hamptoncatlin.com link.
