### PR TITLE
Atomically write to the Sass cache.

### DIFF
--- a/lib/sass/cache_stores/filesystem.rb
+++ b/lib/sass/cache_stores/filesystem.rb
@@ -36,7 +36,7 @@ module Sass
         # return if File.exists?(File.dirname(compiled_filename)) && !File.writable?(File.dirname(compiled_filename))
         # return if File.exists?(compiled_filename) && !File.writable?(compiled_filename)
         FileUtils.mkdir_p(File.dirname(compiled_filename))
-        File.open(compiled_filename, "wb") do |f|
+        Sass::Util.atomic_create_and_write_file(compiled_filename) do |f|
           f.puts(version)
           f.puts(sha)
           f.write(contents)

--- a/lib/sass/plugin/staleness_checker.rb
+++ b/lib/sass/plugin/staleness_checker.rb
@@ -24,11 +24,13 @@ module Sass
     #   as its instance-level caches are never explicitly expired.
     class StalenessChecker
       @dependencies_cache = {}
+      @dependency_cache_mutex = Mutex.new
 
       class << self
         # TODO: attach this to a compiler instance.
         # @private
         attr_accessor :dependencies_cache
+        attr_reader :dependency_cache_mutex
       end
 
       # Creates a new StalenessChecker
@@ -37,8 +39,6 @@ module Sass
       # @param options [{Symbol => Object}]
       #   See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
       def initialize(options)
-        @dependencies = self.class.dependencies_cache
-
         # URIs that are being actively checked for staleness. Protects against
         # import loops.
         @actively_checking = Set.new
@@ -131,7 +131,7 @@ module Sass
           begin
             mtime = importer.mtime(uri, @options)
             if mtime.nil?
-              @dependencies.delete([uri, importer])
+              with_dependency_cache {|cache| cache.delete([uri, importer])}
               nil
             else
               mtime
@@ -140,11 +140,14 @@ module Sass
       end
 
       def dependencies(uri, importer)
-        stored_mtime, dependencies = Sass::Util.destructure(@dependencies[[uri, importer]])
+        stored_mtime, dependencies =
+          with_dependency_cache {|cache| Sass::Util.destructure(cache[[uri, importer]])}
 
         if !stored_mtime || stored_mtime < mtime(uri, importer)
           dependencies = compute_dependencies(uri, importer)
-          @dependencies[[uri, importer]] = [mtime(uri, importer), dependencies]
+          with_dependency_cache do |cache|
+            cache[[uri, importer]] = [mtime(uri, importer), dependencies]
+          end
         end
 
         dependencies
@@ -177,6 +180,17 @@ module Sass
 
       def tree(uri, importer)
         @parse_trees[[uri, importer]] ||= importer.find(uri, @options).to_tree
+      end
+
+      # Get access to the global dependency cache in a threadsafe manner.
+      # Inside the block, no other thread can access the dependency cache.
+      #
+      # @yieldparam cache
+      # @return The value returned by the block to which this method yields
+      def with_dependency_cache
+        StalenessChecker.dependency_cache_mutex.synchronize do
+          yield StalenessChecker.dependencies_cache
+        end
       end
     end
   end

--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -868,6 +868,32 @@ MSG
       end
     end
 
+    # This creates a temp file and yields it for writing. When the
+    # write is complete, the file is moved into the desired location
+    # the atomicity of this operation is provided by the filesystem's
+    # rename operation.
+    #
+    # @param filename The file to write to.
+    # @yieldparam tmpfile The temp file that can be written to.
+    def atomic_create_and_write_file(filename)
+      require 'tempfile'
+      tmpfile = Tempfile.new(File.basename(filename), File.dirname(filename))
+      tmp_path = tmpfile.path
+      begin
+        begin
+          tmpfile.binmode if tmpfile.respond_to?(:binmode)
+          yield tmpfile
+        ensure
+          tmpfile.close
+        end
+        File.rename tmpfile.path, filename
+      ensure
+        # remove the tempfile if it still exists, presumably due to an error during write
+        FileUtils.rm_f tmp_path
+      end
+      nil
+    end
+
     private
 
     # Calculates the memoization table for the Least Common Subsequence algorithm.

--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -869,29 +869,26 @@ MSG
     end
 
     # This creates a temp file and yields it for writing. When the
-    # write is complete, the file is moved into the desired location
-    # the atomicity of this operation is provided by the filesystem's
+    # write is complete, the file is moved into the desired location.
+    # The atomicity of this operation is provided by the filesystem's
     # rename operation.
     #
-    # @param filename The file to write to.
-    # @yieldparam tmpfile The temp file that can be written to.
+    # @param filename [String] The file to write to.
+    # @yieldparam tmpfile [Tempfile] The temp file that can be written to.
+    # @return The value returned by the block.
     def atomic_create_and_write_file(filename)
       require 'tempfile'
       tmpfile = Tempfile.new(File.basename(filename), File.dirname(filename))
       tmp_path = tmpfile.path
-      begin
-        begin
-          tmpfile.binmode if tmpfile.respond_to?(:binmode)
-          yield tmpfile
-        ensure
-          tmpfile.close
-        end
-        File.rename tmpfile.path, filename
-      ensure
-        # remove the tempfile if it still exists, presumably due to an error during write
-        FileUtils.rm_f tmp_path
-      end
-      nil
+      tmpfile.binmode if tmpfile.respond_to?(:binmode)
+      result = yield tmpfile
+      File.rename tmpfile.path, filename
+      result
+    ensure
+      # close and remove the tempfile if it still exists,
+      # presumably due to an error during write
+      tmpfile.close if tmpfile
+      tmpfile.unlink if tmpfile
     end
 
     private

--- a/test/sass/util_test.rb
+++ b/test/sass/util_test.rb
@@ -349,13 +349,11 @@ class UtilTest < Test::Unit::TestCase
     filename = File.join(Dir.tmpdir, "test_atomic_exception")
     FileUtils.rm_f(filename)
     tmp_filename = nil
-    begin
+    assert_raises FakeError do
       atomic_create_and_write_file(filename) do |f|
         tmp_filename = f.path
         raise FakeError.new "Borken"
       end
-    rescue FakeError
-      # pass
     end
     assert !File.exist?(filename)
     assert !File.exist?(tmp_filename)


### PR DESCRIPTION
This fixes a concurrency issue with how Sass writes and reads files from the Sass cache.
