### PR TITLE
corrected a small misprint in opacify/transparentize description

### DIFF
--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -920,7 +920,7 @@ For example:
 is compiled to:
 
     p {
-      color: rgba(255, 0, 0, 0.9);
+      color: rgba(255, 0, 0, 0.8);
       background-color: rgba(255, 0, 0, 0.25); }
 
 IE filters require all colors include the alpha layer, and be in


### PR DESCRIPTION
With this commit I corrected a small typo in the sass reference: "rgba(255, 0, 0, 0.5)" opacified by .3 equals "rgba(255, 0, 0, 0.8)", not "rgba(255, 0, 0, 0.9)".
