### PR TITLE
Adds :staleness_check => true to options passed to importer when that's the case

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Backwards Incompatibilities -- Must Read!
 
+* StalenessChecker now passes :staleness_check => true in options when calling importer's find.
+
 * Sass will now throw an error when `@extend` is used to extend a selector
   outside the `@media` context of the extending selector. This means the
   following will be an error:

--- a/lib/sass/plugin/staleness_checker.rb
+++ b/lib/sass/plugin/staleness_checker.rb
@@ -176,7 +176,7 @@ module Sass
       end
 
       def tree(uri, importer)
-        @parse_trees[[uri, importer]] ||= importer.find(uri, @options).to_tree
+        @parse_trees[[uri, importer]] ||= importer.find(uri, @options.merge({:staleness_check => true})).to_tree
       end
     end
   end


### PR DESCRIPTION
As explained in https://github.com/nex3/sass/issues/625#issuecomment-12334541 this change allows to create custom importers which only require a file once.
