### PR TITLE
Marshaling methods for ImportNode, fixes #1028

### DIFF
--- a/lib/sass/tree/import_node.rb
+++ b/lib/sass/tree/import_node.rb
@@ -39,6 +39,17 @@ module Sass
         end
       end
 
+      def _dump(f)
+        Marshal.dump([@imported_filename, children])
+      end
+
+      def self._load(data)
+        filename, children = Marshal.load(data)
+        node = ImportNode.new(filename)
+        node.children = children
+        node
+      end
+
       private
 
       def import

--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -537,15 +537,10 @@ module Sass
       @jruby = RUBY_PLATFORM =~ /java/
     end
 
-    # @see #jruby_version-class_method
-    def jruby_version
-      Sass::Util.jruby_version
-    end
-
     # Returns an array of ints representing the JRuby version number.
     #
     # @return [Array<Fixnum>]
-    def self.jruby_version
+    def jruby_version
       @jruby_version ||= ::JRUBY_VERSION.split(".").map {|s| s.to_i}
     end
 
@@ -1129,7 +1124,7 @@ MSG
       lcs_backtrace(c, x, y, i - 1, j, &block)
     end
 
-    (Sass::Util.methods - Module.methods - Object.methods).each {|method| module_function method}
+    singleton_methods.each {|method| module_function method}
   end
 end
 

--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -1129,7 +1129,7 @@ MSG
       lcs_backtrace(c, x, y, i - 1, j, &block)
     end
 
-    (Sass::Util.methods - Module.methods).each {|method| module_function method}
+    (Sass::Util.methods - Module.methods - Object.methods).each {|method| module_function method}
   end
 end
 


### PR DESCRIPTION
This simply adds `_dump` and `::load` methods for ImportNode, which avoids dumping the `@options` instance variable, which may be undumpable for reasons external to Sass. For example, sass-rails has anonymous classes and Hashes with default procs, neither of which can be marshaled, and prevents sass from doing its caching work.
