### PR TITLE
Make sass, scss, and sass-convert work with being symlinked from other directories

### DIFF
--- a/bin/sass
+++ b/bin/sass
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 # The command line Sass parser.
 
-require File.dirname(__FILE__) + '/../lib/sass'
+THIS_FILE = File.symlink?(__FILE__) ? File.readlink(__FILE__) : __FILE__
+require File.dirname(THIS_FILE) + '/../lib/sass'
 require 'sass/exec'
 
 opts = Sass::Exec::Sass.new(ARGV)

--- a/bin/sass-convert
+++ b/bin/sass-convert
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../lib/sass'
+THIS_FILE = File.symlink?(__FILE__) ? File.readlink(__FILE__) : __FILE__
+require File.dirname(THIS_FILE) + '/../lib/sass'
 require 'sass/exec'
 
 opts = Sass::Exec::SassConvert.new(ARGV)

--- a/bin/scss
+++ b/bin/scss
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 # The command line Sass parser.
 
-require File.dirname(__FILE__) + '/../lib/sass'
+THIS_FILE = File.symlink?(__FILE__) ? File.readlink(__FILE__) : __FILE__
+require File.dirname(THIS_FILE) + '/../lib/sass'
 require 'sass/exec'
 
 opts = Sass::Exec::Scss.new(ARGV)


### PR DESCRIPTION
The bin programs currently cannot be symlinked from other places due to the way ruby handles **FILE**.

This patch fixes the issue.

See http://marklunds.com/articles/one/384 for more details.
