### PR TITLE
Fix typo in Sass variable arguments documentation.

### DIFF
--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -2072,7 +2072,7 @@ arguments, but are followed by `...`. For example:
 
 is compiled to:
 
-    .shadowed {
+    .shadows {
       -moz-box-shadow: 0px 4px 5px #666, 2px 6px 10px #999;
       -webkit-box-shadow: 0px 4px 5px #666, 2px 6px 10px #999;
       box-shadow: 0px 4px 5px #666, 2px 6px 10px #999;


### PR DESCRIPTION
Made the input and output class names of an example consistent.
