### PR TITLE
Call function

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -69,6 +69,9 @@ Thanks to Alexander Pavlov for implementing this.
   exposed by plugins must begin with a dash to distinguish them from
   official features.
 
+* You can call a function by name by passing the function name to the
+  call function. E.g. `call(nth, a b c, 2) => b`
+
 ### Backwards Incompatibilities -- Must Read!
 
 * Sass will now throw an error when `@extend` is used to extend a selector

--- a/lib/sass/script/tree/funcall.rb
+++ b/lib/sass/script/tree/funcall.rb
@@ -205,7 +205,7 @@ module Sass::Script::Tree
         return args 
       end
 
-      args = args + signature.args[args.size..-1].map do |argname|
+      args = args + (signature.args[args.size..-1] || []).map do |argname|
         if keywords.has_key?(argname)
           keywords.delete(argname)
         else

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -1258,6 +1258,41 @@ MSG
     end
   end
 
+  def test_call_with_positional_arguments
+    assert_equal evaluate("lighten(blue, 5%)"), evaluate("call(lighten, blue, 5%)")
+  end
+
+  def test_call_with_keyword_arguments
+    assert_equal(
+      evaluate("lighten($color: blue, $amount: 5%)"),
+      evaluate("call(lighten, $color: blue, $amount: 5%)"))
+  end
+
+  def test_call_with_keyword_and_positional_arguments
+    assert_equal(
+      evaluate("lighten(blue, $amount: 5%)"),
+      evaluate("call(lighten, blue, $amount: 5%)"))
+  end
+
+  def test_call_with_dynamic_name
+    assert_equal(
+      evaluate("lighten($color: blue, $amount: 5%)"),
+      evaluate("call($fn, $color: blue, $amount: 5%)",
+        env("fn" => Sass::Script::String.new("lighten"))))
+  end
+
+  def test_call_unknown_function
+    assert_equal evaluate("unknown(red, blue)"), evaluate("call(unknown, red, blue)")
+  end
+
+  def test_call_with_non_string_argument
+    assert_error_message "$name: 3px is not a string for `call'", "call(3px)"
+  end
+
+  def test_errors_in_called_function
+    assert_error_message "3px is not a color for `lighten'", "call(lighten, 3px, 5%)"
+  end
+
   ## Regression Tests
 
   def test_saturation_bounds


### PR DESCRIPTION
This patch lets a function call be invoked where the function itself is provided by a script expression. A special built-in function `call` is handled by the when the function call is performed and the function is named `call`.

This implements the functions half of #626.
