### PR TITLE
Add '--default-encoding' alias to '-E' command-line option

### DIFF
--- a/lib/sass/exec.rb
+++ b/lib/sass/exec.rb
@@ -298,7 +298,7 @@ END
         else
           'Specify the default encoding for Sass files.'
         end
-        opts.on('-E encoding', encoding_desc) do |encoding|
+        opts.on('-E', '--default-encoding ENCODING', encoding_desc) do |encoding|
           if ::Sass::Util.ruby1_8?
             $stderr.puts "Specifying the encoding is not supported in ruby 1.8."
             exit 1


### PR DESCRIPTION
This makes it more consistent with other options, as well as making it easier to be driven by external tools (in my case, [grunt-contrib-sass](https://github.com/gruntjs/grunt-contrib-sass)).
