### PR TITLE
Fix exception on bad directive '@'

### DIFF
--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -791,6 +791,9 @@ WARNING
     #   rubocop:disable MethodLength
     def parse_directive(parent, line, root)
       directive, whitespace, value = line.text[1..-1].split(/(\s+)/, 2)
+
+      raise SyntaxError.new("Invalid directive: '@'.") unless directive
+
       offset = directive.size + whitespace.size + 1 if whitespace
 
       directive_name = directive.gsub('-', '_').to_sym

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -171,6 +171,7 @@ MSG
     "a\n  b:\n    c\n    d" => ["Illegal nesting: Only properties may be nested beneath properties.", 3],
     "& foo\n  bar: baz\n  blat: bang" => ["Base-level rules cannot contain the parent-selector-referencing character '&'.", 1],
     "a\n  b: c\n& foo\n  bar: baz\n  blat: bang" => ["Base-level rules cannot contain the parent-selector-referencing character '&'.", 3],
+    "@" => "Invalid directive: '@'.",
   }
 
   def teardown


### PR DESCRIPTION
Without this fix the following exception was raised:
NoMethodError: undefined method `gsub' for nil:NilClass

This is adapted to master form PR #1063 which was made against stable.
