### PR TITLE
Make access to the dependency cache threadsafe.

### DIFF
--- a/lib/sass/plugin/staleness_checker.rb
+++ b/lib/sass/plugin/staleness_checker.rb
@@ -185,7 +185,7 @@ module Sass
       # Get access to the global dependency cache in a threadsafe manner.
       # Inside the block, no other thread can access the dependency cache.
       #
-      # @yieldparam cache
+      # @yieldparam cache [Hash] The hash that is the global dependency cache
       # @return The value returned by the block to which this method yields
       def with_dependency_cache
         StalenessChecker.dependency_cache_mutex.synchronize do

--- a/lib/sass/plugin/staleness_checker.rb
+++ b/lib/sass/plugin/staleness_checker.rb
@@ -24,11 +24,13 @@ module Sass
     #   as its instance-level caches are never explicitly expired.
     class StalenessChecker
       @dependencies_cache = {}
+      @dependency_cache_mutex = Mutex.new
 
       class << self
         # TODO: attach this to a compiler instance.
         # @private
         attr_accessor :dependencies_cache
+        attr_reader :dependency_cache_mutex
       end
 
       # Creates a new StalenessChecker
@@ -37,8 +39,6 @@ module Sass
       # @param options [{Symbol => Object}]
       #   See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
       def initialize(options)
-        @dependencies = self.class.dependencies_cache
-
         # URIs that are being actively checked for staleness. Protects against
         # import loops.
         @actively_checking = Set.new
@@ -131,7 +131,7 @@ module Sass
           begin
             mtime = importer.mtime(uri, @options)
             if mtime.nil?
-              @dependencies.delete([uri, importer])
+              with_dependency_cache {|cache| cache.delete([uri, importer])}
               nil
             else
               mtime
@@ -140,11 +140,14 @@ module Sass
       end
 
       def dependencies(uri, importer)
-        stored_mtime, dependencies = Sass::Util.destructure(@dependencies[[uri, importer]])
+        stored_mtime, dependencies =
+          with_dependency_cache {|cache| Sass::Util.destructure(cache[[uri, importer]])}
 
         if !stored_mtime || stored_mtime < mtime(uri, importer)
           dependencies = compute_dependencies(uri, importer)
-          @dependencies[[uri, importer]] = [mtime(uri, importer), dependencies]
+          with_dependency_cache do |cache|
+            cache[[uri, importer]] = [mtime(uri, importer), dependencies]
+          end
         end
 
         dependencies
@@ -177,6 +180,17 @@ module Sass
 
       def tree(uri, importer)
         @parse_trees[[uri, importer]] ||= importer.find(uri, @options).to_tree
+      end
+
+      # Get access to the global dependency cache in a threadsafe manner.
+      # Inside the block, no other thread can access the dependency cache.
+      #
+      # @yieldparam cache
+      # @return The value returned by the block to which this method yields
+      def with_dependency_cache
+        StalenessChecker.dependency_cache_mutex.synchronize do
+          yield StalenessChecker.dependencies_cache
+        end
       end
     end
   end


### PR DESCRIPTION
This wraps all accesses to the dependency cache in a mutex so that the global thread-unsafe hash object won't trigger hangs in JRuby.
