### PR TITLE
Value helpers

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -273,6 +273,9 @@ maps instead.
   `e`, and `f`; and then `g`, `h`, and `i`. For more information, see
   {file:SASS_REFERENCE.md#each-multi-assign the `@each` reference}.
 
+* There is a new {Sass::Script::Value::Helpers convenience API} for creating
+  Sass values from within ruby extensions.
+
 ### Backwards Incompatibilities -- Must Read!
 
 * Sass will now throw an error when `@extend` is used to extend a selector

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -1779,8 +1779,7 @@ module Sass::Script
         value.slice!(length)
       end
       new_list_value = values.first.zip(*values[1..-1])
-      new_list_arry = new_list_value.map {|list| Sass::Script::Value::List.new(list, :space)}
-      Sass::Script::Value::List.new(new_list_arry, :comma)
+      list(new_list_value.map{|list| list(list, :space)}, :comma)
     end
     declare :zip, [], :var_args => true
 

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -1,3 +1,5 @@
+require 'sass/script/value/helpers'
+
 module Sass::Script
   # Methods in this module are accessible from the SassScript context.
   # For example, you can write
@@ -373,6 +375,7 @@ module Sass::Script
     # are available to use in functions.
     class EvaluationContext
       include Functions
+      include Value::Helpers
 
       # The human-readable names for [Sass::Script::Value::Base]. The default is
       # just the downcased name of the type. The default is the downcased type
@@ -1494,7 +1497,7 @@ module Sass::Script
     def comparable(number_1, number_2)
       assert_type number_1, :Number, :number_1
       assert_type number_2, :Number, :number_2
-      Sass::Script::Value::Bool.new(number_1.comparable_to?(number_2))
+      bool(number_1.comparable_to?(number_2))
     end
     declare :comparable, [:number_1, :number_2]
 
@@ -1803,7 +1806,7 @@ module Sass::Script
       if index
         Sass::Script::Value::Number.new(index + 1)
       else
-        Sass::Script::Value::Bool::FALSE
+        bool(false)
       end
     end
     declare :index, [:list, :value]

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -586,7 +586,7 @@ module Sass::Script
     # @raise [ArgumentError] if `$saturation` or `$lightness` are out of bounds
     #   or any parameter is the wrong type
     def hsl(hue, saturation, lightness)
-      hsla(hue, saturation, lightness, Sass::Script::Value::Number.new(1))
+      hsla(hue, saturation, lightness, number(1))
     end
     declare :hsl, [:hue, :saturation, :lightness]
 
@@ -638,7 +638,7 @@ module Sass::Script
     # @raise [ArgumentError] if `$color` isn't a color
     def red(color)
       assert_type color, :Color, :color
-      Sass::Script::Value::Number.new(color.red)
+      number(color.red)
     end
     declare :red, [:color]
 
@@ -654,7 +654,7 @@ module Sass::Script
     # @raise [ArgumentError] if `$color` isn't a color
     def green(color)
       assert_type color, :Color, :color
-      Sass::Script::Value::Number.new(color.green)
+      number(color.green)
     end
     declare :green, [:color]
 
@@ -670,7 +670,7 @@ module Sass::Script
     # @raise [ArgumentError] if `$color` isn't a color
     def blue(color)
       assert_type color, :Color, :color
-      Sass::Script::Value::Number.new(color.blue)
+      number(color.blue)
     end
     declare :blue, [:color]
 
@@ -688,7 +688,8 @@ module Sass::Script
     # @raise [ArgumentError] if `$color` isn't a color
     def hue(color)
       assert_type color, :Color, :color
-      Sass::Script::Value::Number.new(color.hue, ["deg"])
+      assert_type color, :Color
+      number(color.hue, "deg")
     end
     declare :hue, [:color]
 
@@ -706,7 +707,7 @@ module Sass::Script
     # @raise [ArgumentError] if `$color` isn't a color
     def saturation(color)
       assert_type color, :Color, :color
-      Sass::Script::Value::Number.new(color.saturation, ["%"])
+      number(color.saturation, "%")
     end
     declare :saturation, [:color]
 
@@ -724,7 +725,7 @@ module Sass::Script
     # @raise [ArgumentError] if `$color` isn't a color
     def lightness(color)
       assert_type color, :Color, :color
-      Sass::Script::Value::Number.new(color.lightness, ["%"])
+      number(color.lightness, "%")
     end
     declare :lightness, [:color]
 
@@ -744,13 +745,13 @@ module Sass::Script
              a.value =~ /^[a-zA-Z]+\s*=/
          end
         # Support the proprietary MS alpha() function
-        return Sass::Script::Value::String.new("alpha(#{args.map {|a| a.to_s}.join(", ")})")
+        return identifier("alpha(#{args.map {|a| a.to_s}.join(", ")})")
       end
 
       raise ArgumentError.new("wrong number of arguments (#{args.size} for 1)") if args.size != 1
 
       assert_type args.first, :Color, :color
-      Sass::Script::Value::Number.new(args.first.alpha)
+      number(args.first.alpha)
     end
     declare :alpha, [:color]
 
@@ -763,10 +764,10 @@ module Sass::Script
     # @raise [ArgumentError] if `$color` isn't a color
     def opacity(color)
       if color.is_a?(Sass::Script::Value::Number)
-        return Sass::Script::Value::String.new("opacity(#{color})")
+        return identifier("opacity(#{color})")
       end
       assert_type color, :Color, :color
-      Sass::Script::Value::Number.new(color.alpha)
+      number(color.alpha)
     end
     declare :opacity, [:color]
 
@@ -869,7 +870,7 @@ module Sass::Script
     def saturate(color, amount = nil)
       # Support the filter effects definition of saturate.
       # https://dvcs.w3.org/hg/FXTF/raw-file/tip/filters/index.html
-      return Sass::Script::Value::String.new("saturate(#{color})") if amount.nil?
+      return identifier("saturate(#{color})") if amount.nil?
       _adjust(color, amount, :saturation, 0..100, :+, "%")
     end
     declare :saturate, [:color, :amount]
@@ -929,7 +930,7 @@ module Sass::Script
     def ie_hex_str(color)
       assert_type color, :Color, :color
       alpha = (color.alpha * 255).round.to_s(16).rjust(2, '0')
-      Sass::Script::Value::String.new("##{alpha}#{color.send(:hex_str)[1..-1]}".upcase)
+      identifier("##{alpha}#{color.send(:hex_str)[1..-1]}".upcase)
     end
     declare :ie_hex_str, [:color]
 
@@ -1143,7 +1144,7 @@ module Sass::Script
     # @return [Sass::Script::Value::Color]
     # @raise [ArgumentError] if `$weight` is out of bounds or any parameter is
     #   the wrong type
-    def mix(color_1, color_2, weight = Sass::Script::Value::Number.new(50))
+    def mix(color_1, color_2, weight = number(50))
       assert_type color_1, :Color, :color_1
       assert_type color_2, :Color, :color_2
       assert_type weight, :Number, :weight
@@ -1178,7 +1179,7 @@ module Sass::Script
 
       rgb = color_1.rgb.zip(color_2.rgb).map {|v1, v2| v1 * w1 + v2 * w2}
       alpha = color_1.alpha * p + color_2.alpha * (1 - p)
-      Sass::Script::Value::Color.new(rgb + [alpha])
+      rgb_color(*rgb, alpha)
     end
     declare :mix, [:color_1, :color_2]
     declare :mix, [:color_1, :color_2, :weight]
@@ -1193,9 +1194,9 @@ module Sass::Script
     # @raise [ArgumentError] if `$color` isn't a color
     def grayscale(color)
       if color.is_a?(Sass::Script::Value::Number)
-        return Sass::Script::Value::String.new("grayscale(#{color})")
+        return identifier("grayscale(#{color})")
       end
-      desaturate color, Sass::Script::Value::Number.new(100)
+      desaturate color, number(100)
     end
     declare :grayscale, [:color]
 
@@ -1208,7 +1209,7 @@ module Sass::Script
     # @return [Sass::Script::Value::Color]
     # @raise [ArgumentError] if `$color` isn't a color
     def complement(color)
-      adjust_hue color, Sass::Script::Value::Number.new(180)
+      adjust_hue color, number(180)
     end
     declare :complement, [:color]
 
@@ -1221,7 +1222,7 @@ module Sass::Script
     # @raise [ArgumentError] if `$color` isn't a color
     def invert(color)
       if color.is_a?(Sass::Script::Value::Number)
-        return Sass::Script::Value::String.new("invert(#{color})")
+        return identifier("invert(#{color})")
       end
 
       assert_type color, :Color, :color
@@ -1244,8 +1245,8 @@ module Sass::Script
     # @return [Sass::Script::Value::String]
     # @raise [ArgumentError] if `$string` isn't a string
     def unquote(string)
-      if string.is_a?(Sass::Script::Value::String)
-        Sass::Script::Value::String.new(string.value, :identifier)
+      if string.is_a?(Sass::Script::Value::String) && string.type != :identifier
+        identifier(string.value)
       else
         string
       end
@@ -1283,7 +1284,7 @@ module Sass::Script
     # @raise [ArgumentError] if `$string` isn't a string
     def str_length(string)
       assert_type string, :String, :string
-      Sass::Script::Value::Number.new(string.value.size)
+      number(string.value.size)
     end
     declare :str_length, [:string]
 
@@ -1343,7 +1344,7 @@ module Sass::Script
       assert_type string, :String, :string
       assert_type substring, :String, :substring
       index = string.value.index(substring.value) || -1
-      Sass::Script::Value::Number.new(index + 1)
+      number(index + 1)
     end
     declare :str_index, [:string, :substring]
 
@@ -1373,7 +1374,7 @@ module Sass::Script
       assert_type string, :String, :string
       assert_unit start_at, nil, "start-at"
 
-      end_at = Sass::Script::Value::Number.new(-1) if end_at.nil?
+      end_at = number(-1) if end_at.nil?
       assert_unit end_at, nil, "end-at"
 
       s = start_at.value > 0 ? start_at.value - 1 : start_at.value
@@ -1432,7 +1433,7 @@ module Sass::Script
     # @return [Sass::Script::Value::String] The unquoted string name of the
     #   value's type
     def type_of(value)
-      Sass::Script::Value::String.new(value.class.name.gsub(/Sass::Script::Value::/, '').downcase)
+      identifier(value.class.name.gsub(/Sass::Script::Value::/, '').downcase)
     end
     declare :type_of, [:value]
 
@@ -1448,7 +1449,7 @@ module Sass::Script
     # @raise [ArgumentError] if `$feature` isn't a string
     def feature_exists(feature)
       assert_type feature, :String, :feature
-      Sass::Script::Value::Bool.new(Sass.has_feature?(feature.value))
+      bool(Sass.has_feature?(feature.value))
     end
     declare :feature_exists, [:feature]
 
@@ -1483,7 +1484,7 @@ module Sass::Script
     # @raise [ArgumentError] if `$number` isn't a number
     def unitless(number)
       assert_type number, :Number, :number
-      Sass::Script::Value::Bool.new(number.unitless?)
+      bool(number.unitless?)
     end
     declare :unitless, [:number]
 
@@ -1518,7 +1519,7 @@ module Sass::Script
       unless value.is_a?(Sass::Script::Value::Number) && value.unitless?
         raise ArgumentError.new("$value: #{value.inspect} is not a unitless number")
       end
-      Sass::Script::Value::Number.new(value.value * 100, ['%'])
+      number(value.value * 100, '%')
     end
     declare :percentage, [:value]
 
@@ -1624,7 +1625,7 @@ module Sass::Script
     # @param $list [Sass::Script::Value::Base]
     # @return [Sass::Script::Value::Number]
     def length(list)
-      Sass::Script::Value::Number.new(list.to_a.size)
+      number(list.to_a.size)
     end
     declare :length, [:list]
 
@@ -1708,18 +1709,17 @@ module Sass::Script
     #   If this is `comma` or `space`, that separator will be used. If this is
     #   `auto` (the default), the separator is determined as explained above.
     # @return [Sass::Script::Value::List]
-    def join(list1, list2, separator = Sass::Script::Value::String.new("auto"))
+    def join(list1, list2, separator = identifier("auto"))
       assert_type separator, :String, :separator
       unless %w[auto space comma].include?(separator.value)
         raise ArgumentError.new("Separator name must be space, comma, or auto")
       end
-      Sass::Script::Value::List.new(
-        list1.to_a + list2.to_a,
-        if separator.value == 'auto'
-          list1.separator || list2.separator || :space
-        else
-          separator.value.to_sym
-        end)
+      sep = if separator.value == 'auto'
+              list1.separator || list2.separator || :space
+            else
+              separator.value.to_sym
+            end
+      list(list1.to_a + list2.to_a, sep)
     end
     declare :join, [:list1, :list2]
     declare :join, [:list1, :list2, :separator]
@@ -1742,18 +1742,17 @@ module Sass::Script
     #   If this is `comma` or `space`, that separator will be used. If this is
     #   `auto` (the default), the separator is determined as explained above.
     # @return [Sass::Script::Value::List]
-    def append(list, val, separator = Sass::Script::String.new("auto"))
+    def append(list, val, separator = identifier("auto"))
       assert_type separator, :String, :separator
       unless %w[auto space comma].include?(separator.value)
         raise ArgumentError.new("Separator name must be space, comma, or auto")
       end
-      Sass::Script::Value::List.new(
-        list.to_a + [val],
-        if separator.value == 'auto'
-          list.separator || :space
-        else
-          separator.value.to_sym
-        end)
+      sep = if separator.value == 'auto'
+              list.separator || :space
+            else
+              separator.value.to_sym
+            end
+      list(list.to_a + [val], sep)
     end
     declare :append, [:list, :val]
     declare :append, [:list, :val, :separator]
@@ -1783,7 +1782,7 @@ module Sass::Script
         value.slice!(length)
       end
       new_list_value = values.first.zip(*values[1..-1])
-      list(new_list_value.map{|list| list(list, :space)}, :comma)
+      list(new_list_value.map {|list| list(list, :space)}, :comma)
     end
     declare :zip, [], :var_args => true
 
@@ -1807,7 +1806,7 @@ module Sass::Script
     def index(list, value)
       index = list.to_a.index {|e| e.eq(value).to_bool}
       if index
-        Sass::Script::Value::Number.new(index + 1)
+        number(index + 1)
       else
         bool(false)
       end
@@ -1825,7 +1824,7 @@ module Sass::Script
     # @param $list [Sass::Script::Value::Base]
     # @return [Sass::Script::Value::String] `comma` or `space`
     def list_separator(list)
-      Sass::Script::Value::String.new((list.separator || :space).to_s)
+      identifier((list.separator || :space).to_s)
     end
     declare :separator, [:list]
 
@@ -1972,7 +1971,7 @@ module Sass::Script
       # avoid the temptation of trying to guess the next unique value.
       value = (Thread.current[:sass_last_unique_id] += (rand(10) + 1))
       # the u makes this a legal identifier if it would otherwise start with a number.
-      Sass::Script::String.new("u" + value.to_s(36).rjust(8, '0'))
+      identifier("u" + value.to_s(36).rjust(8, '0'))
     end
     declare :unique_id, []
 
@@ -2015,7 +2014,7 @@ module Sass::Script
     # @overload counter($args...)
     # @return [String]
     def counter(*args)
-      Sass::Script::Value::String.new("counter(#{args.map {|a| a.to_s(options)}.join(',')})")
+      identifier("counter(#{args.map {|a| a.to_s(options)}.join(',')})")
     end
     declare :counter, [], :var_args => true
 

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -1265,7 +1265,11 @@ module Sass::Script
     # @raise [ArgumentError] if `$string` isn't a string
     def quote(string)
       assert_type string, :String, :string
-      Sass::Script::Value::String.new(string.value, :string)
+      if string.type != :string
+        quoted_string(string.value)
+      else
+        string
+      end
     end
     declare :quote, [:string]
 
@@ -1464,7 +1468,7 @@ module Sass::Script
     # @raise [ArgumentError] if `$number` isn't a number
     def unit(number)
       assert_type number, :Number, :number
-      Sass::Script::Value::String.new(number.unit_str, :string)
+      quoted_string(number.unit_str)
     end
     declare :unit, [:number]
 

--- a/lib/sass/script/lexer.rb
+++ b/lib/sass/script/lexer.rb
@@ -296,9 +296,7 @@ module Sass
         raise Sass::SyntaxError.new(<<MESSAGE.rstrip) unless s.size == 4 || s.size == 7
 Colors must have either three or six digits: '#{s}'
 MESSAGE
-        value = s.scan(/^#(..?)(..?)(..?)$/).first.
-          map {|num| num.ljust(2, num).to_i(16)}
-        script_color = Script::Value::Color.new(value)
+        script_color = Script::Value::Color.from_hex(s)
         [:color, script_color]
       end
 

--- a/lib/sass/script/value/color.rb
+++ b/lib/sass/script/value/color.rb
@@ -248,6 +248,24 @@ module Sass::Script::Value
       @attrs[:alpha] = Sass::Util.check_range("Alpha channel", 0..1, @attrs[:alpha])
     end
 
+    # Create a new color from a valid CSS hex string.
+    #
+    # The leading hash is optional.
+    #
+    # @return [Color]
+    def self.from_hex(hex_string, alpha = nil)
+      unless hex_string =~ /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i ||
+             hex_string =~ /^#?([0-9a-f])([0-9a-f])([0-9a-f])$/i
+        raise ArgumentError.new("#{hex_string.inspect} is not a valid hex color.")
+      end
+      red   = $1.ljust(2, $1).to_i(16)
+      green = $2.ljust(2, $2).to_i(16)
+      blue  = $3.ljust(2, $3).to_i(16)
+      attrs = {:red => red, :green => green, :blue => blue}
+      attrs[:alpha] = alpha if alpha
+      new(attrs)
+    end
+
     # The red component of the color.
     #
     # @return [Fixnum]

--- a/lib/sass/script/value/helpers.rb
+++ b/lib/sass/script/value/helpers.rb
@@ -19,5 +19,22 @@ module Sass::Script::Value
     def hex_color(value, alpha = nil)
       Color.from_hex(value, alpha)
     end
+
+    # Construct a Sass Color from hsl values.
+    #
+    # @param hue [::Number] The hue of the color in degrees.
+    #   A non-negative number, usually less than 360.
+    # @param saturation [::Number] The saturation of the color.
+    #   Must be between 0 and 100 inclusive.
+    # @param lightness [::Number] The lightness of the color.
+    #   Must be between 0 and 100 inclusive.
+    # @param alpha [::Number] The alpha channel. A number between 0 and 1.
+    #
+    # @return [Sass::Script::Value::Color] the color object
+    def hsl_color(hue, saturation, lightness, alpha = nil)
+      attrs = {:hue => hue, :saturation => saturation, :lightness => lightness}
+      attrs[:alpha] = alpha if alpha
+      Color.new(attrs)
+    end
   end
 end

--- a/lib/sass/script/value/helpers.rb
+++ b/lib/sass/script/value/helpers.rb
@@ -52,6 +52,28 @@ module Sass::Script::Value
       Number.new(number, *parse_unit_string(unit_string))
     end
 
+    # @overload list(*elements, separator)
+    #   Create a space-separated list from the arguments given.
+    #   @param elements [Array<Sass::Script::Value::Base>] Each argument will be a list element.
+    #   @param separator [Symbol] Either :space or :comma.
+    #   @return [Sass::Script::Value::List] The space separated list.
+    #
+    # @overload list(array, separator)
+    #   Create a space-separated list from the array given.
+    #   @param array [Array<Sass::Script::Value::Base>] A ruby array of Sass values
+    #     to make into a list.
+    #   @return [Sass::Script::Value::List] The space separated list.
+    def list(*elements)
+      unless elements.last.is_a?(Symbol)
+        raise ArgumentError.new("A list type of :space or :comma must be specified.")
+      end
+      separator = elements.pop
+      if elements.size == 1 && elements.first.is_a?(Array)
+        elements = elements.first
+      end
+      Sass::Script::Value::List.new(elements, separator)
+    end
+
     private
 
     # @private

--- a/lib/sass/script/value/helpers.rb
+++ b/lib/sass/script/value/helpers.rb
@@ -74,6 +74,13 @@ module Sass::Script::Value
       Sass::Script::Value::List.new(elements, separator)
     end
 
+    # Create a sass null value.
+    #
+    # @return [Sass::Script::Value::Null]
+    def null
+      Sass::Script::Value::Null.new
+    end
+
     private
 
     # @private

--- a/lib/sass/script/value/helpers.rb
+++ b/lib/sass/script/value/helpers.rb
@@ -81,6 +81,23 @@ module Sass::Script::Value
       Sass::Script::Value::Null.new
     end
 
+    # Create a quoted string.
+    #
+    # @param str [::String] A ruby string.
+    # @return [Sass::Script::Value::String] A quoted string.
+    def quoted_string(str)
+      Sass::Script::String.new(str, :string)
+    end
+
+    # Create an unquoted string.
+    #
+    # @param str [::String] A ruby string.
+    # @return [Sass::Script::Value::String] An unquoted string.
+    def unquoted_string(str)
+      Sass::Script::String.new(str, :identifier)
+    end
+    alias_method :identifier, :unquoted_string
+
     private
 
     # @private

--- a/lib/sass/script/value/helpers.rb
+++ b/lib/sass/script/value/helpers.rb
@@ -1,0 +1,13 @@
+module Sass::Script::Value
+  # Provides helper functions for creating sass values from within ruby methods.
+  # @since `3.3.0`
+  module Helpers
+    # Construct a Sass Boolean.
+    #
+    # @param value [Object] A ruby object that will be tested for truthiness.
+    # @return [Sass::Script::Value::Bool] whether the ruby value is truthy.
+    def bool(value)
+      Bool.new(value)
+    end
+  end
+end

--- a/lib/sass/script/value/helpers.rb
+++ b/lib/sass/script/value/helpers.rb
@@ -37,6 +37,20 @@ module Sass::Script::Value
       Color.new(attrs)
     end
 
+    # Construct a Sass Color from rgb values.
+    #
+    # @param red [::Number] The red component. Must be between 0 and 255 inclusive.
+    # @param green [::Number] The green component. Must be between 0 and 255 inclusive.
+    # @param blue [::Number] The blue component. Must be between 0 and 255 inclusive.
+    # @param alpha [::Number] The alpha channel. A number between 0 and 1.
+    #
+    # @return [Sass::Script::Value::Color] the color object
+    def rgb_color(red, green, blue, alpha = nil)
+      attrs = {:red => red, :green => green, :blue => blue}
+      attrs[:alpha] = alpha if alpha
+      Color.new(attrs)
+    end
+
     # Construct a Sass Number from a ruby number.
     #
     # @param number [::Number] A numeric value.

--- a/lib/sass/script/value/helpers.rb
+++ b/lib/sass/script/value/helpers.rb
@@ -36,5 +36,51 @@ module Sass::Script::Value
       attrs[:alpha] = alpha if alpha
       Color.new(attrs)
     end
+
+    # Construct a Sass Number from a ruby number.
+    #
+    # @param number [::Number] A numeric value.
+    # @param unit_string [::String] A unit string of the form
+    #   `numeral_unit1 * numeral_unit2 ... / denominator_unit1 * denominator_unit2 ...`
+    #   this is the same format that is returned by
+    #   {Sass::Script::Value::Number#unit_str the `unit_str` method}
+    #
+    # @see Sass::Script::Value::Number#unit_str
+    #
+    # @return [Sass::Script::Value::Number] The sass number representing the given ruby number.
+    def number(number, unit_string = nil)
+      Number.new(number, *parse_unit_string(unit_string))
+    end
+
+    private
+
+    # @private
+    VALID_UNIT = /#{Sass::SCSS::RX::NMSTART}#{Sass::SCSS::RX::NMCHAR}|%*/
+
+    # @example
+    #   parse_unit_string("em*px/in*%") # => [["em", "px], ["in", "%"]]
+    #
+    # @param unit_string [String] A string adhering to the output of a number with complex
+    #   units. E.g. "em*px/in*%"
+    # @return [Array<Array<String>>] A list of numerator units and a list of denominator units.
+    def parse_unit_string(unit_string)
+      denominator_units = numerator_units = Sass::Script::Value::Number::NO_UNITS
+      return numerator_units, denominator_units unless unit_string && unit_string.length > 0
+      num_over_denominator = unit_string.split(/ *\/ */)
+      unless (1..2).include?(num_over_denominator.size)
+        raise ArgumentError.new("Malformed unit string: #{unit_string}")
+      end
+      numerator_units = num_over_denominator[0].split(/ *\* */)
+      denominator_units = (num_over_denominator[1] || "").split(/ *\* */)
+      [[numerator_units, "numerator"], [denominator_units, "denominator"]].each do |units, name|
+        if unit_string =~ /\// && units.size == 0
+          raise ArgumentError.new("Malformed unit string: #{unit_string}")
+        end
+        if units.any? {|unit| unit !~ VALID_UNIT}
+          raise ArgumentError.new("Malformed #{name} in unit string: #{unit_string}")
+        end
+      end
+      [numerator_units, denominator_units]
+    end
   end
 end

--- a/lib/sass/script/value/helpers.rb
+++ b/lib/sass/script/value/helpers.rb
@@ -9,5 +9,15 @@ module Sass::Script::Value
     def bool(value)
       Bool.new(value)
     end
+
+    # Construct a Sass Color from a hex color string.
+    #
+    # @param value [::String] A string representing a hex color.
+    #   The leading hash ("#") is optional.
+    # @param alpha [::Number] The alpha channel. A number between 0 and 1.
+    # @return [Sass::Script::Value::Color] the color object
+    def hex_color(value, alpha = nil)
+      Color.from_hex(value, alpha)
+    end
   end
 end

--- a/lib/sass/script/value/null.rb
+++ b/lib/sass/script/value/null.rb
@@ -1,9 +1,19 @@
 module Sass::Script::Value
   # A SassScript object representing a null value.
   class Null < Base
-    # Creates a new null value.
-    def initialize
-      super nil
+
+    # The null value in SassScript.
+    #
+    # This is assigned before new is overridden below so that we use the default implementation.
+    NULL = new(nil)
+
+    # We override object creation so that users of the core API
+    # will not need to know that null is a specific constant.
+    #
+    # @private
+    # @return [Null] the {NULL} constant.
+    def self.new
+      NULL
     end
 
     # @return [Boolean] `false` (the Ruby boolean value)

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -163,7 +163,7 @@ class SassFunctionTest < Test::Unit::TestCase
   end
 
   def test_min
-    #assert_equal("1", evaluate("min(1, 2, 3)"))
+    assert_equal("1", evaluate("min(1, 2, 3)"))
     assert_equal("1", evaluate("min(3px, 2px, 1)"))
     assert_equal("4em", evaluate("min(4em)"))
     assert_equal("10cm", evaluate("min(10cm, 6in)"))

--- a/test/sass/script_test.rb
+++ b/test/sass/script_test.rb
@@ -681,4 +681,8 @@ SASS
     assert_equal "-Infinity", eval("-1.0/0.0")
     assert_equal "NaN", eval("0.0/0.0")
   end
+
+  def test_null_is_a_singleton
+    assert_same Sass::Script::Value::Null.new, Sass::Script::Value::Null.new
+  end
 end

--- a/test/sass/value_helpers_test.rb
+++ b/test/sass/value_helpers_test.rb
@@ -131,4 +131,8 @@ class ValueHelpersTest < Test::Unit::TestCase
       list(number(1, "px"), hex_color("#f71"))
     end
   end
+
+  def test_null
+    assert_kind_of Sass::Script::Value::Null, null
+  end
 end

--- a/test/sass/value_helpers_test.rb
+++ b/test/sass/value_helpers_test.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+require File.dirname(__FILE__) + '/../test_helper'
+
+class ValueHelpersTest < Test::Unit::TestCase
+  include Sass::Script
+  include Sass::Script::Value::Helpers
+
+  def test_bool
+    assert_same Value::Bool::TRUE, bool(true)
+    assert_same Value::Bool::FALSE, bool(false)
+    assert_same Value::Bool::FALSE, bool(nil)
+    assert_same Value::Bool::TRUE, bool(Object.new)
+  end
+
+end

--- a/test/sass/value_helpers_test.rb
+++ b/test/sass/value_helpers_test.rb
@@ -135,4 +135,31 @@ class ValueHelpersTest < Test::Unit::TestCase
   def test_null
     assert_kind_of Sass::Script::Value::Null, null
   end
+
+  def test_quoted_string
+    s = quoted_string("sassy string")
+    s.options = {}
+    assert_kind_of Sass::Script::Value::String, s
+    assert_equal "sassy string", s.value
+    assert_equal :string, s.type
+    assert_equal '"sassy string"', s.to_sass
+  end
+
+  def test_identifier
+    s = identifier("a-sass-ident")
+    s.options = {}
+    assert_kind_of Sass::Script::Value::String, s
+    assert_equal "a-sass-ident", s.value
+    assert_equal :identifier, s.type
+    assert_equal "a-sass-ident", s.to_sass
+  end
+
+  def test_unquoted_string
+    s = unquoted_string("a-sass-ident")
+    s.options = {}
+    assert_kind_of Sass::Script::Value::String, s
+    assert_equal "a-sass-ident", s.value
+    assert_equal :identifier, s.type
+    assert_equal "a-sass-ident", s.to_sass
+  end
 end

--- a/test/sass/value_helpers_test.rb
+++ b/test/sass/value_helpers_test.rb
@@ -111,4 +111,24 @@ class ValueHelpersTest < Test::Unit::TestCase
       number(1, "px/")
     end
   end
+
+  def test_space_list
+    l = list(number(1, "px"), hex_color("#f71"), :space)
+    l.options = {}
+    assert_kind_of Sass::Script::Value::List, l
+    assert_equal "1px #ff7711", l.to_sass
+  end
+
+  def test_comma_list
+    l = list(number(1, "px"), hex_color("#f71"), :comma)
+    l.options = {}
+    assert_kind_of Sass::Script::Value::List, l
+    assert_equal "1px, #ff7711", l.to_sass
+  end
+
+  def test_missing_list_type
+    assert_raises ArgumentError do
+      list(number(1, "px"), hex_color("#f71"))
+    end
+  end
 end

--- a/test/sass/value_helpers_test.rb
+++ b/test/sass/value_helpers_test.rb
@@ -73,6 +73,22 @@ class ValueHelpersTest < Test::Unit::TestCase
     assert_equal 0.5, has_alpha.alpha
   end
 
+  def test_rgb_color_without_alpha
+    no_alpha = rgb_color(255, 0, 0)
+    assert_equal 255, no_alpha.red
+    assert_equal 0, no_alpha.green
+    assert_equal 0, no_alpha.blue
+    assert_equal 1, no_alpha.alpha
+  end
+
+  def test_rgb_color_with_alpha
+    has_alpha = rgb_color(255, 255, 255, 0.5)
+    assert_equal 255, has_alpha.red
+    assert_equal 255, has_alpha.green
+    assert_equal 255, has_alpha.blue
+    assert_equal 0.5, has_alpha.alpha
+  end
+
   def test_number
     n = number(1)
     assert_equal 1, n.value

--- a/test/sass/value_helpers_test.rb
+++ b/test/sass/value_helpers_test.rb
@@ -56,4 +56,20 @@ class ValueHelpersTest < Test::Unit::TestCase
       hex_color("FF007F", 50)
     end
   end
+
+  def test_hsl_color_without_alpha
+    no_alpha = hsl_color(1, 0.5, 1)
+    assert_equal 1, no_alpha.hue
+    assert_equal 0.5, no_alpha.saturation
+    assert_equal 1, no_alpha.lightness
+    assert_equal 1, no_alpha.alpha
+  end
+
+  def test_hsl_color_with_alpha
+    has_alpha = hsl_color(1, 0.5, 1, 0.5)
+    assert_equal 1, has_alpha.hue
+    assert_equal 0.5, has_alpha.saturation
+    assert_equal 1, has_alpha.lightness
+    assert_equal 0.5, has_alpha.alpha
+  end
 end

--- a/test/sass/value_helpers_test.rb
+++ b/test/sass/value_helpers_test.rb
@@ -12,4 +12,48 @@ class ValueHelpersTest < Test::Unit::TestCase
     assert_same Value::Bool::TRUE, bool(Object.new)
   end
 
+  def test_hex_color_with_three_digits
+    color = hex_color("F07")
+    assert_equal 255, color.red
+    assert_equal 0, color.green
+    assert_equal 119, color.blue
+    assert_equal 1, color.alpha
+  end
+
+  def test_hex_color_without_hash
+    color_without_hash = hex_color("FF007F")
+    assert_equal 255, color_without_hash.red
+    assert_equal 0, color_without_hash.green
+    assert_equal 127, color_without_hash.blue
+    assert_equal 1, color_without_hash.alpha
+  end
+
+  def test_hex_color_with_hash
+    color_with_hash = hex_color("#FF007F")
+    assert_equal 255, color_with_hash.red
+    assert_equal 0, color_with_hash.green
+    assert_equal 127, color_with_hash.blue
+    assert_equal 1, color_with_hash.alpha
+  end
+
+  def test_malformed_hex_color
+    assert_raises ArgumentError do
+      hex_color("green")
+    end
+    assert_raises ArgumentError do
+      hex_color("#abcd")
+    end
+  end
+
+
+  def test_hex_color_with_alpha
+    color_with_alpha = hex_color("FF007F", 0.5)
+    assert_equal 0.5, color_with_alpha.alpha
+  end
+
+  def test_hex_color_alpha_enforces_0_to_1
+    assert_raises ArgumentError do
+      hex_color("FF007F", 50)
+    end
+  end
 end

--- a/test/sass/value_helpers_test.rb
+++ b/test/sass/value_helpers_test.rb
@@ -72,4 +72,43 @@ class ValueHelpersTest < Test::Unit::TestCase
     assert_equal 1, has_alpha.lightness
     assert_equal 0.5, has_alpha.alpha
   end
+
+  def test_number
+    n = number(1)
+    assert_equal 1, n.value
+    assert_equal "1", n.to_sass
+  end
+
+  def test_number_with_single_unit
+    n = number(1, "px")
+    assert_equal 1, n.value
+    assert_equal "1px", n.to_sass
+  end
+
+  def test_number_with_singal_numerator_and_denominator
+    ratio = number(1, "px/em")
+    assert_equal "1px/em", ratio.to_sass
+  end
+
+  def test_number_with_many_numerator_and_denominator_units
+    complex = number(1, "px*in/em*%")
+    assert_equal "1in*px/%*em", complex.to_sass
+  end
+
+  def test_number_with_many_numerator_and_denominator_units_with_spaces
+    complex = number(1, "px * in / em * %")
+    assert_equal "1in*px/%*em", complex.to_sass
+  end
+
+  def test_number_with_malformed_units
+    assert_raises ArgumentError do
+      number(1, "px/em/%")
+    end
+    assert_raises ArgumentError do
+      number(1, "/")
+    end
+    assert_raises ArgumentError do
+      number(1, "px/")
+    end
+  end
 end


### PR DESCRIPTION
It turns out you can only type `Sass::Script::Value::<type>.new` so many times before you want to :cry:. I recently passed that limit and coded this up while sitting in a pool of tears.

This is a refactor to make constructing sass values from ruby extensions more convenient. The API is tailored to how developers work with the Sass values instead of how the parser wants to construct the same objects. This refactor significantly cleaned up our own ruby-based Sass functions.

P.S. Yes, I am aware that I can include `Sass::Script::Value` in order to make object creation less typing, but even without that, the creation patterns for developers differs significantly from that of the parser. And I find a function call to be more aesthetically pleasing in this context than a call to `.new` on a class.
