### PR TITLE
Support use of   listen >=1.1.0  < 2.2

### DIFF
--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -316,12 +316,11 @@ module Sass::Plugin
         listener.thread.join
         listener.stop # Partially work around guard/listen#146
       else
-        # rubocop:disable RescueException
         begin
           listener.start!
         rescue Interrupt
+          # Squelch Interrupt for clean exit from Listen::Listener
         end
-        # rubocop:enable RescueException
       end
     end
 

--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -283,6 +283,7 @@ module Sass::Plugin
 
       listener.start
       listener.thread.join
+      listener.stop # Partially work around guard/listen#146
     end
 
     # Non-destructively modifies \{#options} so that default values are properly set,

--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -281,13 +281,8 @@ module Sass::Plugin
       # https://github.com/nex3/sass/commit/a3031856b22bc834a5417dedecb038b7be9b9e3e
       listener.force_polling(true) if @options[:poll] || Sass::Util.windows?
 
-      # rubocop:disable RescueException
-      begin
-        listener.start!
-      rescue Exception => e
-        raise e unless e.is_a?(Interrupt)
-      end
-      # rubocop:enable RescueException
+      listener.start
+      listener.thread.join
     end
 
     # Non-destructively modifies \{#options} so that default values are properly set,
@@ -310,7 +305,7 @@ module Sass::Plugin
 
     def create_listener(*args, &block)
       require 'listen'
-      Listen::Listener.new(*args, &block)
+      Listen.to(*args, &block)
     end
 
     def remove_redundant_directories(directories)

--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -281,9 +281,7 @@ module Sass::Plugin
       # https://github.com/nex3/sass/commit/a3031856b22bc834a5417dedecb038b7be9b9e3e
       listener.force_polling(true) if @options[:poll] || Sass::Util.windows?
 
-      listener.start
-      listener.thread.join
-      listener.stop # Partially work around guard/listen#146
+      listen_to(listener)
     end
 
     # Non-destructively modifies \{#options} so that default values are properly set,
@@ -305,8 +303,26 @@ module Sass::Plugin
     private
 
     def create_listener(*args, &block)
-      require 'listen'
-      Listen.to(*args, &block)
+      if Sass::Util.listen_geq_2?
+        Listen.to(*args, &block)
+      else
+        Listen::Listener.new(*args, &block)
+      end
+    end
+
+    def listen_to(listener)
+      if Sass::Util.listen_geq_2?
+        listener.start
+        listener.thread.join
+        listener.stop # Partially work around guard/listen#146
+      else
+        # rubocop:disable RescueException
+        begin
+          listener.start!
+        rescue Interrupt
+        end
+        # rubocop:enable RescueException
+      end
     end
 
     def remove_redundant_directories(directories)

--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -487,6 +487,15 @@ module Sass
       version_geq(ActionPack::VERSION::STRING, version)
     end
 
+    # Returns whether this environment is using Listen
+    # version 2.0.0 or greater.
+    #
+    # @return [Boolean]
+    def listen_geq_2?
+      require 'listen/version'
+      version_geq(::Listen::VERSION, '2.0.0')
+    end
+
     # Returns an ActionView::Template* class.
     # In pre-3.0 versions of Rails, most of these classes
     # were of the form `ActionView::TemplateFoo`,

--- a/sass.gemspec
+++ b/sass.gemspec
@@ -19,7 +19,12 @@ SASS_GEMSPEC = Gem::Specification.new do |spec|
     END
 
   spec.required_ruby_version = '>= 1.8.7'
-  spec.add_dependency 'listen', '~> 2.0.0'
+  spec.add_dependency 'listen', '>= 1.1.0', '< 2.2'
+  if RUBY_VERSION < '1.9.3'
+    spec.add_development_dependency 'listen', '~> 1.1.0'
+  else
+    spec.add_development_dependency 'listen', '>= 1.1.0', '< 2.2'
+  end
   spec.add_development_dependency 'yard', '>= 0.5.3'
   spec.add_development_dependency 'maruku', '>= 0.5.9'
 

--- a/sass.gemspec
+++ b/sass.gemspec
@@ -19,11 +19,11 @@ SASS_GEMSPEC = Gem::Specification.new do |spec|
     END
 
   spec.required_ruby_version = '>= 1.8.7'
-  spec.add_dependency 'listen', '>= 1.1.0', '< 2.2'
+  spec.add_dependency 'listen', '>= 1.1.0', '< 2.5'
   if RUBY_VERSION < '1.9.3'
     spec.add_development_dependency 'listen', '~> 1.1.0'
   else
-    spec.add_development_dependency 'listen', '>= 1.1.0', '< 2.2'
+    spec.add_development_dependency 'listen', '>= 1.1.0', '< 2.5'
   end
   spec.add_development_dependency 'yard', '>= 0.5.3'
   spec.add_development_dependency 'maruku', '>= 0.5.9'

--- a/sass.gemspec
+++ b/sass.gemspec
@@ -19,7 +19,7 @@ SASS_GEMSPEC = Gem::Specification.new do |spec|
     END
 
   spec.required_ruby_version = '>= 1.8.7'
-  spec.add_dependency 'listen', '~> 1.1.0'
+  spec.add_dependency 'listen', '~> 2.0.0'
   spec.add_development_dependency 'yard', '>= 0.5.3'
   spec.add_development_dependency 'maruku', '>= 0.5.9'
 

--- a/test/sass/compiler_test.rb
+++ b/test/sass/compiler_test.rb
@@ -44,6 +44,9 @@ class CompilerTest < Test::Unit::TestCase
       @thread = Thread.new {@run_during_start.call(self) if @run_during_start}
     end
 
+    def stop
+    end
+
     def reset_events!
       @modified = []
       @added = []

--- a/test/sass/compiler_test.rb
+++ b/test/sass/compiler_test.rb
@@ -40,10 +40,16 @@ class CompilerTest < Test::Unit::TestCase
       @run_during_start = run_during_start
     end
 
+    # used for Listen < 2.0
+    def start!
+      @run_during_start.call(self) if @run_during_start
+    end
+    
+    # used for Listen >= 2.0
     def start
       @thread = Thread.new {@run_during_start.call(self) if @run_during_start}
     end
-
+    
     def stop
     end
 

--- a/test/sass/compiler_test.rb
+++ b/test/sass/compiler_test.rb
@@ -44,12 +44,12 @@ class CompilerTest < Test::Unit::TestCase
     def start!
       @run_during_start.call(self) if @run_during_start
     end
-    
+
     # used for Listen >= 2.0
     def start
       @thread = Thread.new {@run_during_start.call(self) if @run_during_start}
     end
-    
+
     def stop
     end
 

--- a/test/sass/compiler_test.rb
+++ b/test/sass/compiler_test.rb
@@ -9,6 +9,7 @@ class CompilerTest < Test::Unit::TestCase
     attr_accessor :options
     attr_accessor :directories
     attr_reader :start_called
+    attr_reader :thread
 
     def initialize(*args, &on_filesystem_event)
       self.options = args.last.is_a?(Hash) ? args.pop : {}
@@ -39,8 +40,8 @@ class CompilerTest < Test::Unit::TestCase
       @run_during_start = run_during_start
     end
 
-    def start!
-      @run_during_start.call(self) if @run_during_start
+    def start
+      @thread = Thread.new {@run_during_start.call(self) if @run_during_start}
     end
 
     def reset_events!


### PR DESCRIPTION
This takes the work from pr#960 and extends it so that listen >=1.1.0 and < 2.2 will work - thereby allowing those on ruby 1.9.3+ to move to newer releases of listen while still supporting 1.1.x for older ruby versions
