### PR TITLE
Allow custom script functions to be passed to an Engine

### DIFF
--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -458,6 +458,7 @@ module Sass::Script
       def initialize(environment)
         @environment = environment
         @options = environment.options
+        extend @options[:functions] if @options[:functions]
       end
 
       # Asserts that the type of a given SassScript value

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -27,6 +27,12 @@ module Sass::Script::Functions::UserFunctions
   end
 end
 
+module Sass::Script::Functions::MyFunctions
+  def my_option(name)
+    option(name)
+  end
+end
+
 module Sass::Script::Functions
   include Sass::Script::Functions::UserFunctions
 end
@@ -2686,6 +2692,17 @@ a {
 CSS
 a
   b: option("style")
+SASS
+  end
+
+  def test_my_options_available_in_environment
+    options = { :functions => Sass::Script::Functions::MyFunctions }
+    assert_equal(<<CSS, render(<<SASS, options))
+a {
+  b: nested; }
+CSS
+a
+  b: my-option("style")
 SASS
   end
 


### PR DESCRIPTION
Currently, the suggested and only api to extend Sass script functions are to monkey patch the `Sass::Script::Functions` module.

This can often lead to some plugin functions conflicting with others. Multiple `Sass::Engine`s maybe running in the same Ruby environments with different purposes. Its common to use Sass just as a css minifer since it does a good job. In this use case, you might not want any other functions leaking into the environment.

The idea is that you could pass in a module thats only extended on the `Engine`'s environment rather than globally.

``` ruby
module MyFunctions
  def my_url(url)
  end
end

Engine.new(css, { :functions => MyFunctions })
```

I'm not attached to the api or option name. Just setting up a straw man. 

cc @nex3 @rafaelfranca
