### PR TITLE
Make sass work when symlinked by encap.

### DIFF
--- a/bin/sass
+++ b/bin/sass
@@ -2,7 +2,11 @@
 # The command line Sass parser.
 
 THIS_FILE = File.symlink?(__FILE__) ? File.readlink(__FILE__) : __FILE__
-require File.dirname(THIS_FILE) + '/../lib/sass'
+begin
+  require File.dirname(THIS_FILE) + '/../lib/sass'
+rescue LoadError
+  require 'sass'
+end
 require 'sass/exec'
 
 opts = Sass::Exec::Sass.new(ARGV)

--- a/bin/sass-convert
+++ b/bin/sass-convert
@@ -1,7 +1,11 @@
 #!/usr/bin/env ruby
 
 THIS_FILE = File.symlink?(__FILE__) ? File.readlink(__FILE__) : __FILE__
-require File.dirname(THIS_FILE) + '/../lib/sass'
+begin
+  require File.dirname(THIS_FILE) + '/../lib/sass'
+rescue LoadError
+  require 'sass'
+end
 require 'sass/exec'
 
 opts = Sass::Exec::SassConvert.new(ARGV)

--- a/bin/scss
+++ b/bin/scss
@@ -2,7 +2,11 @@
 # The command line Sass parser.
 
 THIS_FILE = File.symlink?(__FILE__) ? File.readlink(__FILE__) : __FILE__
-require File.dirname(THIS_FILE) + '/../lib/sass'
+begin
+  require File.dirname(THIS_FILE) + '/../lib/sass'
+rescue LoadError
+  require 'sass'
+end
 require 'sass/exec'
 
 opts = Sass::Exec::Scss.new(ARGV)

--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -3,6 +3,11 @@
 * Table of contents
 {:toc}
 
+## 3.2.13 (Unreleased)
+
+* Numbers returned by user-defined functions now trigger division, just like
+  numbers stored in variables.
+
 ## 3.2.12
 
 * Add a couple missing `require`s, fixing some load errors, especially when

--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -761,7 +761,7 @@ However, there are three situations where the `/` will be interpreted as divisio
 These cover the vast majority of cases where division is actually used.
 They are:
 
-1. If the value, or any part of it, is stored in a variable.
+1. If the value, or any part of it, is stored in a variable or returned by a function.
 2. If the value is surrounded by parentheses.
 3. If the value is used as part of another arithmetic expression.
 
@@ -771,6 +771,7 @@ For example:
       font: 10px/8px;             // Plain CSS, no division
       $width: 1000px;
       width: $width/2;            // Uses a variable, does division
+      width: round(1.5)/2;        // Uses a function, does division
       height: (500px/2);          // Uses parentheses, does division
       margin-left: 5px + 8px/2px; // Uses +, does division
     }

--- a/test/sass/script_test.rb
+++ b/test/sass/script_test.rb
@@ -510,6 +510,30 @@ SASS
 
   # Regression Tests
 
+  def test_user_defined_function_forces_division
+    assert_equal(<<CSS, render(<<SASS))
+a {
+  b: 10px; }
+CSS
+@function foo()
+  @return 20px
+
+a
+  b: (foo() / 2)
+SASS
+
+    assert_equal(<<CSS, render(<<SASS))
+a {
+  b: 10px; }
+CSS
+@function foo()
+  @return 20px
+
+a
+  b: foo() / 2
+SASS
+end
+
   def test_funcall_has_higher_precedence_than_color_name
     assert_equal "teal(12)", resolve("teal(12)")
     assert_equal "tealbang(12)", resolve("tealbang(12)")


### PR DESCRIPTION
The sass binaries don't work for when I set them up as encap packages, because of the odd way they handle symlinks. This change makes them work again.

FWIW, this is what I use for my setup. It worked with Sass 3.1.19 on top of MRI 1.9.3p194, but doesn't work on 3.2.9 on top of MRI 2.0.0p195.
https://gist.github.com/pwnall/3017424#file-build_ruby-sh
https://gist.github.com/pwnall/3017424#file-build_sass-sh

Thank you!
