### PR TITLE
Fix exception on bad directive '@'

### DIFF
--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -712,6 +712,8 @@ WARNING
       when 'media'
         parser = Sass::SCSS::Parser.new(value, @options[:filename], @line)
         Tree::MediaNode.new(parser.parse_media_query_list.to_a)
+      when nil
+        raise SyntaxError.new("Invalid directive: '@'.")
       else
         unprefixed_directive = directive.gsub(/^-[a-z0-9]+-/i, '')
         if unprefixed_directive == 'supports'

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -158,6 +158,7 @@ MSG
     "a\n  b:\n    c\n    d" => ["Illegal nesting: Only properties may be nested beneath properties.", 3],
     "& foo\n  bar: baz\n  blat: bang" => ["Base-level rules cannot contain the parent-selector-referencing character '&'.", 1],
     "a\n  b: c\n& foo\n  bar: baz\n  blat: bang" => ["Base-level rules cannot contain the parent-selector-referencing character '&'.", 3],
+    "@" => "Invalid directive: '@'.",
   }
 
   def teardown


### PR DESCRIPTION
When sass encounters a sass-file that has a single @ character, it trips up the parser:

```
undefined method `gsub' for nil:NilClass
sass-3.2.13/lib/sass/engine.rb:716:in `parse_directive'
sass-3.2.13/lib/sass/engine.rb:566:in `parse_line'
sass-3.2.13/lib/sass/engine.rb:471:in `build_tree'
sass-3.2.13/lib/sass/engine.rb:490:in `block in append_children'
sass-3.2.13/lib/sass/engine.rb:489:in `each'
sass-3.2.13/lib/sass/engine.rb:489:in `append_children'
sass-3.2.13/lib/sass/engine.rb:345:in `_to_tree'
sass-3.2.13/lib/sass/engine.rb:274:in `to_tree'
```

In this case `directive` is `nil` so it triggers the else branch, which tries to call gsub on it.
