### PR TITLE
Don't freeze nil.

### DIFF
--- a/lib/sass/script/value/base.rb
+++ b/lib/sass/script/value/base.rb
@@ -20,7 +20,7 @@ module Sass::Script::Value
     #
     # @param value [Object] The object for \{#value}
     def initialize(value = nil)
-      @value = value.freeze
+      @value = value.freeze unless value.nil?
     end
 
     # Sets the options hash for this node,


### PR DESCRIPTION
In Ruby, the nil singleton object is not frozen. Freezing it breaks some other gems. When `Sass::Script::Value::Null` calls `new(nil)`, the Base class ends up freezing nil.

```
~$ irb
2.1.1 :001 > nil.frozen?
 => false
```

Conveniently, the `unless` syntax leaves `@value` as good ol' nil, so there's no need for a ternary. :honeybee: 

Tests pass.
