### PR TITLE
Allow modulo arithmetric for numbers with units

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ## 3.2.10 (Unreleased)
 
+* Allow modulo arithmetic for numbers with units thanks to [Isaac Devine](http://www.devinesystems.co.nz)
+
 * Use the Sass logger infrastructure for `@debug` directives.
 
 * When printing a Sass error into a CSS comment, escape `*/` so the comment

--- a/lib/sass/script/number.rb
+++ b/lib/sass/script/number.rb
@@ -186,13 +186,10 @@ module Sass::Script
     # @param other [Number] The right-hand side of the operator
     # @return [Number] This number modulo the other
     # @raise [NoMethodError] if `other` is an invalid type
-    # @raise [Sass::UnitConversionError] if `other` has any units
+    # @raise [Sass::UnitConversionError] if `other` has incompatible units
     def mod(other)
       if other.is_a?(Number)
-        unless other.unitless?
-          raise Sass::UnitConversionError.new("Cannot modulo by a number with units: #{other.inspect}.")
-        end
-        operate(other, :%)
+          operate(other, :%)
       else
         raise NoMethodError.new(nil, :mod)
       end
@@ -364,7 +361,7 @@ module Sass::Script
       end
     end
 
-    OPERATIONS = [:+, :-, :<=, :<, :>, :>=]
+    OPERATIONS = [:+, :-, :<=, :<, :>, :>=, :%]
 
     def operate(other, operation)
       this = self

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -54,7 +54,7 @@ MSG
     "$a: 1b <= 2c" => "Incompatible units: 'c' and 'b'.",
     "$a: 1b >= 2c" => "Incompatible units: 'c' and 'b'.",
     "a\n  b: 1b * 2c" => "2b*c isn't a valid CSS value.",
-    "a\n  b: 1b % 2c" => "Cannot modulo by a number with units: 2c.",
+    "a\n  b: 1b % 2c" => "Incompatible units: 'c' and 'b'.",
     "$a: 2px + #ccc" => "Cannot add a number with units (2px) to a color (#cccccc).",
     "$a: #ccc + 2px" => "Cannot add a number with units (2px) to a color (#cccccc).",
     "& a\n  :b c" => ["Base-level rules cannot contain the parent-selector-referencing character '&'.", 1],

--- a/test/sass/results/units.css
+++ b/test/sass/results/units.css
@@ -8,4 +8,5 @@ b {
   pt: -72pt;
   inches: 2in;
   more-inches: 3.5in;
-  mixed: 2.04167in; }
+  mixed: 2.04167in;
+  mod-with-same-units: 5px; }

--- a/test/sass/templates/units.sass
+++ b/test/sass/templates/units.sass
@@ -9,3 +9,4 @@ b
   :inches 1in + 2.54cm
   :more-inches 1in + ((72pt * 2in) + (36pt * 1in)) / 2.54cm
   :mixed (1 + (1em * 6px / 3in)) * 4in / 2em
+  :mod-with-same-units 16px % 11px


### PR DESCRIPTION
For example, 24px % 13px will return 11px. Removal of previous exception
that was used when units were present "Cannot modulo by a number with
units: 13px"
