### PR TITLE
Variable argument maps

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -167,6 +167,26 @@ Produces:
       font-size: 1.2em;
     }
 
+#### Variable Keyword Arguments
+
+Maps can be passed as variable arguments, just like lists. For example, if
+`$map` is `(lightness: 10%, blue: -30%)`, you can write `scale-color($color,
+$map...)` and it will do the same thing as `scale-color($color, $lightness: 10%,
+$blue: 30%)`. To pass a variable argument list and map at the same time, just do
+the list first, then the map, as in `fn($list..., $map...)`.
+
+You can also access the keywords passed to a function that accepts a variable
+argument list using the new {Sass::Script::Functions#keywords `keywords($args)`
+function}. For example:
+
+    @function create-map($args...) {
+      @return keywords($args);
+    }
+
+    create-map($foo: 10, $bar: 11); // returns (foo: 10, bar: 11)
+
+#### Lists of Pairs as Maps
+
 The new map functions work on lists of pairs as well, for the time being. This
 feature exists to help libraries that previously used lists of pairs to simulate
 maps. These libraries can now use map functions internally without introducing

--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -170,8 +170,8 @@ Produces:
 #### Variable Keyword Arguments
 
 Maps can be passed as variable arguments, just like lists. For example, if
-`$map` is `(lightness: 10%, blue: -30%)`, you can write `scale-color($color,
-$map...)` and it will do the same thing as `scale-color($color, $lightness: 10%,
+`$map` is `(alpha: -10%, "blue": 30%)`, you can write `scale-color($color,
+$map...)` and it will do the same thing as `scale-color($color, $alpha: -10%,
 $blue: 30%)`. To pass a variable argument list and map at the same time, just do
 the list first, then the map, as in `fn($list..., $map...)`.
 

--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -2212,12 +2212,13 @@ Since the named arguments are variable names, underscores and dashes can be used
 
 #### Variable Arguments
 
-Sometimes it makes sense for a mixin to take an unknown number of arguments. For
-example, a mixin for creating box shadows might take any number of shadows as
-arguments. For these situations, Sass supports "variable arguments," which are
-arguments at the end of a mixin declaration that take all leftover arguments and
-package them up as a [list](#lists). These arguments look just like normal
-arguments, but are followed by `...`. For example:
+Sometimes it makes sense for a mixin or function to take an unknown number of
+arguments. For example, a mixin for creating box shadows might take any number
+of shadows as arguments. For these situations, Sass supports "variable
+arguments," which are arguments at the end of a mixin or function declaration
+that take all leftover arguments and package them up as a [list](#lists). These
+arguments look just like normal arguments, but are followed by `...`. For
+example:
 
     @mixin box-shadow($shadows...) {
       -moz-box-shadow: $shadows;
@@ -2237,8 +2238,14 @@ is compiled to:
       box-shadow: 0px 4px 5px #666, 2px 6px 10px #999;
     }
 
+Variable arguments also contain any keyword arguments passed to the mixin or
+function. These can be accessed using the {Sass::Script::Functions#keywords
+`keywords($args)` function}, which returns them as a map from strings (without
+`$`) to values.
+
 Variable arguments can also be used when calling a mixin. Using the same syntax,
 you can expand a list of values so that each value is passed as a separate
+argument, or expand a map of values so that each pair is treated as a keyword
 argument. For example:
 
     @mixin colors($text, $background, $border) {
@@ -2252,6 +2259,11 @@ argument. For example:
       @include colors($values...);
     }
 
+    $value-map: (text: #00ff00, background: #0000ff, border: #ff0000);
+    .secondary {
+      @include colors($value-map...);
+    }
+
 is compiled to:
 
     .primary {
@@ -2260,9 +2272,18 @@ is compiled to:
       border-color: #0000ff;
     }
 
+    .secondary {
+      color: #0000ff;
+      background-color: #ff0000;
+      border-color: #00ff00;
+    }
+
+You can pass both an argument list and a map as long as the list comes before
+the map, as in `@include colors($values..., $map...)`.
+
 You can use variable arguments to wrap a mixin and add additional styles without
-changing the argument signature of the mixin. If you do so, even keyword
-arguments will get passed through to the wrapped mixin. For example:
+changing the argument signature of the mixin. If you do, keyword arguments will
+get directly passed through to the wrapped mixin. For example:
 
     @mixin wrapped-stylish-mixin($args...) {
       font-weight: bold;

--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -1060,9 +1060,10 @@ WARNING
       raise SyntaxError.new("Invalid mixin include \"#{line.text}\".") if name.nil?
 
       offset = line.offset + line.text.size - arg_string.size
-      args, keywords, splat = Script::Parser.new(arg_string.strip, @line, to_parser_offset(offset), @options).
-        parse_mixin_include_arglist
-      Tree::MixinNode.new(name, args, keywords, splat)
+      args, keywords, splat, kwarg_splat =
+        Script::Parser.new(arg_string.strip, @line, to_parser_offset(offset), @options).
+          parse_mixin_include_arglist
+      Tree::MixinNode.new(name, args, keywords, splat, kwarg_splat)
     end
 
     FUNCTION_RE = /^@function\s*(#{Sass::SCSS::RX::IDENT})(.*)$/

--- a/lib/sass/script/tree/funcall.rb
+++ b/lib/sass/script/tree/funcall.rb
@@ -25,7 +25,7 @@ module Sass::Script::Tree
 
     # The first splat argument for this function, if one exists.
     #
-    # This could be a lsit of positional arguments, a map of keyword
+    # This could be a list of positional arguments, a map of keyword
     # arguments, or an arglist containing both.
     #
     # @return [Node?]

--- a/lib/sass/scss/parser.rb
+++ b/lib/sass/scss/parser.rb
@@ -209,9 +209,9 @@ module Sass
 
       def include_directive(start_pos)
         name = tok! IDENT
-        args, keywords, splat = sass_script(:parse_mixin_include_arglist)
+        args, keywords, splat, kwarg_splat = sass_script(:parse_mixin_include_arglist)
         ss
-        include_node = node(Sass::Tree::MixinNode.new(name, args, keywords, splat), start_pos)
+        include_node = node(Sass::Tree::MixinNode.new(name, args, keywords, splat, kwarg_splat), start_pos)
         if tok?(/\{/)
           include_node.has_children = true
           block(include_node, :directive)

--- a/lib/sass/tree/mixin_node.rb
+++ b/lib/sass/tree/mixin_node.rb
@@ -21,7 +21,7 @@ module Sass::Tree
 
     # The first splat argument for this mixin, if one exists.
     #
-    # This could be a lsit of positional arguments, a map of keyword
+    # This could be a list of positional arguments, a map of keyword
     # arguments, or an arglist containing both.
     #
     # @return [Node?]

--- a/lib/sass/tree/mixin_node.rb
+++ b/lib/sass/tree/mixin_node.rb
@@ -19,20 +19,33 @@ module Sass::Tree
     # @return [{String => Script::Tree::Node}]
     attr_accessor :keywords
 
-    # The splat argument for this mixin, if one exists.
+    # The first splat argument for this mixin, if one exists.
     #
-    # @return [Script::Tree::Node?]
+    # This could be a lsit of positional arguments, a map of keyword
+    # arguments, or an arglist containing both.
+    #
+    # @return [Node?]
     attr_accessor :splat
+
+    # The second splat argument for this mixin, if one exists.
+    #
+    # If this exists, it's always a map of keyword arguments, and
+    # \{#splat} is always either a list or an arglist.
+    #
+    # @return [Node?]
+    attr_accessor :kwarg_splat
 
     # @param name [String] The name of the mixin
     # @param args [Array<Script::Tree::Node>] See \{#args}
     # @param splat [Script::Tree::Node] See \{#splat}
+    # @param kwarg_splat [Script::Tree::Node] See \{#kwarg_splat}
     # @param keywords [{String => Script::Tree::Node}] See \{#keywords}
-    def initialize(name, args, keywords, splat)
+    def initialize(name, args, keywords, splat, kwarg_splat)
       @name = name
       @args = args
       @keywords = keywords
       @splat = splat
+      @kwarg_splat = kwarg_splat
       super()
     end
   end

--- a/lib/sass/tree/visitors/convert.rb
+++ b/lib/sass/tree/visitors/convert.rb
@@ -208,6 +208,7 @@ class Sass::Tree::Visitors::Convert < Sass::Tree::Visitors::Base
       if node.splat
         splat = (args.empty? && keywords.empty?) ? "" : ", "
         splat = "#{splat}#{arg_to_sass[node.splat]}..."
+        splat = "#{splat}, #{node.kwarg_splat.inspect}..." if node.kwarg_splat
       end
       arglist = "(#{args}#{', ' unless args.empty? || keywords.empty?}#{keywords}#{splat})"
     end

--- a/lib/sass/tree/visitors/perform.rb
+++ b/lib/sass/tree/visitors/perform.rb
@@ -66,7 +66,7 @@ class Sass::Tree::Visitors::Perform < Sass::Tree::Visitors::Base
       end
 
       if callable.splat
-        rest = args[callable.args.length..-1]
+        rest = args[callable.args.length..-1] || []
         arg_list = Sass::Script::Value::ArgList.new(rest, keywords.dup, splat_sep)
         arg_list.options = env.options
         env.set_local_var(callable.splat.name, arg_list)

--- a/lib/sass/tree/visitors/perform.rb
+++ b/lib/sass/tree/visitors/perform.rb
@@ -1,89 +1,135 @@
 # A visitor for converting a dynamic Sass tree into a static Sass tree.
 class Sass::Tree::Visitors::Perform < Sass::Tree::Visitors::Base
-  # @param root [Tree::Node] The root node of the tree to visit.
-  # @param environment [Sass::Environment] The lexical environment.
-  # @return [Tree::Node] The resulting tree of static nodes.
-  def self.visit(root, environment = nil)
-    new(environment).send(:visit, root)
-  end
+  class << self
+    # @param root [Tree::Node] The root node of the tree to visit.
+    # @param environment [Sass::Environment] The lexical environment.
+    # @return [Tree::Node] The resulting tree of static nodes.
+    def visit(root, environment = nil)
+      new(environment).send(:visit, root)
+    end
 
-  # @api private
-  def self.perform_arguments(callable, args, keywords, splat)
-    desc = "#{callable.type.capitalize} #{callable.name}"
-    downcase_desc = "#{callable.type} #{callable.name}"
+    # @api private
+    def perform_arguments(callable, args, keywords, splat)
+      desc = "#{callable.type.capitalize} #{callable.name}"
+      downcase_desc = "#{callable.type} #{callable.name}"
 
-    begin
-      unless keywords.empty?
-        unknown_args = Sass::Util.array_minus(keywords.keys,
-          callable.args.map {|var| var.first.underscored_name})
-        if callable.splat && unknown_args.include?(callable.splat.underscored_name)
-          raise Sass::SyntaxError.new("Argument $#{callable.splat.name} of #{downcase_desc} cannot be used as a named argument.")
-        elsif unknown_args.any?
-          description = unknown_args.length > 1 ? 'the following arguments:' : 'an argument named'
-          raise Sass::SyntaxError.new("#{desc} doesn't have #{description} #{unknown_args.map {|name| "$#{name}"}.join ', '}.")
+      # If variable arguments were passed, there won't be any explicit keywords.
+      if splat && !splat.keywords.empty?
+        old_keywords_accessed = splat.keywords_accessed
+        keywords = splat.keywords
+        splat.keywords_accessed = old_keywords_accessed
+      end
+
+      begin
+        unless keywords.empty?
+          unknown_args = Sass::Util.array_minus(keywords.keys,
+            callable.args.map {|var| var.first.underscored_name})
+          if callable.splat && unknown_args.include?(callable.splat.underscored_name)
+            raise Sass::SyntaxError.new("Argument $#{callable.splat.name} of #{downcase_desc} cannot be used as a named argument.")
+          elsif unknown_args.any?
+            description = unknown_args.length > 1 ? 'the following arguments:' : 'an argument named'
+            raise Sass::SyntaxError.new("#{desc} doesn't have #{description} #{unknown_args.map {|name| "$#{name}"}.join ', '}.")
+          end
         end
-      end
-    rescue Sass::SyntaxError => keyword_exception
-    end
-
-    # If there's no splat, raise the keyword exception immediately. The actual
-    # raising happens in the ensure clause at the end of this function.
-    return if keyword_exception && !callable.splat
-
-    if args.size > callable.args.size && !callable.splat
-      takes = callable.args.size
-      passed = args.size
-      raise Sass::SyntaxError.new(
-        "#{desc} takes #{takes} argument#{'s' unless takes == 1} " +
-        "but #{passed} #{passed == 1 ? 'was' : 'were'} passed.")
-    end
-
-    splat_sep = :comma
-    if splat
-      args += splat.to_a
-      splat_sep = splat.separator if splat.is_a?(Sass::Script::Value::List)
-      # If the splat argument exists, there won't be any keywords passed in
-      # manually, so we can safely overwrite rather than merge here.
-      keywords = splat.keywords if splat.is_a?(Sass::Script::Value::ArgList)
-    end
-
-    keywords = keywords.dup
-    env = Sass::Environment.new(callable.environment)
-    callable.args.zip(args[0...callable.args.length]) do |(var, default), value|
-      if value && keywords.include?(var.underscored_name)
-        raise Sass::SyntaxError.new("#{desc} was passed argument $#{var.name} both by position and by name.")
+      rescue Sass::SyntaxError => keyword_exception
       end
 
-      value ||= keywords.delete(var.underscored_name)
-      value ||= default && default.perform(env)
-      raise Sass::SyntaxError.new("#{desc} is missing argument #{var.inspect}.") unless value
-      env.set_local_var(var.name, value)
+      # If there's no splat, raise the keyword exception immediately. The actual
+      # raising happens in the ensure clause at the end of this function.
+      return if keyword_exception && !callable.splat
+
+      if args.size > callable.args.size && !callable.splat
+        takes = callable.args.size
+        passed = args.size
+        raise Sass::SyntaxError.new(
+          "#{desc} takes #{takes} argument#{'s' unless takes == 1} " +
+          "but #{passed} #{passed == 1 ? 'was' : 'were'} passed.")
+      end
+
+      splat_sep = :comma
+      if splat
+        args += splat.to_a
+        splat_sep = splat.separator
+      end
+
+      keywords = keywords.dup
+      env = Sass::Environment.new(callable.environment)
+      callable.args.zip(args[0...callable.args.length]) do |(var, default), value|
+        if value && keywords.include?(var.underscored_name)
+          raise Sass::SyntaxError.new("#{desc} was passed argument $#{var.name} both by position and by name.")
+        end
+
+        value ||= keywords.delete(var.underscored_name)
+        value ||= default && default.perform(env)
+        raise Sass::SyntaxError.new("#{desc} is missing argument #{var.inspect}.") unless value
+        env.set_local_var(var.name, value)
+      end
+
+      if callable.splat
+        rest = args[callable.args.length..-1]
+        arg_list = Sass::Script::Value::ArgList.new(rest, keywords.dup, splat_sep)
+        arg_list.options = env.options
+        env.set_local_var(callable.splat.name, arg_list)
+      end
+
+      yield env
+    rescue Exception => e
+    ensure
+      # If there's a keyword exception, we don't want to throw it immediately,
+      # because the invalid keywords may be part of a glob argument that should be
+      # passed on to another function. So we only raise it if we reach the end of
+      # this function *and* the keywords attached to the argument list glob object
+      # haven't been accessed.
+      #
+      # The keyword exception takes precedence over any Sass errors, but not over
+      # non-Sass exceptions.
+      if keyword_exception &&
+          !(arg_list && arg_list.keywords_accessed) &&
+          (e.nil? || e.is_a?(Sass::SyntaxError))
+        raise keyword_exception
+      elsif e
+        raise e
+      end
     end
 
-    if callable.splat
-      rest = args[callable.args.length..-1]
-      arg_list = Sass::Script::Value::ArgList.new(rest, keywords.dup, splat_sep)
-      arg_list.options = env.options
-      env.set_local_var(callable.splat.name, arg_list)
+    # @api private
+    # @return [Sass::Script::Value::ArgList]
+    def perform_splat(splat, kwarg_splat, environment)
+      return unless splat
+      splat = splat.perform(environment)
+      unless kwarg_splat
+        return splat if splat.is_a?(Sass::Script::Value::ArgList)
+        if splat.is_a?(Sass::Script::Value::Map)
+          args = []
+          kwargs = arg_hash(splat)
+        else
+          args = splat.to_a
+          kwargs = {}
+        end
+        return Sass::Script::Value::ArgList.new(args, kwargs, splat.separator || :comma)
+      end
+
+      kwarg_splat = kwarg_splat.perform(environment)
+      unless kwarg_splat.is_a?(Sass::Script::Value::Map)
+        raise Sass::SyntaxError.new("Variable keyword arguments must be a map (was #{kwarg_splat.inspect}).")
+      end
+
+      if splat.is_a?(Sass::Script::Value::ArgList)
+        return Sass::Script::Value::ArgList.new(
+          splat.value, splat.keywords.merge(arg_hash(kwarg_splat)), splat.separator)
+      else
+        return Sass::Script::Value::ArgList.new(splat.to_a, arg_hash(kwarg_splat), splat.separator)
+      end
     end
 
-    yield env
-  rescue Exception => e
-  ensure
-    # If there's a keyword exception, we don't want to throw it immediately,
-    # because the invalid keywords may be part of a glob argument that should be
-    # passed on to another function. So we only raise it if we reach the end of
-    # this function *and* the keywords attached to the argument list glob object
-    # haven't been accessed.
-    #
-    # The keyword exception takes precedence over any Sass errors, but not over
-    # non-Sass exceptions.
-    if keyword_exception &&
-        !(arg_list && arg_list.keywords_accessed) &&
-        (e.nil? || e.is_a?(Sass::SyntaxError))
-      raise keyword_exception
-    elsif e
-      raise e
+    private
+
+    def arg_hash(map)
+      Sass::Util.map_keys(map.to_h) do |key|
+        next key.value if key.is_a?(Sass::Script::Value::String)
+        raise Sass::SyntaxError.new("Variable keyword argument map must have string keys.\n" +
+          "#{key.inspect} is not a string in #{map.inspect}.");
+      end
     end
   end
 
@@ -267,7 +313,7 @@ class Sass::Tree::Visitors::Perform < Sass::Tree::Visitors::Base
 
       args = node.args.map {|a| a.perform(@environment)}
       keywords = Sass::Util.map_hash(node.keywords) {|k, v| [k, v.perform(@environment)]}
-      splat = node.splat.perform(@environment) if node.splat
+      splat = self.class.perform_splat(node.splat, node.kwarg_splat, @environment)
 
       self.class.perform_arguments(mixin, args, keywords, splat) do |env|
         env.caller = Sass::Environment.new(@environment)

--- a/test/sass/conversion_test.rb
+++ b/test/sass/conversion_test.rb
@@ -1722,7 +1722,7 @@ SASS
 SCSS
   end
 
-  def test_function_var_kwargs
+  def test_function_var_kwargs_with_list
     assert_scss_to_sass <<SASS, <<SCSS
 @function foo($a: b, $c: d)
   @return $a, $c

--- a/test/sass/conversion_test.rb
+++ b/test/sass/conversion_test.rb
@@ -1621,6 +1621,26 @@ SASS
 SCSS
   end
 
+  def test_mixin_var_kwargs
+    assert_scss_to_sass <<SASS, <<SCSS
+=foo($a: b, $c: d)
+  a: $a
+  c: $c
+
+.foo
+  +foo($list..., $map...)
+SASS
+@mixin foo($a: b, $c: d) {
+  a: $a;
+  c: $c;
+}
+
+.foo {
+  @include foo($list..., $map...);
+}
+SCSS
+  end
+
   def test_function_var_args
     assert_scss_to_sass <<SASS, <<SCSS
 @function foo($args...)
@@ -1644,6 +1664,24 @@ SASS
 .foo {
   a: foo($list...);
   b: bar(1, $list...);
+}
+SCSS
+  end
+
+  def test_function_var_kwargs
+    assert_scss_to_sass <<SASS, <<SCSS
+@function foo($a: b, $c: d)
+  @return foo
+
+.foo
+  a: foo($list..., $map...)
+SASS
+@function foo($a: b, $c: d) {
+  @return foo;
+}
+
+.foo {
+  a: foo($list..., $map...);
 }
 SCSS
   end
@@ -1680,6 +1718,24 @@ SASS
   @at-root .bar {
     a: b;
   }
+}
+SCSS
+  end
+
+  def test_function_var_kwargs
+    assert_scss_to_sass <<SASS, <<SCSS
+@function foo($a: b, $c: d)
+  @return $a, $c
+
+.foo
+  a: foo($list..., $map...)
+SASS
+@function foo($a: b, $c: d) {
+  @return $a, $c;
+}
+
+.foo {
+  a: foo($list..., $map...);
 }
 SCSS
   end

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -3282,6 +3282,26 @@ SASS
       ], e.sass_backtrace)
   end
 
+  def test_mixin_with_args_and_varargs_passed_no_var_args
+    assert_equal <<CSS, render(<<SASS, :syntax => :scss)
+.foo {
+  a: 1;
+  b: 2;
+  c: 3; }
+CSS
+@mixin three-or-more-args($a, $b, $c, $rest...) {
+  a: $a;
+  b: $b;
+  c: $c;
+}
+
+.foo {
+  @include three-or-more-args($a: 1, $b: 2, $c: 3);
+}
+SASS
+
+  end
+
   private
 
   def assert_hash_has(hash, expected)

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -1350,6 +1350,12 @@ WARNING
     end
   end
 
+  def test_keywords
+    # The actual functionality is tested in tests where real arglists are passed.
+    assert_error_message("12 is not a variable argument list for `keywords'", "keywords(12)")
+    assert_error_message("(1 2 3) is not a variable argument list for `keywords'", "keywords(1 2 3)")
+  end
+
   def test_partial_list_of_pairs_doesnt_work_as_a_map
     assert_raises(Sass::SyntaxError) {evaluate("map-get((foo bar, baz bang, bip), 1)")}
     assert_raises(Sass::SyntaxError) {evaluate("map-get((foo bar, baz bang, bip bap bop), 1)")}


### PR DESCRIPTION
Add support for passing maps as variable arguments and using the `keywords()` function to access them.
