### PR TITLE
Support trailing commas in lists and maps.

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -289,6 +289,11 @@ maps instead.
 * The `if()` function now only evaluates the argument corresponding to
   the value of the first argument.
 
+* Comma-separated lists may now have trailing commas (e.g. `1, 2,
+  3,`). This also allows you to use a trailing comma to distinguish a
+  list with a single element from that element itself -- for example,
+  `(1,)` is explicitly a list containing the value `1`.
+
 ### Backwards Incompatibilities -- Must Read!
 
 * Sass will now throw an error when `@extend` is used to extend a selector

--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -730,6 +730,12 @@ contains empty lists or null values, as in `1px 2px () 3px` or `1px 2px null
 3px`, the empty lists and null values will be removed before the containing list
 is turned into CSS.
 
+Comma-separated lists may have a trailing comma. This is especially
+useful because it allows you to represent a single-element list. For
+example, `(1,)` is a list containing `1` and `(1 2 3,)` is a
+comma-separated list containing a space-separated list containing `1`,
+`2`, and `3`.
+
 #### Maps
 
 Maps represent an association between keys and values, where keys are used to

--- a/lib/sass/script/tree/list_literal.rb
+++ b/lib/sass/script/tree/list_literal.rb
@@ -29,7 +29,7 @@ module Sass::Script::Tree
     def to_sass(opts = {})
       return "()" if elements.empty?
       precedence = Sass::Script::Parser.precedence_of(separator)
-      elements.reject {|e| e.is_a?(Sass::Script::Value::Null)}.map do |v|
+      members = elements.map do |v|
         if v.is_a?(ListLiteral) && Sass::Script::Parser.precedence_of(v.separator) <= precedence ||
             separator == :space && v.is_a?(UnaryOperation) &&
             (v.operator == :minus || v.operator == :plus)
@@ -37,7 +37,11 @@ module Sass::Script::Tree
         else
           v.to_sass(opts)
         end
-      end.join(sep_str(nil))
+      end
+
+      return "(#{members.first},)" if separator == :comma && members.length == 1
+
+      members.join(sep_str(nil))
     end
 
 

--- a/lib/sass/script/value/list.rb
+++ b/lib/sass/script/value/list.rb
@@ -52,7 +52,7 @@ module Sass::Script::Value
     def to_sass(opts = {})
       return "()" if value.empty?
       precedence = Sass::Script::Parser.precedence_of(separator)
-      value.reject {|e| e.is_a?(Null)}.map do |v|
+      members = value.reject {|e| e.is_a?(Null)}.map do |v|
         if v.is_a?(List) && Sass::Script::Parser.precedence_of(v.separator) <= precedence ||
             separator == :space && v.is_a?(Sass::Script::Tree::UnaryOperation) &&
             (v.operator == :minus || v.operator == :plus)
@@ -60,7 +60,9 @@ module Sass::Script::Value
         else
           v.to_sass(opts)
         end
-      end.join(sep_str(nil))
+      end
+      return "(#{members.first},)" if members.length == 1 && separator == :comma
+      members.join(sep_str(nil))
     end
 
     # @see Value#to_h

--- a/test/sass/script_conversion_test.rb
+++ b/test/sass/script_conversion_test.rb
@@ -83,6 +83,12 @@ class SassScriptConversionTest < Test::Unit::TestCase
     assert_renders "foo(a, b, (a, b, c)...)"
   end
 
+  def test_singleton_list
+    assert_renders "(1,)"
+    assert_renders "(1 2 3,)"
+    assert_renders "((1, 2, 3),)"
+  end
+
   def test_map
     assert_renders "(foo: bar)"
     assert_renders "(foo: bar, baz: bip)"

--- a/test/sass/script_test.rb
+++ b/test/sass/script_test.rb
@@ -492,6 +492,18 @@ SASS
     assert_equal "1 2 3", resolve("null 1 2 3")
   end
 
+  def test_map_can_have_trailing_comma
+    assert_equal("(foo: 1, bar: 2)", eval("(foo: 1, bar: 2,)").to_sass)
+  end
+
+  def test_list_can_have_trailing_comma
+    assert_equal("1, 2, 3", resolve("1, 2, 3,"))
+  end
+
+  def test_trailing_comma_defines_singleton_list
+    assert_equal("1 2 3", resolve("nth((1 2 3,), 1)"))
+  end
+
   def test_map_cannot_have_duplicate_keys
     assert_raise_message(Sass::SyntaxError, 'Duplicate key "foo" in map (foo: bar, foo: baz).') do
       eval("(foo: bar, foo: baz)")


### PR DESCRIPTION
This also adds the syntax (value,) for creating a singleton list.

Closes #917
