### PR TITLE
--unix-newlines/--in-place are not working on Windows

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -8,6 +8,9 @@
 * Fix a bug where `@extend`s would occasionally cause a selector to be generated
   with the incorrect specificity.
 
+* Fix a bug where `sass --unix-newlines` and `sass-convert --in-place` are not working on Windows
+  (thanks [SATO Kentaro](http://www.ranvis.com)).
+
 ## 3.2.8
 
 * Fix some edge cases where redundant selectors were emitted when using

--- a/lib/sass/exec.rb
+++ b/lib/sass/exec.rb
@@ -157,7 +157,7 @@ module Sass
 
       def write_output(text, destination)
         if destination.is_a?(String)
-          File.open(destination, 'w') {|file| file.write(text)}
+          open_file(destination, 'w') {|file| file.write(text)}
         else
           destination.write(text)
         end
@@ -168,7 +168,10 @@ module Sass
       def open_file(filename, flag = 'r')
         return if filename.nil?
         flag = 'wb' if @options[:unix_newlines] && flag == 'w'
-        File.open(filename, flag)
+        file = File.open(filename, flag)
+        return file unless block_given?
+        yield file
+        file.close
       end
 
       def handle_load_error(err)
@@ -683,7 +686,7 @@ END
             end
           end
 
-        output = File.open(input.path, 'w') if @options[:in_place]
+        output = input.path if @options[:in_place]
         write_output(out, output)
       rescue ::Sass::SyntaxError => e
         raise e if @options[:trace]

--- a/lib/sass/util/test.rb
+++ b/lib/sass/util/test.rb
@@ -1,0 +1,10 @@
+module Sass
+  module Util
+    module Test
+      def skip(msg = nil, bt = caller)
+        super if defined?(super)
+        return
+      end
+    end
+  end
+end

--- a/test/sass/exec_test.rb
+++ b/test/sass/exec_test.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+require File.dirname(__FILE__) + '/../test_helper'
+require 'sass/exec'
+require 'tmpdir'
+
+class ExecTest < Test::Unit::TestCase
+  def setup
+    @css_in = ".ruleset { margin: 0 }"
+    @css_out = ".ruleset {\n  margin: 0;\n}\n"
+    @sass_out = ".ruleset\n  margin: 0\n"
+    @dir = Dir.mktmpdir
+    @src = File.join(@dir, "src.scss")
+    @dest = File.join(@dir, "dest.css")
+    open(@src, 'wb') {|f| f.write(@css_in)}
+  end
+
+  def teardown
+    FileUtils.rm_rf(@dir)
+  end
+
+  def to_options(commandline)
+    return commandline.split(/\s+/).push(@src, @dest)
+  end
+
+  def binread(file)
+    content = nil
+    open(@dest, 'rb') {|f| content = f.read}
+    return content
+  end
+
+  def test_exec
+    Sass::Exec::Scss.new(to_options("-t expanded --unix-newlines")).parse
+    assert_equal(@css_out, binread(@dest))
+    Sass::Exec::SassConvert.new(to_options("-T sass --unix-newlines")).parse
+    assert_equal(@sass_out, binread(@dest))
+    Sass::Exec::SassConvert.new(to_options("-T sass --in-place --unix-newlines")).parse
+    assert_equal(@sass_out, binread(@src))
+  end
+
+  def test_no_unix_newlines
+    unless Sass::Util.windows?
+      skip "Can be run on Windows only" if respond_to?(:skip)
+      return
+    end
+    @css_out.gsub!(/\n/, "\r\n")
+    @sass_out.gsub!(/\n/, "\r\n")
+    Sass::Exec::Scss.new(to_options("-t expanded")).parse
+    assert_equal(@css_out, binread(@dest))
+    Sass::Exec::SassConvert.new(to_options("-T sass")).parse
+    assert_equal(@sass_out, binread(@dest))
+    Sass::Exec::SassConvert.new(to_options("-T sass --in-place")).parse
+    assert_equal(@sass_out, binread(@src))
+  end
+end


### PR DESCRIPTION
- `sass --unix-newlines` doesn't produce LF-eol files.
  
  Caused because output files are opened with 'w' not 'wb.'
- `sass-convert --in-place` doesn't do anything.
  
  Haven't investigated why actually...

these are confirmed on ruby 1.9.3p392 (2013-02-22) [i386-mingw32]
