### PR TITLE
Listen loading refactor

### DIFF
--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -229,7 +229,9 @@ module Sass::Plugin
       # A Listen version prior to 2.0 will write a test file to a directory to
       # see if a watcher supports watching that directory. That breaks horribly
       # on read-only directories, so we filter those out.
-      directories.reject {|d| File.writable?(d)} unless Sass::Util.listen_geq_2?
+      unless Sass::Util.listen_geq_2?
+        directories = directories.select {|d| File.directory?(d) && File.writable?(d)}
+      end
 
       # TODO: Keep better track of what depends on what
       # so we don't have to run a global update every time anything changes.

--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -276,7 +276,7 @@ module Sass::Plugin
     private
 
     def create_listener(*args, &block)
-      load_listen!
+      Sass::Util.load_listen!
       if Sass::Util.listen_geq_2?
         Listen.to(*args, &block)
       else
@@ -308,44 +308,6 @@ module Sass::Plugin
         dedupped << new_directory
       end
       dedupped
-    end
-
-    def load_listen!
-      if defined?(gem)
-        begin
-          gem 'listen', '>= 1.1.0', '< 3.0.0'
-          require 'listen'
-        rescue Gem::LoadError
-          dir = Sass::Util.scope("vendor/listen/lib")
-          $LOAD_PATH.unshift dir
-          begin
-            require 'listen'
-          rescue LoadError => e
-            if Sass::Util.version_geq(RUBY_VERSION, "1.9.3")
-              version_constraint = "~> 2.7"
-            else
-              version_constraint = "~> 1.1"
-            end
-            e.message << "\n" <<
-              "Run \"gem install listen --version '#{version_constraint}'\" to get it."
-            raise e
-          end
-        end
-      else
-        begin
-          require 'listen'
-        rescue LoadError => e
-          dir = Sass::Util.scope("vendor/listen/lib")
-          if $LOAD_PATH.include?(dir)
-            raise e unless File.exists?(scope(".git"))
-            e.message << "\n" <<
-              'Run "git submodule update --init" to get the bundled version.'
-          else
-            $LOAD_PATH.unshift dir
-            retry
-          end
-        end
-      end
     end
 
     def on_file_changed(individual_files, modified, added, removed)

--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -1173,6 +1173,44 @@ MSG
       tmpfile.unlink if tmpfile
     end
 
+    def load_listen!
+      if defined?(gem)
+        begin
+          gem 'listen', '>= 1.1.0', '< 3.0.0'
+          require 'listen'
+        rescue Gem::LoadError
+          dir = scope("vendor/listen/lib")
+          $LOAD_PATH.unshift dir
+          begin
+            require 'listen'
+          rescue LoadError => e
+            if version_geq(RUBY_VERSION, "1.9.3")
+              version_constraint = "~> 2.7"
+            else
+              version_constraint = "~> 1.1"
+            end
+            e.message << "\n" <<
+              "Run \"gem install listen --version '#{version_constraint}'\" to get it."
+            raise e
+          end
+        end
+      else
+        begin
+          require 'listen'
+        rescue LoadError => e
+          dir = scope("vendor/listen/lib")
+          if $LOAD_PATH.include?(dir)
+            raise e unless File.exists?(scope(".git"))
+            e.message << "\n" <<
+              'Run "git submodule update --init" to get the bundled version.'
+          else
+            $LOAD_PATH.unshift dir
+            retry
+          end
+        end
+      end
+    end
+
     private
 
     # rubocop:disable LineLength

--- a/test/sass/compiler_test.rb
+++ b/test/sass/compiler_test.rb
@@ -174,12 +174,12 @@ class CompilerTest < Test::Unit::TestCase
     directories = nil
     c = watcher do |listener|
       directories = listener.directories
-      listener.removed "/asdf/foobar/sass/foo.scss"
+      listener.removed File.expand_path("./foo.scss")
       listener.fire_events!
     end
-    c.watch([["/asdf/foobar/sass/foo.scss", "/asdf/foobar/css/foo.css", nil]])
-    assert directories.include?("/asdf/foobar/sass"), directories.inspect
-    assert_equal "/asdf/foobar/css/foo.css", c.deleted_css_files.first, "the corresponding css file was not deleted"
+    c.watch([[File.expand_path("./foo.scss"), File.expand_path("./foo.css"), nil]])
+    assert directories.include?(File.expand_path(".")), directories.inspect
+    assert_equal File.expand_path("./foo.css"), c.deleted_css_files.first, "the corresponding css file was not deleted"
     assert_equal [], c.update_stylesheets_called_with[1], "the sass file should not have been compiled"
   end
 


### PR DESCRIPTION
This is a simple refactor that moves the code for loading the listen library from Sass::Compiler to Sass::Util so that compass can call it.
