### PR TITLE
Bug#594 @import 'file' on windows fails with more than 1 subdir in the p...

### DIFF
--- a/lib/sass/importers/filesystem.rb
+++ b/lib/sass/importers/filesystem.rb
@@ -115,6 +115,10 @@ module Sass
       # @param name [String] The filename to search for.
       # @return [(String, Symbol)] A filename-syntax pair.
       def find_real_file(dir, name, options)
+        # on windows 'dir' can be in native File::ALT_SEPARATOR form
+        if File::ALT_SEPARATOR
+          dir = dir.gsub(File::ALT_SEPARATOR, File::SEPARATOR)
+        end
         found = possible_files(remove_root(name)).map do |f, s|
           path = (dir == "." || Pathname.new(f).absolute?) ? f : "#{dir}/#{f}"
           Dir[path].map do |full_path|


### PR DESCRIPTION
...ath

This commit changes lib/sass/importers/filesystem.rb and the method
find_real_file(dir, name, options) to ensure the 'dir' argument is
canonialized to rubys standard "/" use for path separators.
