### PR TITLE
Fix marshaling of mixin def node with variable arguments

### DIFF
--- a/lib/sass/tree/visitors/set_options.rb
+++ b/lib/sass/tree/visitors/set_options.rb
@@ -63,6 +63,7 @@ class Sass::Tree::Visitors::SetOptions < Sass::Tree::Visitors::Base
       k.options = @options
       v.options = @options if v
     end
+    node.splat.options = @options if node.splat
     yield
   end
 

--- a/test/sass/cache_test.rb
+++ b/test/sass/cache_test.rb
@@ -73,10 +73,22 @@ class CacheTest < Test::Unit::TestCase
   end
 
   def test_cache_node_with_unmarshalable_option
-    engine = Sass::Engine.new("foo {a: b + c}",
-      :syntax => :scss, :object => Unmarshalable.new, :filename => 'file.scss',
-      :importer => Sass::Importers::Filesystem.new(absolutize('templates')))
-    engine.to_tree
+    engine_with_unmarshalable_options("foo {a: b + c}").to_tree
+  end
+
+  def test_cache_varargs_sass_node_with_unmarshalable_option
+    engine_with_unmarshalable_options(<<-SASS, :syntax => :sass).to_tree
+=color($args...)
+  color: red
+SASS
+  end
+
+  def test_cache_varargs_scss_node_with_unmarshalable_option
+    engine_with_unmarshalable_options(<<-SCSS, :syntax => :scss).to_tree
+      @mixin color($args...) {
+        color: red;
+      }
+    SCSS
   end
 
   private
@@ -85,5 +97,12 @@ class CacheTest < Test::Unit::TestCase
       @mixin color($c) { color: $c}
       div { @include color(red); }
     SCSS
+  end
+
+  def engine_with_unmarshalable_options(src, options={})
+    Sass::Engine.new(src, {
+      :syntax => :scss, :object => Unmarshalable.new, :filename => 'file.scss',
+      :importer => Sass::Importers::Filesystem.new(absolutize('templates'))
+    }.merge(options))
   end
 end


### PR DESCRIPTION
After seeing this issue for a long time and originally thinking it was an issue in Sprockets (sstephenson/sprockets#536), I've finally narrowed this down to an issue within Sass.

The problem occurs when defining a mixin with a splat argument, and when the engine options are unmarshalable (which is the case with Sprockets). e.g.

``` sass
=kaboom($args...)
  color: red
```

which gives an error like:

```
Warning. Error encountered while saving cache 5eeafa3aa0f7f3a490743b762a56c00651a72d7e/test.css.sassc: can't dump anonymous class #<Class:0x007fcacb3ef150>
```

Curiously this does not occur when using SCSS syntax. I'm not sure why.
