### PR TITLE
Prevent built .gem files from accidentally being version controlled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.gem
 /.yardoc
 /coverage
 /doc


### PR DESCRIPTION
Building sass with `gem build sass.gemspec` results in a file `sass-x.y.z.gem`, which does not belong in version control. I added `*.gem` to `.gitignore` to prevent this from happening.
