### PR TITLE
Refactor @at-root to ensure that it works properly with a plain &.

### DIFF
--- a/lib/sass/selector/comma_sequence.rb
+++ b/lib/sass/selector/comma_sequence.rb
@@ -18,9 +18,12 @@ module Sass
       # handling commas appropriately.
       #
       # @param super_cseq [CommaSequence] The parent selector
+      # @param implicit_parent [Boolean] Whether the the parent
+      #   selector should automatically be prepended to the resolved
+      #   selector if it contains no parent refs.
       # @return [CommaSequence] This selector, with parent references resolved
       # @raise [Sass::SyntaxError] If a parent selector is invalid
-      def resolve_parent_refs(super_cseq)
+      def resolve_parent_refs(super_cseq, implicit_parent = true)
         if super_cseq.nil?
           if @members.any? do |sel|
                sel.members.any? do |sel_or_op|
@@ -36,7 +39,7 @@ module Sass
 
         CommaSequence.new(
           super_cseq.members.map do |super_seq|
-            @members.map {|seq| seq.resolve_parent_refs(super_seq)}
+            @members.map {|seq| seq.resolve_parent_refs(super_seq, implicit_parent)}
           end.flatten)
       end
 

--- a/lib/sass/selector/sequence.rb
+++ b/lib/sass/selector/sequence.rb
@@ -44,14 +44,20 @@ module Sass
       # handling commas appropriately.
       #
       # @param super_seq [Sequence] The parent selector sequence
+      # @param implicit_parent [Boolean] Whether the the parent
+      #   selector should automatically be prepended to the resolved
+      #   selector if it contains no parent refs.
       # @return [Sequence] This selector, with parent references resolved
       # @raise [Sass::SyntaxError] If a parent selector is invalid
-      def resolve_parent_refs(super_seq)
+      def resolve_parent_refs(super_seq, implicit_parent)
         members = @members.dup
         nl = (members.first == "\n" && members.shift)
-        unless members.any? do |seq_or_op|
-                 seq_or_op.is_a?(SimpleSequence) && seq_or_op.members.first.is_a?(Parent)
-               end
+        contains_parent_ref = members.any? do |seq_or_op|
+          seq_or_op.is_a?(SimpleSequence) && seq_or_op.members.first.is_a?(Parent)
+        end
+        return self if !implicit_parent && !contains_parent_ref
+
+        unless contains_parent_ref
           old_members, members = members, []
           members << nl if nl
           members << SimpleSequence.new([Parent.new], false)

--- a/lib/sass/tree/node.rb
+++ b/lib/sass/tree/node.rb
@@ -8,14 +8,15 @@ module Sass
   # in addition to nodes for CSS rules and properties.
   # Nodes that only appear in this state are called **dynamic nodes**.
   #
-  # {Tree::Visitors::Perform} creates a static Sass tree, which is different.
-  # It still has nodes for CSS rules and properties
-  # but it doesn't have any dynamic-generation-related nodes.
-  # The nodes in this state are in the same structure as the Sass document:
-  # rules and properties are nested beneath one another.
-  # Nodes that can be in this state or in the dynamic state
-  # are called **static nodes**; nodes that can only be in this state
-  # are called **solely static nodes**.
+  # {Tree::Visitors::Perform} creates a static Sass tree, which is
+  # different. It still has nodes for CSS rules and properties but it
+  # doesn't have any dynamic-generation-related nodes. The nodes in
+  # this state are in a similar structure to the Sass document: rules
+  # and properties are nested beneath one another, although the
+  # {Tree::RuleNode} selectors are already in their final state. Nodes
+  # that can be in this state or in the dynamic state are called
+  # **static nodes**; nodes that can only be in this state are called
+  # **solely static nodes**.
   #
   # {Tree::Visitors::Cssize} is then used to create a static CSS tree.
   # This is like a static Sass tree,

--- a/lib/sass/tree/rule_node.rb
+++ b/lib/sass/tree/rule_node.rb
@@ -16,18 +16,17 @@ module Sass::Tree
     # @return [Array<String, Sass::Script::Tree::Node>]
     attr_accessor :rule
 
-    # The CSS selector for this rule,
-    # without any unresolved interpolation
-    # but with parent references still intact.
-    # It's only set once {Tree::Visitors::Perform} has been run.
-    #
+    # The CSS selector for this rule, without any unresolved
+    # interpolation but with parent references still intact. It's only
+    # guaranteed to be set once {Tree::Visitors::Perform} has been
+    # run, but it may be set before then for optimization reasons.
     #
     # @return [Selector::CommaSequence]
     attr_accessor :parsed_rules
 
-    # The CSS selector for this rule,
-    # without any unresolved interpolation or parent references.
-    # It's only set once {Tree::Visitors::Cssize} has been run.
+    # The CSS selector for this rule, without any unresolved
+    # interpolation or parent references. It's only set once
+    # {Tree::Visitors::Perform} has been run.
     #
     # @return [Selector::CommaSequence]
     attr_accessor :resolved_rules

--- a/lib/sass/tree/visitors/cssize.rb
+++ b/lib/sass/tree/visitors/cssize.rb
@@ -191,14 +191,9 @@ class Sass::Tree::Visitors::Cssize < Sass::Tree::Visitors::Base
     result
   end
 
-  # Resolves parent references and nested selectors,
-  # and updates the indentation of the rule node based on the nesting level.
+  # Updates the indentation of the rule node based on the nesting
+  # level. The selectors were resolved in {Perform}.
   def visit_rule(node)
-    parent_resolved_rules = parent.is_a?(Sass::Tree::RuleNode) ? parent.resolved_rules : nil
-    # It's possible for resolved_rules to be set
-    # if we've duplicated this node during @media bubbling
-    node.resolved_rules ||= node.parsed_rules.resolve_parent_refs(parent_resolved_rules)
-
     yield
 
     rules = node.children.select {|c| c.is_a?(Sass::Tree::RuleNode) || c.bubbles?}

--- a/test/sass/scss/scss_test.rb
+++ b/test/sass/scss/scss_test.rb
@@ -1958,6 +1958,51 @@ CSS
 SCSS
   end
 
+  def test_at_root_with_parent_ref
+    assert_equal <<CSS, render(<<SCSS)
+.foo {
+  a: b; }
+CSS
+.foo {
+  @at-root & {
+    a: b;
+  }
+}
+SCSS
+  end
+
+  def test_multi_level_at_root_with_parent_ref
+    assert_equal <<CSS, render(<<SCSS)
+.foo .bar {
+  a: b; }
+CSS
+.foo {
+  @at-root & {
+    .bar {
+      @at-root & {
+        a: b;
+      }
+    }
+  }
+}
+SCSS
+  end
+
+  def test_multi_level_at_root_with_inner_parent_ref
+    assert_equal <<CSS, render(<<SCSS)
+.bar {
+  a: b; }
+CSS
+.foo {
+  @at-root .bar {
+    @at-root & {
+      a: b;
+    }
+  }
+}
+SCSS
+  end
+
   ## Selector Script
 
   def test_selector_script
@@ -2100,6 +2145,21 @@ CSS
 .foo {
   @at-root \#{&}-bar {
     a: b;
+  }
+}
+SCSS
+  end
+
+  def test_multi_level_at_root_with_inner_selector_script
+    assert_equal <<CSS, render(<<SCSS)
+.bar {
+  a: b; }
+CSS
+.foo {
+  @at-root .bar {
+    @at-root \#{&} {
+      a: b;
+    }
   }
 }
 SCSS


### PR DESCRIPTION
This changes the structure of the intermediate trees a little. Instead of having the RuleNode nesting resolved entirely in the Cssize visitor, the selectors are now resolved in Perform, while the nesting itself is removed in Cssize. This is necessary to make the resolved selectors consistently available to script &.
