### PR TITLE
Add newline after sourceMappingURL comment to prevent Git warnings

### DIFF
--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -367,7 +367,7 @@ ERR
       rendered << "\n" unless compressed
       rendered << "/*# sourceMappingURL="
       rendered << Sass::Util.escape_uri(sourcemap_uri)
-      rendered << " */"
+      rendered << " */\n"
       rendered = encode_and_set_charset(rendered)
       return rendered, sourcemap
     end


### PR DESCRIPTION
When I enable sourcemaps generation while compiling Sass, the final line of each generated CSS file is something like:

```

/*# sourceMappingURL=help.css.map */
```

Because some deployments don't have a full build system in production, it can sometimes be necessary to check in generated CSS into source control. When I look at the changeset of a generated CSS file in Git, I always see this the " \ No newline at end of file" warning:

```
 diff --git a/public/css/help.css b/public/css/help.css
 index ede5afd..3bd5495 100644
 --- a/public/css/help.css
 +++ b/public/css/help.css
 @@ -23,3 +23,5 @@
    display: table-cell;
    vertical-align: middle;
  }
 +
 +/*# sourceMappingURL=help.css.map */
 \ No newline at end of file
```

This certainly isn't a bug. But adding a newline is an easy fix for this annoyance. Thanks!
