### PR TITLE
Don't strip bangs from loud comments (closes: #784 and #786)

### DIFF
--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -637,7 +637,6 @@ WARNING
           value = [line.text]
         else
           value = self.class.parse_interp(line.text, line.index, line.offset, :filename => @filename)
-          value[0].slice!(2) if loud # get rid of the "!"
         end
         value = with_extracted_values(value) do |str|
           str = str.gsub(/^#{line.comment_tab_str}/m, '')[2..-1] # get rid of // or /*

--- a/lib/sass/scss/parser.rb
+++ b/lib/sass/scss/parser.rb
@@ -120,7 +120,6 @@ module Sass
           value = [text.sub(/^\s*\/\//, '/*').gsub(/^\s*\/\//, ' *') + ' */']
         else
           value = Sass::Engine.parse_interp(text, line, @scanner.pos - text.size, :filename => @filename)
-          value[0].slice!(2) if loud # get rid of the "!"
           value.unshift(@scanner.
             string[0...@scanner.pos].
             reverse[/.*?\*\/(.*?)($|\Z)/, 1].

--- a/lib/sass/tree/visitors/convert.rb
+++ b/lib/sass/tree/visitors/convert.rb
@@ -89,7 +89,6 @@ class Sass::Tree::Visitors::Convert < Sass::Tree::Visitors::Base
       end.gsub(/^/, spaces) + "\n"
       content
     end
-    content.sub!(%r{^\s*(/\*)}, '/*!') if node.type == :loud #'
     content
   end
 

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -1804,7 +1804,7 @@ SASS
 
   def test_loud_comment_in_compressed_mode
     assert_equal <<CSS, render(<<SASS, :style => :compressed)
-foo{color:blue;/* foo
+foo{color:blue;/*! foo
  * bar
  */}
 CSS
@@ -1818,10 +1818,9 @@ SASS
 
   def test_loud_comment_is_evaluated
     assert_equal <<CSS, render(<<SASS)
-/* Hue: 327.21649deg */
+/*! Hue: 327.21649deg */
 CSS
-/*!
-  Hue: \#{hue(#f836a0)}
+/*! Hue: \#{hue(#f836a0)}
 SASS
   end
 
@@ -2486,15 +2485,15 @@ SASS
 
   def test_interpolated_comment_in_mixin
     assert_equal <<CSS, render(<<SASS)
-/* color: red */
+/*! color: red */
 .foo {
   color: red; }
 
-/* color: blue */
+/*! color: blue */
 .foo {
   color: blue; }
 
-/* color: green */
+/*! color: green */
 .foo {
   color: green; }
 CSS
@@ -2789,7 +2788,7 @@ CSS
 /* \\\#{foo}
 SASS
     assert_equal <<CSS, render(<<SASS)
-/* \#{foo} */
+/*! \#{foo} */
 CSS
 /*! \\\#{foo}
 SASS


### PR DESCRIPTION
First of all I'm not a Ruby dev, and all I did was `ack -i loud` so I might be missing something. I'm not sure about the newline in `test_loud_comment_is_evaluated`, but it looks fine to me. Comments are welcome :smile: 
