### PR TITLE
Add --bell and --bwatch command line options

### DIFF
--- a/lib/sass/exec.rb
+++ b/lib/sass/exec.rb
@@ -239,8 +239,8 @@ END
         end
         opts.on('--bwatch', 'Watches file or directories for changes and outputs a bell after compilation is finished.',
                             'The location of the generated CSS can be set using a colon:',
-                            "  #{@default_syntax} --watch input.#{@default_syntax}:output.css",
-                            "  #{@default_syntax} --watch input-dir:output-dir") do
+                            "  #{@default_syntax} --bwatch input.#{@default_syntax}:output.css",
+                            "  #{@default_syntax} --bwatch input-dir:output-dir") do
           @options[:watch] = true
           @options[:bell] = true
 		end

--- a/lib/sass/exec.rb
+++ b/lib/sass/exec.rb
@@ -237,13 +237,6 @@ END
         opts.on('--bell', 'Output bell when compilation is finished.') do
           @options[:bell] = true
         end
-        opts.on('--bwatch', 'Watches file or directories for changes and outputs a bell after compilation is finished.',
-                            'The location of the generated CSS can be set using a colon:',
-                            "  #{@default_syntax} --bwatch input.#{@default_syntax}:output.css",
-                            "  #{@default_syntax} --bwatch input-dir:output-dir") do
-          @options[:watch] = true
-          @options[:bell] = true
-		end
         opts.on('--update', 'Compile files or directories to CSS.',
                             'Locations are set like --watch.') do
           @options[:update] = true

--- a/lib/sass/exec.rb
+++ b/lib/sass/exec.rb
@@ -124,7 +124,7 @@ module Sass
       #   Can be `:red`, `:green`, or `:yellow`.
       def puts_action(name, color, arg)
         return if @options[:for_engine][:quiet]
-        printf "\a" if @options[:bell]
+        printf "\a" if @options[:bell] and name != :error
         printf color(color, "%11s %s\n"), name, arg
         STDOUT.flush
       end

--- a/lib/sass/exec.rb
+++ b/lib/sass/exec.rb
@@ -124,6 +124,7 @@ module Sass
       #   Can be `:red`, `:green`, or `:yellow`.
       def puts_action(name, color, arg)
         return if @options[:for_engine][:quiet]
+        printf "\a" if @options[:bell]
         printf color(color, "%11s %s\n"), name, arg
         STDOUT.flush
       end
@@ -233,6 +234,16 @@ END
                            "  #{@default_syntax} --watch input-dir:output-dir") do
           @options[:watch] = true
         end
+        opts.on('--bell', 'Output bell when compilation is finished.') do
+          @options[:bell] = true
+        end
+        opts.on('--bwatch', 'Watches file or directories for changes and outputs a bell after compilation is finished.',
+                            'The location of the generated CSS can be set using a colon:',
+                            "  #{@default_syntax} --watch input.#{@default_syntax}:output.css",
+                            "  #{@default_syntax} --watch input-dir:output-dir") do
+          @options[:watch] = true
+          @options[:bell] = true
+		end
         opts.on('--update', 'Compile files or directories to CSS.',
                             'Locations are set like --watch.') do
           @options[:update] = true


### PR DESCRIPTION
Add `--bell` and `--bwatch` (shortcut for `--bell --watch`) command line options.  --bell rings a system bell when a file is compiled.  For my use case, this is really nice because I typically have Visual Studio in one window and my browser in another, and I don't want to give up any screen real estate to the cmd.exe to keep an eye on my `sass --watch`.  With the custom framework we use, it can take up to 5 seconds sometimes to fully compile everything, and having the bell has really made my life easier in that regard.
