### PR TITLE
Automatic workaround for other CSS counters bug on IE7

### DIFF
--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -1488,7 +1488,7 @@ module Sass::Script
     end
     declare :if, [:condition, :if_true, :if_false]
 
-    # This function only exists as a workaround for IE7's [`content:counter`
+    # This function only exists as a workaround for IE7's [`content: counter`
     # bug][bug]. It works identically to any other plain-CSS function, except it
     # avoids adding spaces between the argument commas.
     #
@@ -1502,6 +1502,21 @@ module Sass::Script
       Sass::Script::String.new("counter(#{args.map {|a| a.to_s(options)}.join(',')})")
     end
     declare :counter, [], :var_args => true
+
+    # This functions is another workaround for IE7's [`content: counter`
+    # bug][bug]. Just as \{#counter counter} it simply avoids adding spaces
+    # between the argument commas.
+    #
+    # [bug]: http://jes.st/2013/ie7s-css-breaking-content-counter-bug/
+    #
+    # @example
+    #   counters(item, ".") => counters(item,".")
+    # @overload counters($args...)
+    # @return [String]
+    def counters(*args)
+      Sass::Script::String.new("counters(#{args.map {|a| a.to_s(options)}.join(',')})")
+    end
+    declare :counters, [], :var_args => true
 
     private
 

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -1046,6 +1046,12 @@ MSG
     assert_equal('counter(item,".")', evaluate('counter(item,".")'))
   end
 
+  def test_counters
+    assert_equal("counters(foo)", evaluate("counters(foo)"))
+    assert_equal('counters(item,".")', evaluate('counters(item, ".")'))
+    assert_equal('counters(item,".")', evaluate('counters(item,".")'))
+  end
+
   def test_keyword_args_rgb
     assert_equal(%Q{white}, evaluate("rgb($red: 255, $green: 255, $blue: 255)"))
   end


### PR DESCRIPTION
This P/R addresses an issue described in #744 but related to `counters` (not `counter`). The functions do slightly different things of course, but they cause the same [bug](http://jes.st/2013/ie7s-css-breaking-content-counter-bug/) in IE7.

A walkaround for `counter` has already been done (i.e. 1556fe288b5aa96a777291a208998deb31522a33). I simply modify it and use for the other function. :)
