### PR TITLE
Fixed the number of the default decimal precision in the inline help.

### DIFF
--- a/lib/sass/exec.rb
+++ b/lib/sass/exec.rb
@@ -262,7 +262,7 @@ END
           @options[:for_engine][:style] = name.to_sym
         end
         opts.on('--precision NUMBER_OF_DIGITS', Integer,
-                'How many digits of precision to use when outputting decimal numbers. Defaults to 3.') do |precision|
+                "How many digits of precision to use when outputting decimal numbers. Defaults to #{::Sass::Script::Value::Number.precision}.") do |precision|
           ::Sass::Script::Value::Number.precision = precision
         end
         opts.on('-q', '--quiet', 'Silence warnings and status messages during compilation.') do


### PR DESCRIPTION
The current value is false. Indeed, the default precision is 5 and not 3.
