### PR TITLE
Use system temporary directory as default cache_location

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -14,6 +14,8 @@
 * Fixed a bug in the output of lists containing unary plus or minus
   operations during sass <=> scss conversion.
 
+* Use system temporary directory for default cache_location (thanks Osric Wilkinson)
+
 ## 3.2.10
 
 * Use the Sass logger infrastructure for `@debug` directives.

--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -1,5 +1,6 @@
 require 'set'
 require 'digest/sha1'
+require 'tmpdir'
 require 'sass/cache_stores'
 require 'sass/tree/node'
 require 'sass/tree/root_node'
@@ -155,7 +156,7 @@ module Sass
       :style => :nested,
       :load_paths => ['.'],
       :cache => true,
-      :cache_location => './.sass-cache',
+      :cache_location => File.join(Dir::tmpdir, '.sass-cache'),
       :syntax => :sass,
       :filesystem_importer => Sass::Importers::Filesystem
     }.freeze


### PR DESCRIPTION
This is actually to fix a bug in the Netbeans plug-in, where @import doesn't work because sass tries to create a directory in \Program Files\Netbeans, and it can't because the user doesn't have Administrator access.

The patch uses the builtin Dir::tmpdir to find the system temporary directory, and then uses File.join to build the cache path. This replaces the default behaviour which creates a directory wherever sass happens to be running.
