### PR TITLE
Support compass watching

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -3,6 +3,23 @@
 * Table of contents
 {:toc}
 
+## 3.3.11 (UNRELEASED)
+
+* The Sass::Compiler class has a number of new minor features to support
+Compass's compilation needs:
+
+  * The template_deleted event of the Sass Compiler class now runs before the
+    side-effect events.
+  * The Sass Compiler class can now be used to clean output files.
+  * The Sass Compiler class now exposes an updating_stylesheets callback
+    that runs before stylesheets are mass-updated.
+  * The Sass Compiler class now exposes a the compilation_starting callback
+    that runs before an individual stylesheet is compiled.
+  * The Sass Compiler class now runs the updated_stylesheets callback
+    after stylesheets are mass-updated.
+  * The Sass Compiler can now be made to skip the initial update
+    when watching.
+
 ## 3.3.10 (11 July 2014)
 
 * Properly encode URLs in sourcemaps.

--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -56,7 +56,7 @@ module Sass::Plugin
     #
     # @yield [updated_files]
     # @yieldparam updated_files [<(String, String)>]
-    #   Individual files that were updated
+    #   Individual files that were updated.
     #   The first element of each pair is the source file, the second is the target CSS file.
     define_callback :updated_stylesheets
 

--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -285,15 +285,6 @@ module Sass::Plugin
     # @param options [Hash] The options that control how watching works.
     # @option options [Boolean] :skip_initial_update
     #   Don't do an initial update when starting the watcher when true
-    # @option options [Array<String>] :additional_watch_paths
-    #   A list of paths that should be watched for changes for use by the block
-    #   given to this method.
-    #
-    # @yield [modified, added, removed] The files that the listener noticed changed.
-    #   These can be any file in the watched directories; they might not be sass files.
-    # @yieldparam [Array<String>] modified The files that were modified.
-    # @yieldparam [Array<String>] added The files that were added.
-    # @yieldparam [Array<String>] removed The files that were removed.
     def watch(individual_files = [], options = {})
       options, individual_files = individual_files, [] if individual_files.is_a?(Hash)
       update_stylesheets(individual_files) unless options[:skip_initial_update]
@@ -313,6 +304,8 @@ module Sass::Plugin
 
       # TODO: Keep better track of what depends on what
       # so we don't have to run a global update every time anything changes.
+      # XXX The :additional_watch_paths option exists for Compass to use until
+      # a deprecated feature is removed. It may be removed without warning.
       listener_args = directories +
                       Array(options[:additional_watch_paths]) +
                       [{:relative_paths => false}]

--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -328,6 +328,7 @@ module Sass::Plugin
       end
 
       removed.uniq.each do |f|
+        run_template_deleted(relative_to_pwd(f))
         if (files = individual_files.find {|(source, _, _)| File.expand_path(source) == f})
           recompile_required = true
           # This was a file we were watching explicitly and compiling to a particular location.
@@ -347,7 +348,6 @@ module Sass::Plugin
             end
           end
         end
-        run_template_deleted(relative_to_pwd(f))
       end
 
       if recompile_required

--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -78,6 +78,21 @@ module Sass::Plugin
     #   The location of the sourcemap being generated, if any.
     define_callback :updated_stylesheet
 
+    # Register a callback to be run when compilation starts.
+    #
+    # In combination with on_updated_stylesheet, this could be used
+    # to collect compilation statistics like timing or to take a
+    # diff of the changes to the output file.
+    #
+    # @yield [template, css, sourcemap]
+    # @yieldparam template [String]
+    #   The location of the Sass/SCSS file being updated.
+    # @yieldparam css [String]
+    #   The location of the CSS file being generated.
+    # @yieldparam sourcemap [String]
+    #   The location of the sourcemap being generated, if any.
+    define_callback :compilation_starting
+
     # Register a callback to be run when Sass decides not to update a stylesheet.
     # In particular, the callback is run when Sass finds that
     # the template file and none of its dependencies
@@ -434,6 +449,7 @@ module Sass::Plugin
                                      :filename => filename,
                                      :sourcemap_filename => sourcemap)
         mapping = nil
+        run_compilation_starting(filename, css, sourcemap)
         engine = Sass::Engine.for_file(filename, engine_opts)
         if sourcemap
           rendered, mapping = engine.render_with_sourcemap(File.basename(sourcemap))

--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -36,17 +36,17 @@ module Sass::Plugin
       options.merge!(opts)
     end
 
-    # Register a callback to be run after stylesheets are mass-updated.
+    # Register a callback to be run before stylesheets are mass-updated.
     # This is run whenever \{#update\_stylesheets} is called,
     # unless the \{file:SASS_REFERENCE.md#never_update-option `:never_update` option}
     # is enabled.
     #
-    # @yield [individual_files]
-    # @yieldparam individual_files [<(String, String)>]
-    #   Individual files to be updated, in addition to the directories
-    #   specified in the options.
+    # @yield [files]
+    # @yieldparam files [<(String, String, String)>]
+    #   Individual files to be updated. Files in directories specified are included in this list.
     #   The first element of each pair is the source file,
-    #   the second is the target CSS file.
+    #   the second is the target CSS file,
+    #   the third is the target sourcemap file.
     define_callback :updating_stylesheets
 
     # Register a callback to be run after a single stylesheet is updated.
@@ -175,6 +175,7 @@ module Sass::Plugin
       staleness_checker = StalenessChecker.new(engine_options)
 
       files = file_list(individual_files)
+      run_updating_stylesheets(files)
 
       files.each do |file, css, sourcemap|
         # TODO: Does staleness_checker need to check the sourcemap file as well?

--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -367,7 +367,7 @@ module Sass::Plugin
           run_deleting_css css_file
           File.delete(css_file)
         end
-        if File.exist?(sourcemap_file)
+        if sourcemap_file && File.exist?(sourcemap_file)
           run_deleting_sourcemap sourcemap_file
           File.delete(sourcemap_file)
         end

--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -273,8 +273,12 @@ module Sass::Plugin
     #   {file:SASS_REFERENCE.md#template_location-option `:template_location` option}.**
     #   The first string in each pair is the location of the Sass/SCSS file,
     #   the second is the location of the CSS file that it should be compiled to.
-    def watch(individual_files = [])
-      update_stylesheets(individual_files)
+    # @param options [Hash] The options that control how watching works.
+    # @option options [Boolean] :skip_initial_update
+    #   Don't do an initial update when starting the watcher when true
+    def watch(individual_files = [], options = {})
+      options, individual_files = individual_files, [] if individual_files.is_a?(Hash)
+      update_stylesheets(individual_files) unless options[:skip_initial_update]
 
       directories = watched_paths
       individual_files.each do |(source, _, _)|


### PR DESCRIPTION
These are the changes I needed to make in order to remove Compass's compiler/watcher and replace it with a simple adapter to the Sass compiler/watcher.

None of the watching code in Sass is tested at all and these changes are relatively simple, but if you think some of it needs testing, I can add tests.
