### PR TITLE
Updated deadlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Then any Sass files in `public/stylesheets/sass`
 will be compiled into CSS files in `public/stylesheets` on every request.
 
 To use Sass programmatically,
-check out the [YARD documentation](http://sass-lang.com/docs/yardoc/).
+check out the [YARD documentation](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#using_sass).
 
 ## Formatting
 
@@ -71,10 +71,10 @@ and get small stylesheets up and running quickly,
 particularly with the help of
 [the Compass style library](http://compass-style.org).
 
-[vars]:    http://beta.sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html#variables_
-[nested]:  http://beta.sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html#nested_rules_
-[mixins]:  http://beta.sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html#mixins
-[imports]: http://beta.sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html#import
+[vars]:    http://sass-lang.com/documentation/file.SASS_REFERENCE.html#variables_
+[nested]:  http://sass-lang.com/documentation/file.SASS_REFERENCE.html#nested_rules
+[mixins]:  http://sass-lang.com/documentation/file.SASS_REFERENCE.html#mixins
+[imports]: http://sass-lang.com/documentation/file.SASS_REFERENCE.html#import
 
 Sass has two syntaxes.
 The one presented here, known as "SCSS" (for "Sassy CSS"),
@@ -83,7 +83,7 @@ The other (older) syntax, known as the indented syntax or just "Sass",
 is whitespace-sensitive and indentation-based.
 For more information, see the [reference documentation][syntax].
 
-[syntax]: http://beta.sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html#syntax
+[syntax]: http://sass-lang.com/documentation/file.SASS_REFERENCE.html#syntax
 
 To run the following examples and see the CSS they produce,
 put them in a file called `test.scss` and run `sass test.scss`.
@@ -152,7 +152,7 @@ You can even give them arguments.
     }
 
 A comprehensive list of features is available
-in the [Sass reference](http://beta.sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html).
+in the [Sass reference](http://sass-lang.com/documentation/file.SASS_REFERENCE.html).
 
 ## Executables
 


### PR DESCRIPTION
updated deadlinks to the actual working links.

Most of the links are referring to beta version. These links are no longer available.
