### PR TITLE
added test for script & when the parent is created in a mixin

### DIFF
--- a/test/sass/scss/scss_test.rb
+++ b/test/sass/scss/scss_test.rb
@@ -2025,6 +2025,25 @@ CSS
 SCSS
   end
 
+  def test_selector_script_through_mixin_with_parent_created_in_mixin
+	assert_equal(<<CSS, render(<<SCSS))
+.foo {
+  content: ".foo"; }
+CSS
+@mixin mixin1 {
+  .foo {
+    @include mixin2;
+  }
+}
+
+@mixin mixin2 {
+  content: "\#{&}";
+}
+
+@include mixin1;
+SCSS
+  end
+
   def test_selector_script_through_content
     assert_equal(<<CSS, render(<<SCSS))
 .foo {


### PR DESCRIPTION
On Sass 3.3 alpha 255, Sass seems to lose certain parts of the parent selector when it's interpolated in Sass script: that is, in a nested mixin, it seems to lose any rule nodes that were created in containing mixins. More info and sample code in #930. Sorry I can't help any further -- I did clone a copy of the repo onto my computer and tried to fish through the code, but I think that fixing this issue would demand a lot more knowledge of the code than I have!

Oh, and sorry for submitting a pull request that intentionally breaks the CI build :-)
