### PR TITLE
Dropping the backronym from the page title.

### DIFF
--- a/serve.rb
+++ b/serve.rb
@@ -1,24 +1,9 @@
-require '.haml/lib/haml'
-require '.sass/lib/sass'
 require 'rubygems'
 require 'sinatra'
 require 'sinatra/dynamicmatic'
 require 'timeout'
 require 'date'
 
-get('/try.html') {haml :try}
-
-post('/try.html') do
-  begin
-    Timeout.timeout(5) do
-      syntax = (params[:syntax] == 'sass') ? :sass : :scss
-      @result = Sass::Engine.new(params[:input], :syntax => syntax).render
-    end
-  rescue Sass::SyntaxError => e
-    @result = "Sass Error: " + e
-  rescue Timeout::Error
-    @result = "Timed out!"
-  end
-
-  haml :try
-end
+get('/try.html') {
+  redirect "http://trysass.com"
+}

--- a/src/layouts/application.haml
+++ b/src/layouts/application.haml
@@ -6,7 +6,7 @@
     %meta{"http-equiv" => "Content-Type", :content => "text/html; charset=utf-8"}/
     %meta{:name => "description", :content => "Style with Attitude"}/
     %meta{:name => "keywords", :content => "Sass, SASS, sass, CSS, stylesheet, stylesheets, variables, mixins, abstraction, Syntactically Awesome Stylesheets, Ruby, Rails"}/
-    %title&= @title || "Sass - CSS Extension Language"
+    %title&= @title || "Sass: CSS with Superpowers"
     = stylesheets :application
     %script{:src => "http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js", :type => "text/javascript"}
     = javascripts :application

--- a/src/layouts/application.haml
+++ b/src/layouts/application.haml
@@ -4,9 +4,9 @@
     %link{:rel => "shortcut icon", :href => "/images/sass_icon.ico", :type => "image/vnd.microsoft.icon"}/
     %meta{:name => "verify-v1", :content => "LyBvSzD3T4u1uK95pBqTMBKVyLoOe4JREb+9U6UJ99o="}/
     %meta{"http-equiv" => "Content-Type", :content => "text/html; charset=utf-8"}/
-    %meta{:name => "description", :content => "Syntactically Awesome Stylesheets"}/
+    %meta{:name => "description", :content => "Style with Attitude"}/
     %meta{:name => "keywords", :content => "Sass, SASS, sass, CSS, stylesheet, stylesheets, variables, mixins, abstraction, Syntactically Awesome Stylesheets, Ruby, Rails"}/
-    %title&= @title || "Sass - Syntactically Awesome Stylesheets"
+    %title&= @title || "Sass - CSS Extension Language"
     = stylesheets :application
     %script{:src => "http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js", :type => "text/javascript"}
     = javascripts :application

--- a/src/pages/_header.haml
+++ b/src/pages/_header.haml
@@ -17,8 +17,8 @@
       %li= link "About", "/about.html"
       %li= link "Tutorial", "/tutorial.html"
       %li= link "Documentation", "/docs.html"
-      %li= link "Blog", "http://nex-3.com/?tag=sass"
-      %li= link "Try Online", "/try.html"
+      %li= link "Twitter", "http://twitter.com/sasscss"
+      %li= link "Try Online", "http://trysass.com/"
 
   #latest
     %h2 Latest Release:


### PR DESCRIPTION
It was suggested on twitter that one of the reasons why we see "SASS" so much is that the title of the website is misleading. The acronym was just a backronym and was never meant to be taken seriously.

In this pull request, I am proposing that the best thing for people to see when searching for the Sass lang site is "Sass - The CSS Extension Language'--- I think it frames Sass much better and is very clear about our relationship to CSS. There are cuter names that we use for Sass {style with attitude}, etc. but I think being more clear in the title is much, much better.

I'm not saying its perfect, but I think its better until we are ready for the new site.
