### PR TITLE
Add more compression for numbers (implementing issue #847)

### DIFF
--- a/lib/sass/script/value/number.rb
+++ b/lib/sass/script/value/number.rb
@@ -262,6 +262,7 @@ module Sass::Script::Value
     # @raise [Sass::SyntaxError] if this number has units that can't be used in CSS
     #   (e.g. `px*in`)
     def to_s(opts = {})
+      return value.to_s if opts[:style] == :compressed && int? && to_i == 0
       return original if original
       raise Sass::SyntaxError.new("#{inspect} isn't a valid CSS value.") unless legal_units?
       inspect

--- a/lib/sass/script/value/number.rb
+++ b/lib/sass/script/value/number.rb
@@ -262,7 +262,11 @@ module Sass::Script::Value
     # @raise [Sass::SyntaxError] if this number has units that can't be used in CSS
     #   (e.g. `px*in`)
     def to_s(opts = {})
-      return value.to_s if opts[:style] == :compressed && int? && to_i == 0
+      if opts[:style] == :compressed
+        return '0' if int? && to_i == 0 # remove units from integer zeros
+        return original.sub(/^0\./, '.') if original
+      end
+
       return original if original
       raise Sass::SyntaxError.new("#{inspect} isn't a valid CSS value.") unless legal_units?
       inspect

--- a/lib/sass/tree/visitors/perform.rb
+++ b/lib/sass/tree/visitors/perform.rb
@@ -303,7 +303,7 @@ class Sass::Tree::Visitors::Perform < Sass::Tree::Visitors::Base
   def visit_prop(node)
     node.resolved_name = run_interp(node.name)
     val = node.value.perform(@environment)
-    node.resolved_value = val.to_s
+    node.resolved_value = val.to_s(:style => node.style)
     node.value_source_range = val.source_range if val.source_range
     yield
   end

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -2661,6 +2661,14 @@ RESULT
 SOURCE
   end
 
+  def test_compressed_integer_zeros
+    assert_equal ".foo{width:0;height:10em}\n", render(<<SOURCE, :style => :compressed)
+.foo
+  width: 0px
+  height: 10em
+SOURCE
+  end
+
   def test_comment_with_crazy_indentation
     assert_equal(<<CSS, render(<<SASS))
 /* This is a loud comment:

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -2669,6 +2669,15 @@ SOURCE
 SOURCE
   end
 
+  def test_compressed_leading_zero_floats
+    assert_equal ".foo{width:.2px;height:.5em;max-height:34.5em}\n", render(<<SOURCE, :style => :compressed)
+.foo
+  width: 0.2px
+  height: 0.5em
+  max-height: 34.5em
+SOURCE
+  end
+
   def test_comment_with_crazy_indentation
     assert_equal(<<CSS, render(<<SASS))
 /* This is a loud comment:


### PR DESCRIPTION
As requested in issue #847, this change implements the following when outputting css in `:compressed` mode:
- Removing the leading zero from floating-point numbers (`0.5em` -> `.5em`)
- Removing the units from 0 (`0px` -> `0`)

These are implemented in the YUI compressor but previously missing from sass.
