### PR TITLE
Add suggestion to use a partial to "Undefined variable" error message

### DIFF
--- a/lib/sass/script/variable.rb
+++ b/lib/sass/script/variable.rb
@@ -46,7 +46,7 @@ module Sass
       # @return [Literal] The SassScript object that is the value of the variable
       # @raise [Sass::SyntaxError] if the variable is undefined
       def _perform(environment)
-        raise SyntaxError.new("Undefined variable: \"$#{name}\".") unless val = environment.var(name)
+        raise SyntaxError.new("Undefined variable: \"$#{name}\". Did you forget to use a partial?") unless val = environment.var(name)
         if val.is_a?(Number)
           val = val.dup
           val.original = nil


### PR DESCRIPTION
So I'm fairly new to Sass, and I didn't know about partials. I was trying to import a Sass file, and suddenly my variables weren't working. I started googling (which was successful in the end) but a pointer such as the one I'm suggesting in the commit would've helped quite a bit, since I would've had a keyword to google for.

I know that this is a definite case of RTFM, but I imagine that this might not be an uncommon issue for peope new to Sass, since it is not super-intuitive, imho.

Ideally, the error message mentioning the partial should only be displayed when actually inside an import, but I didn't find a way to determine if that is the case. If someone would be so kind as to give me a hint on how I can detect that, I'd be glad to change the PR :smile: 
