### PR TITLE
Fix for when template_location_array is a String

### DIFF
--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -371,11 +371,11 @@ module Sass::Plugin
     end
 
     def template_locations
-      template_location_array.to_a.map {|l| l.first}
+      Array(template_location_array).map {|l| l.first}
     end
 
     def css_locations
-      template_location_array.to_a.map {|l| l.last}
+      Array(template_location_array).map {|l| l.last}
     end
 
     def css_filename(name, path)


### PR DESCRIPTION
Do not call to_a on Strings:

```
NoMethodError (undefined method `to_a' for #<String:0x639002>)
```
