### PR TITLE
Do not freeze `true` or `false` in `Script::Value::Base.new`.

### DIFF
--- a/lib/sass/script/value/base.rb
+++ b/lib/sass/script/value/base.rb
@@ -20,7 +20,8 @@ module Sass::Script::Value
     #
     # @param value [Object] The object for \{#value}
     def initialize(value = nil)
-      @value = value.freeze unless value.nil?
+      value.freeze unless [nil, true, false].include?(value)
+      @value = value
     end
 
     # Sets the options hash for this node,


### PR DESCRIPTION
This fixes #1210, wherein the freezing of `true` causes strange side
effects in other gems. It also separates the `value.freeze` call from
the assignment `@value = value`, to emphasize that `value.freeze` is a
side effect that mutates the value, not a function that returns a frozen
copy of the value.
