### PR TITLE
Add warning that recursion is forbidden to the Sass Reference

### DIFF
--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -1974,7 +1974,13 @@ For example:
     @mixin highlighted-background { background-color: #fc0; }
     @mixin header-text { font-size: 20px; }
 
-Mixins that only define descendent selectors, can be safely mixed
+A mixin may not include itself, directly or indirectly. That is,
+mixin recursion is forbidden. Attempting to recurse will produce
+the following compilation error:
+
+    An @include loop has been found: xxxxx includes itself
+
+Mixins that only define descendent selectors can be safely mixed
 into the top most level of a document.
 
 ### Arguments {#mixin-arguments}


### PR DESCRIPTION
This documents the limitation I stumbled upon when writing a mixin.

I also fix a small grammar error in the following paragraph.
