### PR TITLE
Minitest5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,3 +18,4 @@ else
 end
 
 gem 'rubyforge', :group => :development
+gem 'minitest', :group => :test

--- a/sass.gemspec
+++ b/sass.gemspec
@@ -21,6 +21,7 @@ SASS_GEMSPEC = Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.8.7'
   spec.add_development_dependency 'yard', '>= 0.5.3'
   spec.add_development_dependency 'maruku', '>= 0.5.9'
+  spec.add_development_dependency 'minitest', '>= 5'
 
   readmes = Dir['*'].reject{ |x| x =~ /(^|[^.a-z])[a-z]+/ || x == "TODO" }
   spec.executables = ['sass', 'sass-convert', 'scss']

--- a/test/sass/cache_test.rb
+++ b/test/sass/cache_test.rb
@@ -3,7 +3,7 @@ require File.dirname(__FILE__) + '/../test_helper'
 require File.dirname(__FILE__) + '/test_helper'
 require 'sass/engine'
 
-class CacheTest < Test::Unit::TestCase
+class CacheTest < MiniTest::Test
   @@cache_dir = "tmp/file_cache"
 
   def setup

--- a/test/sass/callbacks_test.rb
+++ b/test/sass/callbacks_test.rb
@@ -26,7 +26,7 @@ module ClassLevelCallerBack
   end
 end
 
-class SassCallbacksTest < Test::Unit::TestCase
+class SassCallbacksTest < MiniTest::Test
   def test_simple_callback
     cb = CallerBack.new
     there = false

--- a/test/sass/compiler_test.rb
+++ b/test/sass/compiler_test.rb
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
-require 'test/unit'
+require 'minitest/autorun'
 require File.dirname(__FILE__) + '/../test_helper'
 require 'sass/plugin'
 require 'sass/plugin/compiler'
 
-class CompilerTest < Test::Unit::TestCase
+class CompilerTest < MiniTest::Test
   class FakeListener
     attr_accessor :options
     attr_accessor :directories

--- a/test/sass/conversion_test.rb
+++ b/test/sass/conversion_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require File.dirname(__FILE__) + '/../test_helper'
 
-class ConversionTest < Test::Unit::TestCase
+class ConversionTest < MiniTest::Test
   def test_basic
     assert_renders <<SASS, <<SCSS
 foo bar

--- a/test/sass/css2sass_test.rb
+++ b/test/sass/css2sass_test.rb
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
-require 'test/unit'
+require 'minitest/autorun'
 require File.dirname(__FILE__) + '/../test_helper'
 require 'sass/css'
 
-class CSS2SassTest < Test::Unit::TestCase
+class CSS2SassTest < MiniTest::Test
   def test_basic
     css = <<CSS
 h1 {

--- a/test/sass/encoding_test.rb
+++ b/test/sass/encoding_test.rb
@@ -4,7 +4,7 @@ require File.dirname(__FILE__) + '/../test_helper'
 require File.dirname(__FILE__) + '/test_helper'
 require 'sass/util/test'
 
-class EncodingTest < Test::Unit::TestCase
+class EncodingTest < MiniTest::Test
   include Sass::Util::Test
 
   def test_encoding_error

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -31,7 +31,7 @@ module Sass::Script::Functions
   include Sass::Script::Functions::UserFunctions
 end
 
-class SassEngineTest < Test::Unit::TestCase
+class SassEngineTest < MiniTest::Test
   FAKE_FILE_NAME = __FILE__.gsub(/rb$/,"sass")
   # A map of erroneous Sass documents to the error messages they should produce.
   # The error messages may be arrays;
@@ -1668,7 +1668,7 @@ SASS
   end
 
   def test_argument_error
-    assert_raise(Sass::SyntaxError) { render("a\n  b: hsl(1)") }
+    assert_raises(Sass::SyntaxError) { render("a\n  b: hsl(1)") }
   end
 
   def test_comments_at_the_top_of_a_document

--- a/test/sass/exec_test.rb
+++ b/test/sass/exec_test.rb
@@ -3,7 +3,7 @@ require File.dirname(__FILE__) + '/../test_helper'
 require 'sass/util/test'
 require 'tmpdir'
 
-class ExecTest < Test::Unit::TestCase
+class ExecTest < MiniTest::Test
   include Sass::Util::Test
 
   def setup

--- a/test/sass/extend_test.rb
+++ b/test/sass/extend_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require File.dirname(__FILE__) + '/../test_helper'
 
-class ExtendTest < Test::Unit::TestCase
+class ExtendTest < MiniTest::Test
   def test_basic
     assert_equal <<CSS, render(<<SCSS)
 .foo, .bar {
@@ -675,7 +675,7 @@ SCSS
   end
 
   def test_nested_extender_with_trailing_child_selector
-    assert_raise(Sass::SyntaxError, "bar > can't extend: invalid selector") do
+    assert_raises(Sass::SyntaxError, "bar > can't extend: invalid selector") do
       render("bar > {@extend .baz}")
     end
   end

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require 'test/unit'
+require 'minitest/autorun'
 require File.dirname(__FILE__) + '/../test_helper'
 require File.dirname(__FILE__) + '/test_helper'
 require 'sass/script'
@@ -51,7 +51,7 @@ module Sass::Script::Functions
   include Sass::Script::Functions::UserFunctions
 end
 
-class SassFunctionTest < Test::Unit::TestCase
+class SassFunctionTest < MiniTest::Test
   # Tests taken from:
   #   http://www.w3.org/Style/CSS/Test/CSS3/Color/20070927/html4/t040204-hsl-h-rotating-b.htm
   #   http://www.w3.org/Style/CSS/Test/CSS3/Color/20070927/html4/t040204-hsl-values-b.htm
@@ -1321,7 +1321,7 @@ SCSS
     50.times do
       last_id, current_id = current_id, evaluate("unique-id()")
       assert_match(/u[a-z0-9]{8}/, current_id)
-      assert_not_equal last_id, current_id
+      refute_equal last_id, current_id
     end
   end
 
@@ -1646,7 +1646,7 @@ SCSS
     if Sass::Script::Functions.instance_variable_defined?("@random_number_generator")
       Sass::Script::Functions.send(:remove_instance_variable, "@random_number_generator")
     end
-    assert_not_equal evaluate("random()"), evaluate("random()")
+    refute_equal evaluate("random()"), evaluate("random()")
   end
 
   def test_deprecated_arg_names

--- a/test/sass/importer_test.rb
+++ b/test/sass/importer_test.rb
@@ -4,7 +4,7 @@ require File.dirname(__FILE__) + '/test_helper'
 require 'mock_importer'
 require 'sass/plugin'
 
-class ImporterTest < Test::Unit::TestCase
+class ImporterTest < MiniTest::Test
 
   class FruitImporter < Sass::Importers::Base
     def find(name, context = nil)
@@ -397,6 +397,6 @@ MESSAGE
 
   def test_absolute_files_across_template_locations
     importer = Sass::Importers::Filesystem.new(absolutize 'templates')
-    assert_not_nil importer.mtime(absolutize('more_templates/more1.sass'), {})
+    refute_nil importer.mtime(absolutize('more_templates/more1.sass'), {})
   end
 end

--- a/test/sass/logger_test.rb
+++ b/test/sass/logger_test.rb
@@ -2,7 +2,7 @@
 require File.dirname(__FILE__) + '/../test_helper'
 require 'pathname'
 
-class LoggerTest < Test::Unit::TestCase
+class LoggerTest < MiniTest::Test
 
   class InterceptedLogger < Sass::Logger::Base
 

--- a/test/sass/plugin_test.rb
+++ b/test/sass/plugin_test.rb
@@ -17,7 +17,7 @@ module Sass::Script::Functions
   end
 end
 
-class SassPluginTest < Test::Unit::TestCase
+class SassPluginTest < MiniTest::Test
   @@templates = %w{
     complex script parent_ref import scss_import alt
     subdir/subdir subdir/nested_subdir/nested_subdir
@@ -183,7 +183,7 @@ CSS
     Sass::Plugin.options[:full_exception] = false
 
     File.delete(tempfile_loc('bork1'))
-    assert_raise(Sass::SyntaxError) {check_for_updates!}
+    assert_raises(Sass::SyntaxError) {check_for_updates!}
   ensure
     Sass::Plugin.options[:full_exception] = old_full_exception
   end

--- a/test/sass/script_conversion_test.rb
+++ b/test/sass/script_conversion_test.rb
@@ -3,7 +3,7 @@
 require File.dirname(__FILE__) + '/../test_helper'
 require 'sass/engine'
 
-class SassScriptConversionTest < Test::Unit::TestCase
+class SassScriptConversionTest < MiniTest::Test
   def test_bool
     assert_renders "true"
     assert_renders "false"

--- a/test/sass/script_test.rb
+++ b/test/sass/script_test.rb
@@ -18,7 +18,7 @@ module Sass::Script::Functions
   include Sass::Script::Functions::UserFunctions
 end
 
-class SassScriptTest < Test::Unit::TestCase
+class SassScriptTest < MiniTest::Test
   include Sass::Script
 
   def test_color_checks_input
@@ -281,8 +281,8 @@ SASS
     assert_equal eval('1 2 3.0'), eval('1 2 3')
     assert_equal eval('1, 2, 3.0'), eval('1, 2, 3')
     assert_equal eval('(1 2), (3, 4), (5 6)'), eval('(1 2), (3, 4), (5 6)')
-    assert_not_equal eval('1, 2, 3'), eval('1 2 3')
-    assert_not_equal eval('1'), eval('"1"')
+    refute_equal eval('1, 2, 3'), eval('1 2 3')
+    refute_equal eval('1'), eval('"1"')
   end
 
   def test_booleans
@@ -614,7 +614,7 @@ SASS
     return if RUBY_PLATFORM =~ /java/
 
     # Don't validate the message; it's different on Rubinius.
-    assert_raise(ArgumentError) {resolve("arg-error()")}
+    assert_raises(ArgumentError) {resolve("arg-error()")}
   end
 
   def test_shallow_argument_error_unwrapped

--- a/test/sass/scss/css_test.rb
+++ b/test/sass/scss/css_test.rb
@@ -6,7 +6,7 @@ require 'sass/scss/css_parser'
 # These tests just test the parsing of CSS
 # (both standard and any hacks we intend to support).
 # Tests of SCSS-specific behavior go in scss_test.rb.
-class ScssCssTest < Test::Unit::TestCase
+class ScssCssTest < MiniTest::Test
   include ScssTestHelper
 
   def test_basic_scss

--- a/test/sass/scss/rx_test.rb
+++ b/test/sass/scss/rx_test.rb
@@ -3,7 +3,7 @@
 require File.dirname(__FILE__) + '/../../test_helper'
 require 'sass/engine'
 
-class ScssRxTest < Test::Unit::TestCase
+class ScssRxTest < MiniTest::Test
   include Sass::SCSS::RX
 
   def test_identifiers
@@ -144,13 +144,13 @@ class ScssRxTest < Test::Unit::TestCase
   private
 
   def assert_match(rx, str)
-    assert_not_nil(match = rx.match(str))
+    refute_nil(match = rx.match(str))
     assert_equal str.size, match[0].size
   end
 
   def assert_no_match(rx, str)
     match = rx.match(str)
-    assert_not_equal str.size, match && match[0].size
+    refute_equal str.size, match && match[0].size
   end
 
 end

--- a/test/sass/scss/scss_test.rb
+++ b/test/sass/scss/scss_test.rb
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 require File.dirname(__FILE__) + '/test_helper'
 
-class ScssTest < Test::Unit::TestCase
+class ScssTest < MiniTest::Test
   include ScssTestHelper
 
   ## One-Line Comments

--- a/test/sass/source_map_test.rb
+++ b/test/sass/source_map_test.rb
@@ -3,12 +3,12 @@
 require File.dirname(__FILE__) + '/../test_helper'
 require File.dirname(__FILE__) + '/test_helper'
 
-class SourcemapTest < Test::Unit::TestCase
+class SourcemapTest < MiniTest::Test
   def test_to_json_requires_args
     _, sourcemap = render_with_sourcemap('')
-    assert_raise(ArgumentError) {sourcemap.to_json({})}
-    assert_raise(ArgumentError) {sourcemap.to_json({:css_path => 'foo'})}
-    assert_raise(ArgumentError) {sourcemap.to_json({:sourcemap_path => 'foo'})}
+    assert_raises(ArgumentError) {sourcemap.to_json({})}
+    assert_raises(ArgumentError) {sourcemap.to_json({:css_path => 'foo'})}
+    assert_raises(ArgumentError) {sourcemap.to_json({:sourcemap_path => 'foo'})}
   end
 
   def test_simple_mapping_scss

--- a/test/sass/superselector_test.rb
+++ b/test/sass/superselector_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require File.dirname(__FILE__) + '/../test_helper'
 
-class SuperselectorTest < Test::Unit::TestCase
+class SuperselectorTest < MiniTest::Test
   def test_superselector_reflexivity
     assert_superselector 'h1', 'h1'
     assert_superselector '.foo', '.foo'
@@ -29,13 +29,13 @@ class SuperselectorTest < Test::Unit::TestCase
   end
 
   def test_leading_combinator_superselector
-    assert_not_superselector '+ .foo', '.foo'
-    assert_not_superselector '+ .foo', '.bar + .foo'
+    refute_superselector '+ .foo', '.foo'
+    refute_superselector '+ .foo', '.bar + .foo'
   end
 
   def test_trailing_combinator_superselector
-    assert_not_superselector '.foo +', '.foo'
-    assert_not_superselector '.foo +', '.foo + .bar'
+    refute_superselector '.foo +', '.foo'
+    refute_superselector '.foo +', '.foo + .bar'
   end
 
   def test_matching_combinator_superselector
@@ -71,8 +71,8 @@ class SuperselectorTest < Test::Unit::TestCase
   end
 
   def test_matches_is_not_superselector_of_any
-    assert_not_superselector ':matches(.foo, .bar)', ':-moz-any(.foo, .bar)'
-    assert_not_superselector ':-moz-any(.foo, .bar)', ':matches(.foo, .bar)'
+    refute_superselector ':matches(.foo, .bar)', ':-moz-any(.foo, .bar)'
+    refute_superselector ':-moz-any(.foo, .bar)', ':matches(.foo, .bar)'
   end
 
   def test_matches_can_be_subselector
@@ -84,7 +84,7 @@ class SuperselectorTest < Test::Unit::TestCase
   end
 
   def test_any_is_not_superselector_of_different_prefix
-    assert_not_superselector ':-moz-any(.foo, .bar)', ':-s-any(.foo, .bar)'
+    refute_superselector ':-moz-any(.foo, .bar)', ':-s-any(.foo, .bar)'
   end
 
   def test_not_is_superselector_of_less_complex_not
@@ -103,8 +103,8 @@ class SuperselectorTest < Test::Unit::TestCase
   end
 
   def test_not_is_not_superselector_of_non_unique_selectors
-    assert_not_superselector ':not(.foo)', '.bar'
-    assert_not_superselector ':not(:hover)', ':visited'
+    refute_superselector ':not(.foo)', '.bar'
+    refute_superselector ':not(:hover)', ':visited'
   end
 
   def test_current_is_superselector_with_identical_innards
@@ -112,8 +112,8 @@ class SuperselectorTest < Test::Unit::TestCase
   end
 
   def test_current_is_superselector_with_subselector_innards
-    assert_not_superselector ':current(.foo)', ':current(.foo.bar)'
-    assert_not_superselector ':current(.foo.bar)', ':current(.foo)'
+    refute_superselector ':current(.foo)', ':current(.foo.bar)'
+    refute_superselector ':current(.foo.bar)', ':current(.foo)'
   end
 
   def test_nth_match_is_superselector_of_subset_nth_match
@@ -124,15 +124,15 @@ class SuperselectorTest < Test::Unit::TestCase
   end
 
   def test_nth_match_is_not_superselector_of_nth_match_with_different_arg
-    assert_not_superselector(
+    refute_superselector(
       ':nth-child(2n of .foo, .bar, .baz)', '#x:nth-child(2n + 1 of .foo.bip, .baz.bang)')
-    assert_not_superselector(
+    refute_superselector(
       ':nth-last-child(2n of .foo, .bar, .baz)', '#x:nth-last-child(2n + 1 of .foo.bip, .baz.bang)')
   end
 
   def test_nth_match_is_not_superselector_of_nth_last_match
-    assert_not_superselector ':nth-child(2n of .foo, .bar)', ':nth-last-child(2n of .foo, .bar)'
-    assert_not_superselector ':nth-last-child(2n of .foo, .bar)', ':nth-child(2n of .foo, .bar)'
+    refute_superselector ':nth-child(2n of .foo, .bar)', ':nth-last-child(2n of .foo, .bar)'
+    refute_superselector ':nth-last-child(2n of .foo, .bar)', ':nth-child(2n of .foo, .bar)'
   end
 
   def test_nth_match_can_be_subselector
@@ -150,14 +150,14 @@ class SuperselectorTest < Test::Unit::TestCase
       "Expected #{superselector} to be a superselector of #{subselector}.")
   end
 
-  def assert_not_superselector(superselector, subselector)
+  def refute_superselector(superselector, subselector)
     assert(!parse_selector(superselector).superselector?(parse_selector(subselector)),
       "Expected #{superselector} not to be a superselector of #{subselector}.")
   end
 
   def assert_strict_superselector(superselector, subselector)
     assert_superselector(superselector, subselector)
-    assert_not_superselector(subselector, superselector)
+    refute_superselector(subselector, superselector)
   end
 
   def parse_selector(selector)

--- a/test/sass/test_helper.rb
+++ b/test/sass/test_helper.rb
@@ -1,7 +1,7 @@
 test_dir = File.dirname(__FILE__)
 $:.unshift test_dir unless $:.include?(test_dir)
 
-class Test::Unit::TestCase
+class MiniTest::Test
   def absolutize(file)
     File.expand_path("#{File.dirname(__FILE__)}/#{file}")
   end

--- a/test/sass/util/multibyte_string_scanner_test.rb
+++ b/test/sass/util/multibyte_string_scanner_test.rb
@@ -3,7 +3,7 @@
 require File.dirname(__FILE__) + '/../../test_helper'
 
 unless Sass::Util.ruby1_8?
-  class MultibyteStringScannerTest < Test::Unit::TestCase
+  class MultibyteStringScannerTest < MiniTest::Test
     def setup
       @scanner = Sass::Util::MultibyteStringScanner.new("cölorfül")
     end

--- a/test/sass/util/normalized_map_test.rb
+++ b/test/sass/util/normalized_map_test.rb
@@ -2,7 +2,7 @@
 require File.dirname(__FILE__) + '/../../test_helper'
 require 'sass/util/normalized_map'
 
-class NormalizedMapTest < Test::Unit::TestCase
+class NormalizedMapTest < MiniTest::Test
   extend PublicApiLinter
 
   lint_api Hash, Sass::Util::NormalizedMap

--- a/test/sass/util/subset_map_test.rb
+++ b/test/sass/util/subset_map_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require File.dirname(__FILE__) + '/../../test_helper'
 
-class SubsetMapTest < Test::Unit::TestCase
+class SubsetMapTest < MiniTest::Test
   def setup
     @ssm = Sass::Util::SubsetMap.new
     @ssm[Set[1, 2]] = "Foo"
@@ -44,7 +44,7 @@ class SubsetMapTest < Test::Unit::TestCase
   end
 
   def test_empty_key_set
-    assert_raise(ArgumentError) {@ssm[Set[]] = "Fail"}
+    assert_raises(ArgumentError) {@ssm[Set[]] = "Fail"}
   end
 
   def test_empty_key_get

--- a/test/sass/util_test.rb
+++ b/test/sass/util_test.rb
@@ -3,7 +3,7 @@ require File.dirname(__FILE__) + '/../test_helper'
 require 'pathname'
 require 'tmpdir'
 
-class UtilTest < Test::Unit::TestCase
+class UtilTest < MiniTest::Test
   include Sass::Util
 
   def test_scope

--- a/test/sass/value_helpers_test.rb
+++ b/test/sass/value_helpers_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require File.dirname(__FILE__) + '/../test_helper'
 
-class ValueHelpersTest < Test::Unit::TestCase
+class ValueHelpersTest < MiniTest::Test
   include Sass::Script
   include Sass::Script::Value::Helpers
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 lib_dir = File.dirname(__FILE__) + '/../lib'
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'fileutils'
 $:.unshift lib_dir unless $:.include?(lib_dir)
 require 'sass'
@@ -22,7 +22,7 @@ module Sass::Script::Functions
   end
 end
 
-class Test::Unit::TestCase
+class MiniTest::Test
   def munge_filename(opts = {})
     opts[:filename] ||= filename_for_test(opts[:syntax] || :sass)
     opts[:sourcemap_filename] ||= sourcemap_filename_for_test


### PR DESCRIPTION
Greetings, we're looking to fix some packages in Fedora the were broken by a recent update to minitest (now at 5.3.1).

sass was one of the gems that was broken due to it's dependency on the old API.

http://koji.fedoraproject.org/koji/packageinfo?packageID=12284

I went through and patched the source to work against the new API and am sending a PR for hopeful inclusion upstream.

Thank you for your time.
