### PR TITLE
script/lexer: properly calculate source_range in `scan`

### DIFF
--- a/lib/sass/script/lexer.rb
+++ b/lib/sass/script/lexer.rb
@@ -370,7 +370,7 @@ MESSAGE
         return unless str
         c = str.count("\n")
         @line += c
-        @offset = (c == 0 ? @offset + str.size : str.size - str.rindex("\n") + 1)
+        @offset = (c == 0 ? @offset + str.size : str.size - str.rindex("\n"))
         str
       end
 


### PR DESCRIPTION
Given the following SCSS:

``` scss
$sizes: (
  navbar: (0.10, 0.20, 0.30)
);
```

The tree looks like this:

``` ruby
  > engine = Sass::Engine.new("...", :syntax => :scss)
  > engine.to_tree

==>  Sass::Tree::RootNode (1:1 to 1:1)
     |--Sass::Tree::VariableNode (1:2 to 3:3)
        |--.expr Sass::Script::Tree::MapLiteral (1:10 to 3:2)     !
           |--Sass::Script::Tree::Literal "navbar" (2:4 to 2:10)  !
           |--Sass::Script::Tree::ListLiteral (2:13 to 2:17)      !
              |--Sass::Script::Tree::Literal "0.1" (2:13 to 2:17) !
              |--Sass::Script::Tree::Literal "0.2" (2:19 to 2:23) !
              |--Sass::Script::Tree::Literal "0.3" (2:25 to 2:29) !
```

If you look closely, the `source_range` of every node marked with `!` is shifted right by one character. Though the tree is parsed correctly, it breaks scss-lint's ability to extract the original source code, and borks a linter: causes/scss-lint#151.

It looks to be an off-by-one error in the lexer fixed by this PR.

When scanning the string `"··\n···"`, we want to set the offset to 4, because there are three characters following the last newline. A diagram to hopefully prove I'm not crazy:

```
    "  \n   "
off  123 123
ind  012 345

size 6
```

So the correct formula is `(size - last newline idx) => (6 - 2) = 4`—right?

I'd write a test case, but I'm not sure where to put it. There don't currently seem to be any assertions on `source_range`. In any case, all existing tests pass locally with this modification.
