### PR TITLE
Fix for #Issue 833

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -5,6 +5,12 @@
 
 ## 3.3.0 (Unreleased)
 
+  * mix()'s arguments now use $name1, $name2 format, in keeping with other functions
+
+  * arguments for percentage(), round(), ceil(), floor(), and abs() now use 'number' instead of 'value' for arguments
+
+  * comparable()'s arguments now use $name1, $name2 format, in keeping with other functions
+
 ### Using `&` in SassScript
 
 For a long time, Sass has supported a special

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -1196,9 +1196,9 @@ module Sass::Script
     # @return [Sass::Script::Value::Color]
     # @raise [ArgumentError] if `$weight` is out of bounds or any parameter is
     #   the wrong type
-    def mix(color_1, color_2, weight = number(50))
-      assert_type color_1, :Color, :color_1
-      assert_type color_2, :Color, :color_2
+    def mix(color1, color2, weight = number(50))
+      assert_type color1, :Color, :color1
+      assert_type color2, :Color, :color2
       assert_type weight, :Number, :weight
 
       Sass::Util.check_range("Weight", 0..100, weight, '%')
@@ -1208,11 +1208,11 @@ module Sass::Script
       # to perform the weighted average of the two RGB values.
       #
       # It works by first normalizing both parameters to be within [-1, 1],
-      # where 1 indicates "only use color_1", -1 indicates "only use color_2", and
+      # where 1 indicates "only use color1", -1 indicates "only use color2", and
       # all values in between indicated a proportionately weighted average.
       #
       # Once we have the normalized variables w and a, we apply the formula
-      # (w + a)/(1 + w*a) to get the combined weight (in [-1, 1]) of color_1.
+      # (w + a)/(1 + w*a) to get the combined weight (in [-1, 1]) of color1.
       # This formula has two especially nice properties:
       #
       #   * When either w or a are -1 or 1, the combined weight is also that number
@@ -1220,21 +1220,21 @@ module Sass::Script
       #
       #   * When a is 0, the combined weight is w, and vice versa.
       #
-      # Finally, the weight of color_1 is renormalized to be within [0, 1]
-      # and the weight of color_2 is given by 1 minus the weight of color_1.
+      # Finally, the weight of color1 is renormalized to be within [0, 1]
+      # and the weight of color2 is given by 1 minus the weight of color1.
       p = (weight.value / 100.0).to_f
       w = p * 2 - 1
-      a = color_1.alpha - color_2.alpha
+      a = color1.alpha - color2.alpha
 
       w1 = ((w * a == -1 ? w : (w + a) / (1 + w * a)) + 1) / 2.0
       w2 = 1 - w1
 
-      rgba = color_1.rgb.zip(color_2.rgb).map {|v1, v2| v1 * w1 + v2 * w2}
-      rgba << color_1.alpha * p + color_2.alpha * (1 - p)
+      rgba = color1.rgb.zip(color2.rgb).map {|v1, v2| v1 * w1 + v2 * w2}
+      rgba << color1.alpha * p + color2.alpha * (1 - p)
       rgb_color(*rgba)
     end
-    declare :mix, [:color_1, :color_2]
-    declare :mix, [:color_1, :color_2, :weight]
+    declare :mix, [:color1, :color2]
+    declare :mix, [:color1, :color2, :weight]
 
     # Converts a color to grayscale. This is identical to `desaturate(color,
     # 100%)`.

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -145,7 +145,7 @@ module Sass::Script
   # \{#ceil ceil($number)}
   # : Rounds a number up to the next whole number.
   #
-  # \{#floor floor($value)}
+  # \{#floor floor($number)}
   # : Rounds a number down to the previous whole number.
   #
   # \{#abs abs($value)}
@@ -1608,10 +1608,10 @@ module Sass::Script
     # @example
     #   floor(10.4px) => 10px
     #   floor(10.6px) => 10px
-    # @overload floor($value)
-    # @param $value [Sass::Script::Value::Number]
+    # @overload floor($number)
+    # @param $number [Sass::Script::Value::Number]
     # @return [Sass::Script::Value::Number]
-    # @raise [ArgumentError] if `$value` isn't a number
+    # @raise [ArgumentError] if `$number` isn't a number
     def floor(number)
       numeric_transformation(number) {|n| n.floor}
     end

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -231,7 +231,7 @@ module Sass::Script
   # \{#unitless unitless($number)}
   # : Returns whether a number has units.
   #
-  # \{#comparable comparable($number-1, $number-2)}
+  # \{#comparable comparable($number1, $number2)}
   # : Returns whether two numbers can be added, subtracted, or compared.
   #
   # \{#call call($name, $args...)}
@@ -1546,9 +1546,9 @@ module Sass::Script
     #   comparable(2px, 1px) => true
     #   comparable(100px, 3em) => false
     #   comparable(10cm, 3mm) => true
-    # @overload comparable($number-1, $number-2)
-    # @param $number-1 [Sass::Script::Value::Number]
-    # @param $number-2 [Sass::Script::Value::Number]
+    # @overload comparable($number1, $number2)
+    # @param $number1 [Sass::Script::Value::Number]
+    # @param $number2 [Sass::Script::Value::Number]
     # @return [Sass::Script::Value::Bool]
     # @raise [ArgumentError] if either parameter is the wrong type
     def comparable(number1, number2)

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -1551,12 +1551,12 @@ module Sass::Script
     # @param $number-2 [Sass::Script::Value::Number]
     # @return [Sass::Script::Value::Bool]
     # @raise [ArgumentError] if either parameter is the wrong type
-    def comparable(number_1, number_2)
-      assert_type number_1, :Number, :number_1
-      assert_type number_2, :Number, :number_2
-      bool(number_1.comparable_to?(number_2))
+    def comparable(number1, number2)
+      assert_type number1, :Number, :number1
+      assert_type number2, :Number, :number2
+      bool(number1.comparable_to?(number2))
     end
-    declare :comparable, [:number_1, :number_2]
+    declare :comparable, [:number1, :number2]
 
     # Converts a unitless number to a percentage.
     #

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -1612,10 +1612,10 @@ module Sass::Script
     # @param $value [Sass::Script::Value::Number]
     # @return [Sass::Script::Value::Number]
     # @raise [ArgumentError] if `$value` isn't a number
-    def floor(value)
-      numeric_transformation(value) {|n| n.floor}
+    def floor(number)
+      numeric_transformation(number) {|n| n.floor}
     end
-    declare :floor, [:value]
+    declare :floor, [:number]
 
     # Returns the absolute value of a number.
     #

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -148,7 +148,7 @@ module Sass::Script
   # \{#floor floor($number)}
   # : Rounds a number down to the previous whole number.
   #
-  # \{#abs abs($value)}
+  # \{#abs abs($number)}
   # : Returns the absolute value of a number.
   #
   # \{#min min($numbers...)\}
@@ -1622,10 +1622,10 @@ module Sass::Script
     # @example
     #   abs(10px) => 10px
     #   abs(-10px) => 10px
-    # @overload abs($value)
-    # @param $value [Sass::Script::Value::Number]
+    # @overload abs($number)
+    # @param $number [Sass::Script::Value::Number]
     # @return [Sass::Script::Value::Number]
-    # @raise [ArgumentError] if `$value` isn't a number
+    # @raise [ArgumentError] if `$number` isn't a number
     def abs(number)
       numeric_transformation(number) {|n| n.abs}
     end

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -1626,10 +1626,10 @@ module Sass::Script
     # @param $value [Sass::Script::Value::Number]
     # @return [Sass::Script::Value::Number]
     # @raise [ArgumentError] if `$value` isn't a number
-    def abs(value)
-      numeric_transformation(value) {|n| n.abs}
+    def abs(number)
+      numeric_transformation(number) {|n| n.abs}
     end
-    declare :abs, [:value]
+    declare :abs, [:number]
 
     # Finds the minimum of several numbers. This function takes any number of
     # arguments.

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -31,7 +31,7 @@ module Sass::Script
   # \{#blue blue($color)}
   # : Gets the blue component of a color.
   #
-  # \{#mix mix($color-1, $color-2, \[$weight\])}
+  # \{#mix mix($color1, $color2, \[$weight\])}
   # : Mixes two colors together.
   #
   # ## HSL Functions
@@ -1187,9 +1187,9 @@ module Sass::Script
     #   mix(#f00, #00f) => #7f007f
     #   mix(#f00, #00f, 25%) => #3f00bf
     #   mix(rgba(255, 0, 0, 0.5), #00f) => rgba(63, 0, 191, 0.75)
-    # @overload mix($color-1, $color-2, $weight: 50%)
-    # @param $color-1 [Sass::Script::Value::Color]
-    # @param $color-2 [Sass::Script::Value::Color]
+    # @overload mix($color1, $color2, $weight: 50%)
+    # @param $color1 [Sass::Script::Value::Color]
+    # @param $color2 [Sass::Script::Value::Color]
     # @param $weight [Sass::Script::Value::Number] The relative weight of each
     #   color. Closer to `0%` gives more weight to `$color`, closer to `100%`
     #   gives more weight to `$color2`

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -1598,10 +1598,10 @@ module Sass::Script
     # @param $value [Sass::Script::Value::Number]
     # @return [Sass::Script::Value::Number]
     # @raise [ArgumentError] if `$value` isn't a number
-    def ceil(value)
-      numeric_transformation(value) {|n| n.ceil}
+    def ceil(number)
+      numeric_transformation(number) {|n| n.ceil}
     end
-    declare :ceil, [:value]
+    declare :ceil, [:number]
 
     # Rounds a number down to the previous whole number.
     #

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -139,7 +139,7 @@ module Sass::Script
   # \{#percentage percentage($number)}
   # : Converts a unitless number to a percentage.
   #
-  # \{#round round($value)}
+  # \{#round round($number)}
   # : Rounds a number to the nearest whole number.
   #
   # \{#ceil ceil($value)}
@@ -1580,10 +1580,10 @@ module Sass::Script
     # @example
     #   round(10.4px) => 10px
     #   round(10.6px) => 11px
-    # @overload round($value)
-    # @param $value [Sass::Script::Value::Number]
+    # @overload round($number)
+    # @param $number [Sass::Script::Value::Number]
     # @return [Sass::Script::Value::Number]
-    # @raise [ArgumentError] if `$value` isn't a number
+    # @raise [ArgumentError] if `$number` isn't a number
     def round(number)
       numeric_transformation(number) {|n| n.round}
     end

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -142,7 +142,7 @@ module Sass::Script
   # \{#round round($number)}
   # : Rounds a number to the nearest whole number.
   #
-  # \{#ceil ceil($value)}
+  # \{#ceil ceil($number)}
   # : Rounds a number up to the next whole number.
   #
   # \{#floor floor($value)}
@@ -1594,10 +1594,10 @@ module Sass::Script
     # @example
     #   ceil(10.4px) => 11px
     #   ceil(10.6px) => 11px
-    # @overload ceil($value)
-    # @param $value [Sass::Script::Value::Number]
+    # @overload ceil($number)
+    # @param $number [Sass::Script::Value::Number]
     # @return [Sass::Script::Value::Number]
-    # @raise [ArgumentError] if `$value` isn't a number
+    # @raise [ArgumentError] if `$number` isn't a number
     def ceil(number)
       numeric_transformation(number) {|n| n.ceil}
     end

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -1584,10 +1584,10 @@ module Sass::Script
     # @param $value [Sass::Script::Value::Number]
     # @return [Sass::Script::Value::Number]
     # @raise [ArgumentError] if `$value` isn't a number
-    def round(value)
-      numeric_transformation(value) {|n| n.round}
+    def round(number)
+      numeric_transformation(number) {|n| n.round}
     end
-    declare :round, [:value]
+    declare :round, [:number]
 
     # Rounds a number up to the next whole number.
     #

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -1567,13 +1567,13 @@ module Sass::Script
     # @param $value [Sass::Script::Value::Number]
     # @return [Sass::Script::Value::Number]
     # @raise [ArgumentError] if `$value` isn't a unitless number
-    def percentage(value)
-      unless value.is_a?(Sass::Script::Value::Number) && value.unitless?
-        raise ArgumentError.new("$value: #{value.inspect} is not a unitless number")
+    def percentage(number)
+      unless number.is_a?(Sass::Script::Value::Number) && number.unitless?
+        raise ArgumentError.new("$number: #{number.inspect} is not a unitless number")
       end
-      number(value.value * 100, '%')
+      number(number.value * 100, '%')
     end
-    declare :percentage, [:value]
+    declare :percentage, [:number]
 
     # Rounds a number to the nearest whole number.
     #

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -136,7 +136,7 @@ module Sass::Script
   #
   # ## Number Functions
   #
-  # \{#percentage percentage($value)}
+  # \{#percentage percentage($number)}
   # : Converts a unitless number to a percentage.
   #
   # \{#round round($value)}
@@ -1563,10 +1563,10 @@ module Sass::Script
     # @example
     #   percentage(0.2) => 20%
     #   percentage(100px / 50px) => 200%
-    # @overload percentage($value)
-    # @param $value [Sass::Script::Value::Number]
+    # @overload percentage($number)
+    # @param $number [Sass::Script::Value::Number]
     # @return [Sass::Script::Value::Number]
-    # @raise [ArgumentError] if `$value` isn't a unitless number
+    # @raise [ArgumentError] if `$number` isn't a unitless number
     def percentage(number)
       unless number.is_a?(Sass::Script::Value::Number) && number.unitless?
         raise ArgumentError.new("$number: #{number.inspect} is not a unitless number")

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -133,7 +133,7 @@ class SassFunctionTest < Test::Unit::TestCase
     assert_equal("5",   evaluate("round(4.8)"))
     assert_equal("5px", evaluate("round(4.8px)"))
     assert_equal("5px", evaluate("round(5.49px)"))
-    assert_equal("5px", evaluate("round($value: 5.49px)"))
+    assert_equal("5px", evaluate("round($number: 5.49px)"))
 
     assert_error_message("$value: #cccccc is not a number for `round'", "round(#ccc)")
   end

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -120,13 +120,13 @@ class SassFunctionTest < Test::Unit::TestCase
     assert_equal("50%",  evaluate("percentage(.5)"))
     assert_equal("100%", evaluate("percentage(1)"))
     assert_equal("25%",  evaluate("percentage(25px / 100px)"))
-    assert_equal("50%",  evaluate("percentage($value: 0.5)"))
+    assert_equal("50%",  evaluate("percentage($number: 0.5)"))
   end
 
   def test_percentage_checks_types
-    assert_error_message("$value: 25px is not a unitless number for `percentage'", "percentage(25px)")
-    assert_error_message("$value: #cccccc is not a unitless number for `percentage'", "percentage(#ccc)")
-    assert_error_message("$value: \"string\" is not a unitless number for `percentage'", %Q{percentage("string")})
+    assert_error_message("$number: 25px is not a unitless number for `percentage'", "percentage(25px)")
+    assert_error_message("$number: #cccccc is not a unitless number for `percentage'", "percentage(#ccc)")
+    assert_error_message("$number: \"string\" is not a unitless number for `percentage'", %Q{percentage("string")})
   end
 
   def test_round

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -149,7 +149,7 @@ class SassFunctionTest < Test::Unit::TestCase
   def test_ceil
     assert_equal("5",   evaluate("ceil(4.1)"))
     assert_equal("5px", evaluate("ceil(4.8px)"))
-    assert_equal("5px", evaluate("ceil($value: 4.8px)"))
+    assert_equal("5px", evaluate("ceil($number: 4.8px)"))
 
     assert_error_message("$value: \"a\" is not a number for `ceil'", "ceil(\"a\")")
   end

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -1017,9 +1017,9 @@ MSG
     assert_equal(%Q{true}, evaluate("comparable(2px, 1px)"))
     assert_equal(%Q{true}, evaluate("comparable(10cm, 3mm)"))
     assert_equal(%Q{false}, evaluate("comparable(100px, 3em)"))
-    assert_equal(%Q{false}, evaluate("comparable($number-1: 100px, $number-2: 3em)"))
-    assert_error_message("$number-1: #ff0000 is not a number for `comparable'", "comparable(#f00, 1px)")
-    assert_error_message("$number-2: #ff0000 is not a number for `comparable'", "comparable(1px, #f00)")
+    assert_equal(%Q{false}, evaluate("comparable($number1: 100px, $number2: 3em)"))
+    assert_error_message("$number1: #ff0000 is not a number for `comparable'", "comparable(#f00, 1px)")
+    assert_error_message("$number2: #ff0000 is not a number for `comparable'", "comparable(1px, #f00)")
   end
 
   def test_length

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -159,7 +159,7 @@ class SassFunctionTest < Test::Unit::TestCase
     assert_equal("5px", evaluate("abs(-5px)"))
     assert_equal("5",   evaluate("abs(5)"))
     assert_equal("5px", evaluate("abs(5px)"))
-    assert_equal("5px", evaluate("abs($value: 5px)"))
+    assert_equal("5px", evaluate("abs($number: 5px)"))
 
     assert_error_message("$value: #aaaaaa is not a number for `abs'", "abs(#aaa)")
   end

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -141,7 +141,7 @@ class SassFunctionTest < Test::Unit::TestCase
   def test_floor
     assert_equal("4",   evaluate("floor(4.8)"))
     assert_equal("4px", evaluate("floor(4.8px)"))
-    assert_equal("4px", evaluate("floor($value: 4.8px)"))
+    assert_equal("4px", evaluate("floor($number: 4.8px)"))
 
     assert_error_message("$value: \"foo\" is not a number for `floor'", "floor(\"foo\")")
   end

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -799,12 +799,12 @@ class SassFunctionTest < Test::Unit::TestCase
     assert_equal("blue", evaluate("mix(transparentize(#f00, 1), #00f, 0%)"))
     assert_equal("rgba(0, 0, 255, 0)", evaluate("mix(#f00, transparentize(#00f, 1), 0%)"))
     assert_equal("rgba(255, 0, 0, 0)", evaluate("mix(transparentize(#f00, 1), #00f, 100%)"))
-    assert_equal("rgba(255, 0, 0, 0)", evaluate("mix($color-1: transparentize(#f00, 1), $color-2: #00f, $weight: 100%)"))
+    assert_equal("rgba(255, 0, 0, 0)", evaluate("mix($color1: transparentize(#f00, 1), $color2: #00f, $weight: 100%)"))
   end
 
   def test_mix_tests_types
-    assert_error_message("$color-1: \"foo\" is not a color for `mix'", "mix(\"foo\", #f00, 10%)")
-    assert_error_message("$color-2: \"foo\" is not a color for `mix'", "mix(#f00, \"foo\", 10%)")
+    assert_error_message("$color1: \"foo\" is not a color for `mix'", "mix(\"foo\", #f00, 10%)")
+    assert_error_message("$color2: \"foo\" is not a color for `mix'", "mix(#f00, \"foo\", 10%)")
     assert_error_message("$weight: \"foo\" is not a number for `mix'", "mix(#f00, #baf, \"foo\")")
   end
 


### PR DESCRIPTION
Brings argument names for `comparable`, `percentage`, `round`, `ceil`, `floor`, `abs`, and `mix` in line with other functions as requested in issue #833.
