### PR TITLE
Fix some warnings.

### DIFF
--- a/lib/sass/script/operation.rb
+++ b/lib/sass/script/operation.rb
@@ -35,7 +35,6 @@ module Sass::Script
 
     # @see Node#to_sass
     def to_sass(opts = {})
-      pred = Sass::Script::Parser.precedence_of(@operator)
       o1 = operand_to_sass @operand1, :left, opts
       o2 = operand_to_sass @operand2, :right, opts
       sep =

--- a/lib/sass/selector/sequence.rb
+++ b/lib/sass/selector/sequence.rb
@@ -255,7 +255,7 @@ module Sass
           # is a supersequence of the other, use that, otherwise give up.
           lcs = Sass::Util.lcs(ops1, ops2)
           return unless lcs == ops1 || lcs == ops2
-          res.unshift *(ops1.size > ops2.size ? ops1 : ops2).reverse
+          res.unshift(*(ops1.size > ops2.size ? ops1 : ops2).reverse)
           return res
         end
 

--- a/lib/sass/selector/simple_sequence.rb
+++ b/lib/sass/selector/simple_sequence.rb
@@ -134,9 +134,9 @@ module Sass
       #   by the time extension and unification happen,
       #   this exception will only ever be raised as a result of programmer error
       def unify(sels, other_subject)
-        return unless sseq = members.inject(sels) do |sseq, sel|
-          return unless sseq
-          sel.unify(sseq)
+        return unless sseq = members.inject(sels) do |_sseq, sel|
+          return unless _sseq
+          sel.unify(_sseq)
         end
         SimpleSequence.new(sseq, other_subject || subject?)
       end

--- a/lib/sass/tree/visitors/cssize.rb
+++ b/lib/sass/tree/visitors/cssize.rb
@@ -124,12 +124,12 @@ class Sass::Tree::Visitors::Cssize < Sass::Tree::Visitors::Base
       end
 
       sel = sseq.members
-      parent.resolved_rules.members.each do |seq|
-        if !seq.members.last.is_a?(Sass::Selector::SimpleSequence)
-          raise Sass::SyntaxError.new("#{seq} can't extend: invalid selector")
+      parent.resolved_rules.members.each do |_seq|
+        if !_seq.members.last.is_a?(Sass::Selector::SimpleSequence)
+          raise Sass::SyntaxError.new("#{_seq} can't extend: invalid selector")
         end
 
-        @extends[sel] = Extend.new(seq, sel, node, @parent_directives.dup, :not_found)
+        @extends[sel] = Extend.new(_seq, sel, node, @parent_directives.dup, :not_found)
       end
     end
 

--- a/lib/sass/tree/visitors/to_css.rb
+++ b/lib/sass/tree/visitors/to_css.rb
@@ -160,7 +160,6 @@ class Sass::Tree::Visitors::ToCss < Sass::Tree::Visitors::Base
 
       to_return = ''
       old_spaces = '  ' * @tabs
-      spaces = '  ' * (@tabs + 1)
       if node.style != :compressed
         if node.options[:debug_info] && !@in_directive
           to_return << visit(debug_info_rule(node.debug_info, node.options)) << "\n"


### PR DESCRIPTION
Fix some warnings.
- I removed a few unused variables, and renamed a few duplicated local variables.
- Fix a warning for `"*" interpreted as argument prefix`
