### PR TITLE
Source map 'version' property should be a number.

### DIFF
--- a/lib/sass/source/map.rb
+++ b/lib/sass/source/map.rb
@@ -104,7 +104,7 @@ module Sass::Source
       css_uri ||= css_path.relative_path_from(sourcemap_path.dirname).to_s
 
       result = "{\n"
-      write_json_field(result, "version", "3", true)
+      write_json_field(result, "version", 3, true)
 
       source_uri_to_id = {}
       id_to_source_uri = {}

--- a/test/sass/importer_test.rb
+++ b/test/sass/importer_test.rb
@@ -204,7 +204,7 @@ SCSS
     _, sourcemap = engine.render_with_sourcemap('sourcemap_uri')
     assert_equal <<JSON.strip, sourcemap.to_json(:css_uri => 'css_uri')
 {
-"version": "3",
+"version": 3,
 "mappings": "AAAA,QAAS;EACP,KAAK,EAAE,IAAI",
 "sources": ["http://orange.example.com/style.scss"],
 "file": "css_uri"
@@ -274,7 +274,7 @@ SCSS
     sourcemap_path = 'map/style.map'
     assert_equal <<JSON.strip, sourcemap.to_json(:css_uri => css_uri, :sourcemap_path => sourcemap_path)
 {
-"version": "3",
+"version": 3,
 "mappings": "AAAA,IAAK;EAAC,CAAC,EAAE,CAAC",
 "sources": ["../sass/style.scss"],
 "file": "css_uri"
@@ -299,7 +299,7 @@ SCSS
     sourcemap_path = 'map/style.map'
     assert_equal <<JSON.strip, sourcemap.to_json(:css_path => css_path, :sourcemap_path => sourcemap_path)
 {
-"version": "3",
+"version": 3,
 "mappings": "AAAA,IAAK;EAAC,CAAC,EAAE,CAAC",
 "sources": ["../sass/style.scss"],
 "file": "../static/style.css"

--- a/test/sass/source_map_test.rb
+++ b/test/sass/source_map_test.rb
@@ -27,7 +27,7 @@ a {
 /*# sourceMappingURL=test.css.map */
 CSS
 {
-"version": "3",
+"version": 3,
 "mappings": "AAAA,CAAE;EACA,GAAG,EAAE,GAAG;;EAER,SAAS,EAAE,IAAI",
 "sources": ["test_simple_mapping_scss_inline.scss"],
 "file": "test.css"
@@ -50,7 +50,7 @@ a {
 /*# sourceMappingURL=test.css.map */
 CSS
 {
-"version": "3",
+"version": 3,
 "mappings": "AAAA,CAAC;EACC,GAAG,EAAE,GAAG;;EAEP,SAAS,EAAC,IAAI",
 "sources": ["test_simple_mapping_sass_inline.sass"],
 "file": "test.css"
@@ -75,7 +75,7 @@ a {
 /*# sourceMappingURL=style.css.map */
 CSS
 {
-"version": "3",
+"version": 3,
 "mappings": "AAAA,CAAE;EACA,GAAG,EAAE,GAAG;;EAER,SAAS,EAAE,IAAI",
 "sources": ["../scss/style.scss"],
 "file": "style.css"
@@ -99,7 +99,7 @@ a {
 /*# sourceMappingURL=style.css.map */
 CSS
 {
-"version": "3",
+"version": 3,
 "mappings": "AAAA,CAAC;EACC,GAAG,EAAE,GAAG;;EAEP,SAAS,EAAC,IAAI",
 "sources": ["../sass/style.sass"],
 "file": "style.css"
@@ -121,7 +121,7 @@ a {
 /*# sourceMappingURL=test.css.map */
 CSS
 {
-"version": "3",
+"version": 3,
 "mappings": ";AAAA,CAAE;EACA,GAAG,EAAE,GAAG",
 "sources": ["test_simple_charset_mapping_scss_inline.scss"],
 "file": "test.css"
@@ -141,7 +141,7 @@ a {
 /*# sourceMappingURL=test.css.map */
 CSS
 {
-"version": "3",
+"version": 3,
 "mappings": ";AAAA,CAAC;EACC,GAAG,EAAE,GAAG",
 "sources": ["test_simple_charset_mapping_sass_inline.sass"],
 "file": "test.css"
@@ -163,7 +163,7 @@ f\x86\x86 {
 /*# sourceMappingURL=test.css.map */
 CSS
 {
-"version": "3",
+"version": 3,
 "mappings": ";AACA,GAAI;EACF,CAAC,EAAE,CAAC",
 "sources": ["test_different_charset_than_encoding_scss_inline.scss"],
 "file": "test.css"
@@ -184,7 +184,7 @@ f\x86\x86 {
 /*# sourceMappingURL=test.css.map */
 CSS
 {
-"version": "3",
+"version": 3,
 "mappings": ";AACA,GAAG;EACD,CAAC,EAAE,CAAC",
 "sources": ["test_different_charset_than_encoding_sass_inline.sass"],
 "file": "test.css"


### PR DESCRIPTION
As per the source map [spec](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit), the 'version' property of a source map should be a positive integer. Currently Sass makes it a string.
