### PR TITLE
Name the arithmetic operators, including modulo, in the Reference

### DIFF
--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -728,7 +728,7 @@ that it has special support for.
 #### Number Operations
 
 SassScript supports the standard arithmetic operations on numbers
-(`+`, `-`, `*`, `/`, `%`),
+(addition `+`, subtraction `-`, multiplication `*`, division `/`, and modulo `%`),
 and will automatically convert between units if it can:
 
     p {


### PR DESCRIPTION
I write the name of the “modulo” operator because I wanted to know how to do it in Sass, but couldn’t find out by searching the Sass Reference. Searching for `%` didn’t help, since that character is used all over in percentages.

I added the names of the other operators because the list would look weird if only one of the operators were named. And I suppose somebody might want to search for “division”, if they noticed that `/` is already used in CSS and wondered if Sass used a different character for division.
