### PR TITLE
Implement source_range tracking for @media rules

### DIFF
--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -813,7 +813,15 @@ WARNING
         parser = Sass::SCSS::Parser.new(value,
           @options[:filename], @options[:importer],
           @line, to_parser_offset(@offset))
-        Tree::MediaNode.new(parser.parse_media_query_list.to_a)
+        # -1 includes the '@' into the range.
+        offset = line.offset + line.text.index(directive).to_i - 1
+        parsed_media_query_list = parser.parse_media_query_list.to_a
+        node = Tree::MediaNode.new(parsed_media_query_list)
+        node.source_range = Sass::Source::Range.new(
+          Sass::Source::Position.new(@line, to_parser_offset(offset)),
+          Sass::Source::Position.new(@line, to_parser_offset(line.offset) + line.text.length),
+          @options[:filename], @options[:importer])
+        node
       else
         unprefixed_directive = directive.gsub(/^-[a-z0-9]+-/i, '')
         if unprefixed_directive == 'supports'

--- a/lib/sass/scss/parser.rb
+++ b/lib/sass/scss/parser.rb
@@ -558,7 +558,6 @@ module Sass
         tok!(/\{/)
         block_contents(node, context)
         tok!(/\}/)
-        node.source_range.end_pos = source_position if node.source_range
         node
       end
 

--- a/test/sass/source_map_test.rb
+++ b/test/sass/source_map_test.rb
@@ -223,6 +223,36 @@ SASS
 CSS
   end
 
+  def test_media_sourcemap_scss
+    assert_parses_with_mapping <<'SCSS', <<'CSS'
+{{1}}@media screen, tv  {{/1}}{
+  {{2}}body {{/2}}{
+    {{3}}max-width{{/3}}: {{4}}1070px{{/4}};
+  }
+}
+SCSS
+{{1}}@media screen, tv{{/1}} {
+  {{2}}body{{/2}} {
+    {{3}}max-width{{/3}}: {{4}}1070px{{/4}}; } }
+
+/*@ sourceMappingURL=test.css.map */
+CSS
+  end
+
+  def test_media_sourcemap_sass
+    assert_parses_with_mapping <<'SASS', <<'CSS', :syntax => :sass
+{{1}}@media screen, tv{{/1}}
+  {{2}}body{{/2}}
+    {{3}}max-width{{/3}}: {{4}}1070px{{/4}}
+SASS
+{{1}}@media screen, tv{{/1}} {
+  {{2}}body{{/2}} {
+    {{3}}max-width{{/3}}: {{4}}1070px{{/4}}; } }
+
+/*@ sourceMappingURL=test.css.map */
+CSS
+  end
+
   def test_interpolation_and_vars_sourcemap_scss
     assert_parses_with_mapping <<'SCSS', <<'CSS'
 $te: "te";


### PR DESCRIPTION
We didn't have source range tracking for @media in sass, and in scss it was wrong, because "def block" would extend the node's source range up to the end of the block.
