### PR TITLE
Upgrade to listen 2.0

### DIFF
--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -284,6 +284,7 @@ module Sass::Plugin
 
       listener.start
       listener.thread.join
+      listener.stop # Partially work around guard/listen#146
     end
 
     # Non-destructively modifies \{#options} so that default values are properly set,

--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -282,13 +282,8 @@ module Sass::Plugin
       # https://github.com/nex3/sass/commit/a3031856b22bc834a5417dedecb038b7be9b9e3e
       listener.force_polling(true) if @options[:poll] || Sass::Util.windows?
 
-      # rubocop:disable RescueException
-      begin
-        listener.start!
-      rescue Exception => e
-        raise e unless e.is_a?(Interrupt)
-      end
-      # rubocop:enable RescueException
+      listener.start
+      listener.thread.join
     end
 
     # Non-destructively modifies \{#options} so that default values are properly set,
@@ -311,7 +306,7 @@ module Sass::Plugin
 
     def create_listener(*args, &block)
       require 'listen'
-      Listen::Listener.new(*args, &block)
+      Listen.to(*args, &block)
     end
 
     def remove_redundant_directories(directories)

--- a/sass.gemspec
+++ b/sass.gemspec
@@ -19,7 +19,7 @@ SASS_GEMSPEC = Gem::Specification.new do |spec|
     END
 
   spec.required_ruby_version = '>= 1.8.7'
-  spec.add_dependency 'listen', '~> 1.1.0'
+  spec.add_dependency 'listen', '~> 2.0.0'
   spec.add_development_dependency 'yard', '>= 0.5.3'
   spec.add_development_dependency 'maruku', '>= 0.5.9'
 

--- a/test/sass/compiler_test.rb
+++ b/test/sass/compiler_test.rb
@@ -44,6 +44,9 @@ class CompilerTest < Test::Unit::TestCase
       @thread = Thread.new {@run_during_start.call(self) if @run_during_start}
     end
 
+    def stop
+    end
+
     def reset_events!
       @modified = []
       @added = []

--- a/test/sass/compiler_test.rb
+++ b/test/sass/compiler_test.rb
@@ -9,6 +9,7 @@ class CompilerTest < Test::Unit::TestCase
     attr_accessor :options
     attr_accessor :directories
     attr_reader :start_called
+    attr_reader :thread
 
     def initialize(*args, &on_filesystem_event)
       self.options = args.last.is_a?(Hash) ? args.pop : {}
@@ -39,8 +40,8 @@ class CompilerTest < Test::Unit::TestCase
       @run_during_start = run_during_start
     end
 
-    def start!
-      @run_during_start.call(self) if @run_during_start
+    def start
+      @thread = Thread.new {@run_during_start.call(self) if @run_during_start}
     end
 
     def reset_events!


### PR DESCRIPTION
This preserves the existing `sass --watch` functionality. There are still some performance issues and small behavior issues stemming from guard/listen#111, but those are unlikely to be solved in time for 3.3.

Addresses #955.
