### PR TITLE
Fix for ruby 2.0

### DIFF
--- a/lib/sass/tree/visitors/check_nesting.rb
+++ b/lib/sass/tree/visitors/check_nesting.rb
@@ -140,7 +140,7 @@ class Sass::Tree::Visitors::CheckNesting < Sass::Tree::Visitors::Base
   end
 
   def try_send(method, *args)
-    return unless respond_to?(method)
+    return unless respond_to?(method, true)
     send(method, *args)
   end
 end


### PR DESCRIPTION
In Ruby 2.0, respond_to? no longer returns true for protected methods unless you explicitly pass true as a second argument. This causes try_send to fail for @content blocks, keeping sass from knowing that a mixin supports blocks.

Also, Kernel.warn behaves slightly differently. Since the difference is in number of newlines, I figure it's a cosmetic change and made the most expedient fix I could think of.

Let me know if you see any issues!

---

This fix is entirely from [sax](https://github.com/sax) and closes #572 but since that issue has not been updated for a month I thought I'd fix the things commented on in that thread.
