### PR TITLE
Fix incorrect documentation of map-has-key

### DIFF
--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -202,7 +202,7 @@ module Sass::Script
   # \{#map_values map-values($map)}
   # : Returns a list of all values in a map.
   #
-  # \{#map_has_key map-has-key($key)}
+  # \{#map_has_key map-has-key($map, $key)}
   # : Returns whether a map has a value associated with a given key.
   #
   # \{#keywords keywords($args)}


### PR DESCRIPTION
`map-has-key` was previously documented as taking a single parameter, `$key`. Since this is obviously not the case, I updated the documentation to show `map-has-key` taking two parameters, `$map` and `$key`.
