### PR TITLE
Provide a better error message for the -E option in ruby 1.8.

### DIFF
--- a/lib/sass/exec.rb
+++ b/lib/sass/exec.rb
@@ -293,8 +293,16 @@ END
           @options[:for_engine][:cache] = false
         end
 
-        unless ::Sass::Util.ruby1_8?
-          opts.on('-E encoding', 'Specify the default encoding for Sass files.') do |encoding|
+        encoding_desc = if ::Sass::Util.ruby1_8?
+          'Does not work in ruby 1.8.'
+        else
+          'Specify the default encoding for Sass files.'
+        end
+        opts.on('-E encoding', encoding_desc) do |encoding|
+          if ::Sass::Util.ruby1_8?
+            warn "Specifying the encoding is not supported in ruby 1.8."
+            exit 1
+          else
             Encoding.default_external = encoding
           end
         end


### PR DESCRIPTION
Closes #875.
