### PR TITLE
Use Bool::TRUE and Bool::FALSE constants to reduce GC needs.

### DIFF
--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -1617,7 +1617,7 @@ module Sass::Script
       if index
         Sass::Script::Value::Number.new(index + 1)
       else
-        Sass::Script::Value::Bool.new(false)
+        Sass::Script::Value::Bool::FALSE
       end
     end
     declare :index, [:list, :value]

--- a/lib/sass/script/value/bool.rb
+++ b/lib/sass/script/value/bool.rb
@@ -1,6 +1,20 @@
 module Sass::Script::Value
   # A SassScript object representing a boolean (true or false) value.
   class Bool < Base
+
+    TRUE  = self.new(true)
+    FALSE = self.new(false)
+
+    # We override object creation so that users of the core API
+    # will not need to know that booleans are specific constants.
+    #
+    # @param value A ruby value that will be tested for truthiness.
+    #
+    # @return [Bool] TRUE if value is truthy, FALSE if value is falsey
+    def self.new(value)
+      value ? TRUE : FALSE
+    end
+
     # The Ruby value of the boolean.
     #
     # @return [Boolean]
@@ -13,4 +27,5 @@ module Sass::Script::Value
     end
     alias_method :to_sass, :to_s
   end
+
 end

--- a/lib/sass/script/value/bool.rb
+++ b/lib/sass/script/value/bool.rb
@@ -2,14 +2,20 @@ module Sass::Script::Value
   # A SassScript object representing a boolean (true or false) value.
   class Bool < Base
 
-    TRUE  = self.new(true)
-    FALSE = self.new(false)
+    # The true value in SassScript.
+    #
+    # This is assigned before new is overridden below so that we use the default implementation.
+    TRUE  = new(true)
+
+    # The false value in SassScript.
+    #
+    # This is assigned before new is overridden below so that we use the default implementation.
+    FALSE = new(false)
 
     # We override object creation so that users of the core API
     # will not need to know that booleans are specific constants.
     #
     # @param value A ruby value that will be tested for truthiness.
-    #
     # @return [Bool] TRUE if value is truthy, FALSE if value is falsey
     def self.new(value)
       value ? TRUE : FALSE
@@ -27,5 +33,4 @@ module Sass::Script::Value
     end
     alias_method :to_sass, :to_s
   end
-
 end

--- a/lib/sass/script/value/number.rb
+++ b/lib/sass/script/value/number.rb
@@ -192,7 +192,7 @@ module Sass::Script::Value
     # @param other [Value] The right-hand side of the operator
     # @return [Boolean] Whether this number is equal to the other object
     def eq(other)
-      return Sass::Script::Value::Bool.new(false) unless other.is_a?(Sass::Script::Value::Number)
+      return Bool::FALSE unless other.is_a?(Sass::Script::Value::Number)
       this = self
       begin
         if unitless?
@@ -201,10 +201,9 @@ module Sass::Script::Value
           other = other.coerce(@numerator_units, @denominator_units)
         end
       rescue Sass::UnitConversionError
-        return Sass::Script::Value::Bool.new(false)
+        return Bool::FALSE
       end
-
-      Sass::Script::Value::Bool.new(this.value == other.value)
+      Bool.new(this.value == other.value)
     end
 
     # The SassScript `>` operation.


### PR DESCRIPTION
Instead of generating a different sass object for each boolean defined
and returned during the processing of Sass files, we now define TRUE and
FALSE constants and return those instead.
