### PR TITLE
Add tests and documentation for JSON error and warning output.

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ## 3.3.0 (Unreleased)
 
+* Add a `--json-err` option that causes errors and warnings to be output as JSON.
+ Check the
+ [reference for details on the JSON format](file:SASS_REFERENCE.md#json_err-option Reference Documentation).
+ (thanks [Eric Wendelin](http://www.eriwen.com))
+
 ### Backwards Incompatibilities -- Must Read!
 
 * Sass will now throw an error when `@extend` is used to extend a selector
@@ -169,7 +174,7 @@ that each value is passed as a separate argument. For example:
       // $shadows is a list of all arguments passed to box-shadow
       -moz-box-shadow: $shadows;
       -webkit-box-shadow: $shadows;
-      box-shadow: $shadows;      
+      box-shadow: $shadows;
     }
 
     // This is the same as "@include spacing(1, 2, 3);"

--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -319,6 +319,48 @@ Available options are:
   for displaying the Sass filename and line number.
   Automatically disabled when using the `:compressed` output style.
 
+{#trace-option} `:trace`
+: Show a full traceback on error.
+
+{#json_err-option} `:json_err`
+: When set to true, errors are written to stderr in JSON format.
+  This implies --trace.
+
+#### JSON format
+: All warnings and errors have a `type`, `message`, and `backtrace`. Some may
+  have some additional fields pertinent to the particular warning.
+
+    {
+        "type": ["warning", "WarningType"],
+        "message": "Warning message",
+        "backtrace": ["bar.sass:3:in `foo'", "qux.sass:72", ...],
+        "additional_field1": "value"
+    }
+
+: In addition to `type`, `message`, and `backtrace`, all `Sass::SyntaxError`s
+ have a `sass_backtrace`, `filename`, `line`, and a `mixin` (if the error
+ occurred within a mixin).
+
+    {
+        "type": ["error", "Sass::SyntaxError"],
+        "message": "Undefined mixin 'foo'.",
+        "backtrace": ["bar.sass:3:in `foo'", "qux.sass:72", ...],
+        "filename": "bar.sass",
+        "line": 3,
+        "mixin": "foo",
+        "sass_backtrace": [
+            {
+                "filename": "bar.sass"
+                "mixin": "foo",
+                "line": 3
+            },
+            {
+                "filename": "qux.sass"
+                "line": 72
+            }
+        ]
+    }
+
 {#custom-option} `:custom`
 : An option that's available for individual applications to set
   to make data available to {Sass::Script::Functions custom Sass functions}.

--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -319,16 +319,9 @@ Available options are:
   for displaying the Sass filename and line number.
   Automatically disabled when using the `:compressed` output style.
 
-{#trace-option} `:trace`
-: Show a full traceback on error.
-
-{#json_err-option} `:json_err`
-: When set to true, errors are written to stderr in JSON format.
-  This implies --trace.
-
 #### JSON format
-: All warnings and errors have a `type`, `message`, and `backtrace`. Some may
-  have some additional fields pertinent to the particular warning.
+All warnings and errors have a `type`, `message`, and `backtrace`. Some may
+have some additional fields pertinent to the particular warning.
 
     {
         "type": ["warning", "WarningType"],
@@ -337,9 +330,9 @@ Available options are:
         "additional_field1": "value"
     }
 
-: In addition to `type`, `message`, and `backtrace`, all `Sass::SyntaxError`s
- have a `sass_backtrace`, `filename`, `line`, and a `mixin` (if the error
- occurred within a mixin).
+In addition to `type`, `message`, and `backtrace`, all errors caused by the stylesheets
+have a `sass_backtrace`, `filename`, `line`, and a `mixin` (if the error
+occurred within a mixin).
 
     {
         "type": ["error", "Sass::SyntaxError"],

--- a/test/sass/cache_test.rb
+++ b/test/sass/cache_test.rb
@@ -2,7 +2,20 @@
 require File.dirname(__FILE__) + '/../test_helper'
 require File.dirname(__FILE__) + '/test_helper'
 require 'sass/engine'
-require 'json'
+
+class FaultyStore < Sass::CacheStores::Base
+  def _store(a, b, c, d)
+    raise LoadError.new("LOAD_ERROR")
+  end
+
+  def _retrieve(a, b, c)
+    raise TypeError.new("TYPE_ERROR")
+  end
+
+  def path_to(key)
+    "PATH"
+  end
+end
 
 class CacheTest < Test::Unit::TestCase
   @@cache_dir = "tmp/file_cache"
@@ -67,38 +80,22 @@ class CacheTest < Test::Unit::TestCase
     assert_equal an_object, cache.retrieve("an_object", "")
   end
 
-  class FaultyStore < Sass::CacheStores::Base
-    def _store(a, b, c, d)
-      raise LoadError.new("LOAD_ERROR")
-    end
-
-    def _retrieve(a, b, c)
-      raise TypeError.new("TYPE_ERROR")
-    end
-
-    def path_to(key)
-      "PATH"
-    end
-  end
-
   def test_storage_error_gives_metadata_in_json_warning
     cache = FaultyStore.new
-    with_json_warnings do
-      json = JSON.parse(collect_stderr {cache.store("_", "_", "_")})
-      assert_equal json["type"], ["warning", "cache"]
-      assert_equal json["message"], "Warning. Error encountered while saving cache PATH: LOAD_ERROR"
-      assert_not_nil json["backtrace"]
-    end
+    json = collect_json_warnings {cache.store("_", "_", "_")}
+    assert_equal ["warning", "cache"], json["type"]
+    assert_equal "Warning. Error encountered while saving cache PATH:" \
+        " LOAD_ERROR", json["message"]
+    assert_not_nil json["backtrace"]
   end
 
   def test_retrieval_error_gives_metadata_in_json_warning
     cache = FaultyStore.new
-    with_json_warnings do
-      json = JSON.parse(collect_stderr {cache.retrieve("_", "_")})
-      assert_equal json["type"], ["warning", "cache"]
-      assert_equal json["message"], "Warning. Error encountered while reading cache PATH: TYPE_ERROR"
-      assert_not_nil json["backtrace"]
-    end
+    json = collect_json_warnings {cache.retrieve("_", "_")}
+    assert_equal ["warning", "cache"], json["type"]
+    assert_equal "Warning. Error encountered while reading cache PATH:" \
+        " TYPE_ERROR", json["message"]
+    assert_not_nil json["backtrace"]
   end
 
   class Unmarshalable

--- a/test/sass/importer_test.rb
+++ b/test/sass/importer_test.rb
@@ -3,7 +3,6 @@ require File.dirname(__FILE__) + '/../test_helper'
 require File.dirname(__FILE__) + '/test_helper'
 
 require 'sass/plugin'
-require 'json'
 
 class ImporterTest < Test::Unit::TestCase
 
@@ -192,24 +191,24 @@ CSS
   end
 
   def test_ambiguous_imports_sends_json_metadata
-    with_json_warnings do
-      expected_dir = absolutize "templates"
-      template_name = "same_name_different_ext"
-      stderr = collect_stderr do
-        importer = Sass::Importers::Filesystem.new(expected_dir)
-        importer.mtime(absolutize("templates/#{template_name}"), {})
-      end
-      json = JSON.parse stderr
-      assert_equal json["type"], ["warning", "ambiguous_import"]
-      assert_equal json["message"], <<MESSAGE
+    expected_dir = absolutize "templates"
+    template_name = "same_name_different_ext"
+    expected_message = <<MESSAGE
 WARNING: In #{expected_dir}:
   There are multiple files that match the name "#{template_name}":
     #{template_name}.sass
     #{template_name}.scss
 MESSAGE
-      assert_equal expected_dir, json["dir"]
-      assert_equal template_name, json["name"]
-      assert_equal [[absolutize("templates/#{template_name}.sass"), "sass"], [absolutize("templates/#{template_name}.scss"), "scss"]], json["candidates"]
+
+    json = collect_json_warnings do
+      importer = Sass::Importers::Filesystem.new(expected_dir)
+      importer.mtime(absolutize("templates/#{template_name}"), {})
     end
+
+    assert_equal ["warning", "ambiguous_import"], json["type"]
+    assert_equal expected_message, json["message"]
+    assert_equal expected_dir, json["dir"]
+    assert_equal template_name, json["name"]
+    assert_equal [[absolutize("templates/#{template_name}.sass"), "sass"], [absolutize("templates/#{template_name}.scss"), "scss"]], json["candidates"]
   end
 end

--- a/test/sass/util_test.rb
+++ b/test/sass/util_test.rb
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 require File.dirname(__FILE__) + '/../test_helper'
 require 'pathname'
-require 'json'
 
 class UtilTest < Test::Unit::TestCase
   include Sass::Util
@@ -153,13 +152,11 @@ class UtilTest < Test::Unit::TestCase
   end
 
   def test_sass_json_warn
-    with_json_warnings do
-      json = JSON.parse(collect_stderr {sass_warn "Foo!", :type1, :type2, :field => :value})
-      assert_equal(json["type"], ["warning", "type1", "type2"])
-      assert_equal(json["message"], "Foo!")
-      assert_not_nil(json["backtrace"])
-      assert_equal(json["field"], "value")
-    end
+    json = collect_json_warnings {sass_warn "Foo!", :type1, :type2, :field => :value}
+    assert_equal(json["type"], ["warning", "type1", "type2"])
+    assert_equal(json["message"], "Foo!")
+    assert_not_nil(json["backtrace"])
+    assert_equal(json["field"], "value")
   end
 
   def test_silence_sass_warnings

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require 'test/unit'
 require 'fileutils'
 $:.unshift lib_dir unless $:.include?(lib_dir)
 require 'sass'
+require 'json'
 require 'mathn' if ENV['MATHN'] == 'true'
 
 Sass::RAILS_LOADED = true unless defined?(Sass::RAILS_LOADED)
@@ -65,6 +66,12 @@ class Test::Unit::TestCase
     yield
   ensure
     Sass.json_err = old_json_err
+  end
+
+  def collect_json_warnings(&block)
+    with_json_warnings do
+      JSON.parse(collect_stderr(&block))
+    end
   end
 
   def assert_raise_message(klass, message)


### PR DESCRIPTION
This PR addresses a couple of @nex3's [requests](https://github.com/nex3/sass/issues/593#issuecomment-11631340) on nex3/sass#593. 

I will submit a different pull request to add metadata to SyntaxErrors, but I'm less sure of how that work will end up. 

I'm just adding tests and docs here. There is a persistent test failure `test_extend_sourcemap_scss` unrelated to this change. 

Hope you approve :)
