### PR TITLE
Old link for IE Filters dead - added new link.

### DIFF
--- a/doc-src/SCSS_FOR_SASS_USERS.md
+++ b/doc-src/SCSS_FOR_SASS_USERS.md
@@ -6,7 +6,7 @@ while still supporting the full power of Sass.
 This means that every valid CSS3 stylesheet
 is a valid SCSS file with the same meaning.
 In addition, SCSS understands most CSS hacks
-and vendor-specific syntax, such as [IE's old `filter` syntax](http://msdn.microsoft.com/en-us/library/ms533754%28VS.85%29.aspx).
+and vendor-specific syntax, such as [IE's old `filter` syntax](http://msdn.microsoft.com/en-us/library/ms532847%28v=vs.85%29.aspx#Defining_Visual_Filt).
 
 Since SCSS is a CSS extension,
 everything that works in CSS works in SCSS.


### PR DESCRIPTION
I think this is close to what the old link had; though microsoft.com suggests http://msdn.microsoft.com/en-us/library/ie/aa740473.aspx.
