### PR TITLE
Fix deprecation warning File.exists? -> File.exist?

### DIFF
--- a/lib/sass/exec.rb
+++ b/lib/sass/exec.rb
@@ -682,7 +682,7 @@ END
         unless File.directory?(@options[:input])
           raise "Error: '#{@options[:input]}' is not a directory"
         end
-        if @options[:output] && File.exists?(@options[:output]) &&
+        if @options[:output] && File.exist?(@options[:output]) &&
           !File.directory?(@options[:output])
           raise "Error: '#{@options[:output]}' is not a directory"
         end
@@ -711,7 +711,7 @@ END
             FileUtils.mkdir_p(File.dirname(output))
           end
           puts_action :convert, :green, f
-          if File.exists?(output)
+          if File.exist?(output)
             puts_action :overwrite, :yellow, output
           else
             puts_action :create, :green, output

--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -353,14 +353,14 @@ module Sass::Plugin
       if recompile_required
         # In case a file we're watching is removed and then recreated we
         # prune out the non-existant files here.
-        watched_files_remaining = individual_files.select {|(source, _, _)| File.exists?(source)}
+        watched_files_remaining = individual_files.select {|(source, _, _)| File.exist?(source)}
         update_stylesheets(watched_files_remaining)
       end
     end
 
     def update_stylesheet(filename, css, sourcemap)
       dir = File.dirname(css)
-      unless File.exists?(dir)
+      unless File.exist?(dir)
         run_creating_directory dir
         FileUtils.mkdir_p dir
       end
@@ -400,12 +400,12 @@ module Sass::Plugin
     end
 
     def try_delete_css(css)
-      if File.exists?(css)
+      if File.exist?(css)
         run_deleting_css css
         File.delete css
       end
       map = Sass::Util.sourcemap_name(css)
-      if File.exists?(map)
+      if File.exist?(map)
         run_deleting_sourcemap map
         File.delete map
       end

--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -1237,7 +1237,7 @@ MSG
         rescue LoadError => e
           dir = scope("vendor/listen/lib")
           if $LOAD_PATH.include?(dir)
-            raise e unless File.exists?(scope(".git"))
+            raise e unless File.exist?(scope(".git"))
             e.message << "\n" <<
               'Run "git submodule update --init" to get the bundled version.'
           else

--- a/lib/sass/version.rb
+++ b/lib/sass/version.rb
@@ -85,20 +85,20 @@ module Sass
     private
 
     def revision_number
-      if File.exists?(Sass::Util.scope('REVISION'))
+      if File.exist?(Sass::Util.scope('REVISION'))
         rev = File.read(Sass::Util.scope('REVISION')).strip
         return rev unless rev =~ /^([a-f0-9]+|\(.*\))$/ || rev == '(unknown)'
       end
 
-      return unless File.exists?(Sass::Util.scope('.git/HEAD'))
+      return unless File.exist?(Sass::Util.scope('.git/HEAD'))
       rev = File.read(Sass::Util.scope('.git/HEAD')).strip
       return rev unless rev =~ /^ref: (.*)$/
 
       ref_name = $1
       ref_file = Sass::Util.scope(".git/#{ref_name}")
       info_file = Sass::Util.scope(".git/info/refs")
-      return File.read(ref_file).strip if File.exists?(ref_file)
-      return unless File.exists?(info_file)
+      return File.read(ref_file).strip if File.exist?(ref_file)
+      return unless File.exist?(info_file)
       File.open(info_file) do |f|
         f.each do |l|
           sha, ref = l.strip.split("\t", 2)
@@ -110,7 +110,7 @@ module Sass
     end
 
     def version_date
-      return unless File.exists?(Sass::Util.scope('VERSION_DATE'))
+      return unless File.exist?(Sass::Util.scope('VERSION_DATE'))
       DateTime.parse(File.read(Sass::Util.scope('VERSION_DATE')).strip)
     end
   end

--- a/test/sass/cache_test.rb
+++ b/test/sass/cache_test.rb
@@ -18,42 +18,42 @@ class CacheTest < Test::Unit::TestCase
   def test_file_cache_writes_a_file
     file_store = Sass::CacheStores::Filesystem.new(@@cache_dir)
     file_store.store("asdf/foo.scssc", "fakesha1", root_node)
-    assert File.exists?("#{@@cache_dir}/asdf/foo.scssc")
+    assert File.exist?("#{@@cache_dir}/asdf/foo.scssc")
   end
 
   def test_file_cache_reads_a_file
     file_store = Sass::CacheStores::Filesystem.new(@@cache_dir)
-    assert !File.exists?("#{@@cache_dir}/asdf/foo.scssc")
+    assert !File.exist?("#{@@cache_dir}/asdf/foo.scssc")
     file_store.store("asdf/foo.scssc", "fakesha1", root_node)
-    assert File.exists?("#{@@cache_dir}/asdf/foo.scssc")
+    assert File.exist?("#{@@cache_dir}/asdf/foo.scssc")
     assert_kind_of Sass::Tree::RootNode, file_store.retrieve("asdf/foo.scssc", "fakesha1")
   end
 
   def test_file_cache_miss_returns_nil
     file_store = Sass::CacheStores::Filesystem.new(@@cache_dir)
-    assert !File.exists?("#{@@cache_dir}/asdf/foo.scssc")
+    assert !File.exist?("#{@@cache_dir}/asdf/foo.scssc")
     assert_nil file_store.retrieve("asdf/foo.scssc", "fakesha1")
   end
 
   def test_sha_change_invalidates_cache_and_cleans_up
     file_store = Sass::CacheStores::Filesystem.new(@@cache_dir)
-    assert !File.exists?("#{@@cache_dir}/asdf/foo.scssc")
+    assert !File.exist?("#{@@cache_dir}/asdf/foo.scssc")
     file_store.store("asdf/foo.scssc", "fakesha1", root_node)
-    assert File.exists?("#{@@cache_dir}/asdf/foo.scssc")
+    assert File.exist?("#{@@cache_dir}/asdf/foo.scssc")
     assert_nil file_store.retrieve("asdf/foo.scssc", "differentsha1")
-    assert !File.exists?("#{@@cache_dir}/asdf/foo.scssc")
+    assert !File.exist?("#{@@cache_dir}/asdf/foo.scssc")
   end
 
   def test_version_change_invalidates_cache_and_cleans_up
     file_store = Sass::CacheStores::Filesystem.new(@@cache_dir)
-    assert !File.exists?("#{@@cache_dir}/asdf/foo.scssc")
+    assert !File.exist?("#{@@cache_dir}/asdf/foo.scssc")
     file_store.store("asdf/foo.scssc", "fakesha1", root_node)
-    assert File.exists?("#{@@cache_dir}/asdf/foo.scssc")
+    assert File.exist?("#{@@cache_dir}/asdf/foo.scssc")
     real_version = Sass::VERSION
     begin
       Sass::VERSION.replace("a different version")
       assert_nil file_store.retrieve("asdf/foo.scssc", "fakesha1")
-      assert !File.exists?("#{@@cache_dir}/asdf/foo.scssc")
+      assert !File.exist?("#{@@cache_dir}/asdf/foo.scssc")
     ensure
       Sass::VERSION.replace(real_version)
     end

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -648,18 +648,18 @@ SASS
 
   def test_sass_import
     sassc_file = sassc_path("importee")
-    assert !File.exists?(sassc_file)
+    assert !File.exist?(sassc_file)
     renders_correctly "import", { :style => :compact, :load_paths => [File.dirname(__FILE__) + "/templates"] }
-    assert File.exists?(sassc_file)
+    assert File.exist?(sassc_file)
   end
 
   def test_sass_pathname_import
     sassc_file = sassc_path("importee")
-    assert !File.exists?(sassc_file)
+    assert !File.exist?(sassc_file)
     renders_correctly("import",
       :style => :compact,
       :load_paths => [Pathname.new(File.dirname(__FILE__) + "/templates")])
-    assert File.exists?(sassc_file)
+    assert File.exist?(sassc_file)
   end
 
   def test_import_from_global_load_paths
@@ -691,12 +691,12 @@ ERR
   end
 
   def test_no_cache
-    assert !File.exists?(sassc_path("importee"))
+    assert !File.exist?(sassc_path("importee"))
     renders_correctly("import", {
         :style => :compact, :cache => false,
         :load_paths => [File.dirname(__FILE__) + "/templates"],
       })
-    assert !File.exists?(sassc_path("importee"))
+    assert !File.exist?(sassc_path("importee"))
   end
 
   def test_import_in_rule

--- a/test/sass/plugin_test.rb
+++ b/test/sass/plugin_test.rb
@@ -209,7 +209,7 @@ CSS
   end
 
   def test_doesnt_render_partials
-    assert !File.exists?(tempfile_loc('_partial'))
+    assert !File.exist?(tempfile_loc('_partial'))
   end
 
   def test_template_location_array
@@ -507,7 +507,7 @@ WARNING
   def template_loc(name = nil, prefix = nil)
     if name
       scss = absolutize "#{prefix}templates/#{name}.scss"
-      File.exists?(scss) ? scss : absolutize("#{prefix}templates/#{name}.sass")
+      File.exist?(scss) ? scss : absolutize("#{prefix}templates/#{name}.sass")
     else
       absolutize "#{prefix}templates"
     end


### PR DESCRIPTION
`File.exists?` is deprecated.
https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/43377
