### PR TITLE
Source maps should have a 'names' property

### DIFF
--- a/lib/sass/source/map.rb
+++ b/lib/sass/source/map.rb
@@ -190,6 +190,7 @@ WARNING
       source_names = []
       (0...next_source_id).each {|id| source_names.push(id_to_source_uri[id].to_s)}
       write_json_field(result, "sources", source_names)
+      write_json_field(result, "names", [])
       write_json_field(result, "file", css_uri)
 
       result << "\n}"

--- a/test/sass/importer_test.rb
+++ b/test/sass/importer_test.rb
@@ -5,7 +5,7 @@ require File.dirname(__FILE__) + '/test_helper'
 require 'sass/plugin'
 
 class ImporterTest < Test::Unit::TestCase
-  
+
   class FruitImporter < Sass::Importers::Base
     def find(name, context = nil)
       fruit = parse(name)
@@ -207,6 +207,7 @@ SCSS
 "version": 3,
 "mappings": "AAAA,QAAS;EACP,KAAK,EAAE,IAAI",
 "sources": ["http://orange.example.com/style.scss"],
+"names": [],
 "file": "css_uri"
 }
 JSON
@@ -277,6 +278,7 @@ SCSS
 "version": 3,
 "mappings": "AAAA,IAAK;EAAC,CAAC,EAAE,CAAC",
 "sources": ["../sass/style.scss"],
+"names": [],
 "file": "css_uri"
 }
 JSON
@@ -302,6 +304,7 @@ SCSS
 "version": 3,
 "mappings": "AAAA,IAAK;EAAC,CAAC,EAAE,CAAC",
 "sources": ["../sass/style.scss"],
+"names": [],
 "file": "../static/style.css"
 }
 JSON

--- a/test/sass/source_map_test.rb
+++ b/test/sass/source_map_test.rb
@@ -30,6 +30,7 @@ CSS
 "version": 3,
 "mappings": "AAAA,CAAE;EACA,GAAG,EAAE,GAAG;;EAER,SAAS,EAAE,IAAI",
 "sources": ["test_simple_mapping_scss_inline.scss"],
+"names": [],
 "file": "test.css"
 }
 JSON
@@ -53,6 +54,7 @@ CSS
 "version": 3,
 "mappings": "AAAA,CAAC;EACC,GAAG,EAAE,GAAG;;EAEP,SAAS,EAAC,IAAI",
 "sources": ["test_simple_mapping_sass_inline.sass"],
+"names": [],
 "file": "test.css"
 }
 JSON
@@ -78,6 +80,7 @@ CSS
 "version": 3,
 "mappings": "AAAA,CAAE;EACA,GAAG,EAAE,GAAG;;EAER,SAAS,EAAE,IAAI",
 "sources": ["../scss/style.scss"],
+"names": [],
 "file": "style.css"
 }
 JSON
@@ -102,6 +105,7 @@ CSS
 "version": 3,
 "mappings": "AAAA,CAAC;EACC,GAAG,EAAE,GAAG;;EAEP,SAAS,EAAC,IAAI",
 "sources": ["../sass/style.sass"],
+"names": [],
 "file": "style.css"
 }
 JSON
@@ -124,6 +128,7 @@ CSS
 "version": 3,
 "mappings": ";AAAA,CAAE;EACA,GAAG,EAAE,GAAG",
 "sources": ["test_simple_charset_mapping_scss_inline.scss"],
+"names": [],
 "file": "test.css"
 }
 JSON
@@ -144,6 +149,7 @@ CSS
 "version": 3,
 "mappings": ";AAAA,CAAC;EACC,GAAG,EAAE,GAAG",
 "sources": ["test_simple_charset_mapping_sass_inline.sass"],
+"names": [],
 "file": "test.css"
 }
 JSON
@@ -166,6 +172,7 @@ CSS
 "version": 3,
 "mappings": ";AACA,GAAI;EACF,CAAC,EAAE,CAAC",
 "sources": ["test_different_charset_than_encoding_scss_inline.scss"],
+"names": [],
 "file": "test.css"
 }
 JSON
@@ -187,6 +194,7 @@ CSS
 "version": 3,
 "mappings": ";AACA,GAAG;EACD,CAAC,EAAE,CAAC",
 "sources": ["test_different_charset_than_encoding_sass_inline.sass"],
+"names": [],
 "file": "test.css"
 }
 JSON


### PR DESCRIPTION
Fix for #1009. The `names` property of source maps isn't optional as per the [source map v3 spec](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit). It can however just be an empty array, which is what this commit adds.

The [mozilla/source-map](https://github.com/mozilla/source-map) library had to special case for Sass, but other implementations might not do this.
