### PR TITLE
Parentheses example make more sense

### DIFF
--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -969,13 +969,13 @@ Instead, they're manipulated using the
 Parentheses can be used to affect the order of operations:
 
     p {
-      width: 1em + (2em * 3);
+      width: (1em + 2em) * 3;
     }
 
 is compiled to:
 
     p {
-      width: 7em; }
+      width: 9em; }
 
 ### Functions
 


### PR DESCRIPTION
In the old example, parentheses had no impact because multiplication should have precedence over addition.

Thanks to @inseo for the suggestion.

![96](https://f.cloud.github.com/assets/85783/565240/46f337a8-c5f5-11e2-9802-bcc84f73f82a.gif)
