### PR TITLE
Native Sass function to return list separator

### DIFF
--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -147,6 +147,9 @@ module Sass::Script
   # \{#append append($list1, $val, \[$separator\])}
   # : Appends a single value onto the end of a list.
   #
+  # \{#list-separator list-separator(#list)}
+  # : Returns the separator of a list.
+  #
   # ## Introspection Functions
   #
   # \{#type_of type-of($value)}
@@ -1405,13 +1408,14 @@ module Sass::Script
     # If not a list, returns false.
     #
     # @example
-    #   separator(1px 2px 3px) => 'space'
-    #   separator('foo') => false
-    def separator(list)
+    #   list-separator(1px 2px 3px) => 'space'
+    #   list-separator(1px, 2px, 3px) => 'comma'
+    #   list-separator('foo') => 'space'
+    def list_separator(list)
       if list.class == Sass::Script::List
         String.new(list.separator)
       else
-        Bool.new(false)
+        String.new('space')
       end
     end
     declare :separator, [:list]

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -1401,6 +1401,21 @@ module Sass::Script
     end
     declare :index, [:list, :value]
 
+    # Returns the separator of the given list
+    # If not a list, returns false.
+    #
+    # @example
+    #   separator(1px 2px 3px) => 'space'
+    #   separator('foo') => false
+    def separator(list)
+      if list.class == Sass::Script::List
+        String.new(list.separator)
+      else
+        Bool.new(false)
+      end
+    end
+    declare :separator, [:list]
+
     # Returns one of two values based on the truth value of the first argument.
     #
     # @example

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -1401,7 +1401,7 @@ module Sass::Script
     end
     declare :index, [:list, :value]
 
-    # Returns the separator of the given list
+    # Returns the separator of the given list.
     # If not a list, returns false.
     #
     # @example

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -1028,6 +1028,16 @@ MSG
     assert_equal("false", evaluate("index(1px solid blue, notfound)"))
   end
 
+  def test_list_separator
+    assert_equal("space", evaluate("list-separator(1 2 3 4 5)"))
+    assert_equal("comma", evaluate("list-separator((foo, bar, baz, bip))"))
+    assert_equal("comma", evaluate("list-separator((foo, bar, baz bip))"))
+    assert_equal("comma", evaluate("list-separator((foo, bar, (baz, bip)))"))
+    assert_equal("space", evaluate("list-separator(#f00)"))
+    assert_equal("space", evaluate("list-separator(())"))
+    assert_equal("space", evaluate("list-separator(1 2 () 3)"))
+  end
+
   def test_if
     assert_equal("1px", evaluate("if(true, 1px, 2px)"))
     assert_equal("2px", evaluate("if(false, 1px, 2px)"))


### PR DESCRIPTION
This should return the separator of a list or false if the input isn't a list. Solves https://github.com/nex3/sass/issues/688
