### PR TITLE
Specify the correct module for the sourcemap_name method

### DIFF
--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -171,7 +171,7 @@ module Sass::Plugin
           # Get the relative path to the file
           name = file.sub(template_location.to_s.sub(/\/*$/, '/'), "")
           css = css_filename(name, css_location)
-          sourcemap = Util::sourcemap_name(css) if engine_options[:sourcemap]
+          sourcemap = Sass::Util::sourcemap_name(css) if engine_options[:sourcemap]
           individual_files << [file, css, sourcemap]
         end
       end


### PR DESCRIPTION
Running with the --sourcemap argument, I got
lib/sass/plugin/compiler.rb:174:in `block (2 levels) in update_stylesheets':
    uninitialized constant Sass::Plugin::Compiler::Util (NameError)
