### PR TITLE
Update SASS_REFERENCE.md. Invalid css.

### DIFF
--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -543,9 +543,7 @@ The property namespace itself can also have a value.
 For example:
 
     .funky {
-      font: 2px/3px {
-        family: fantasy;
-        size: 30em;
+      font: 20px/24px fantasy {
         weight: bold;
       }
     }
@@ -553,10 +551,10 @@ For example:
 is compiled to:
 
     .funky {
-      font: 2px/3px;
-        font-family: fantasy;
-        font-size: 30em;
-        font-weight: bold; }
+      font: 20px/24px fantasy;
+        font-weight: bold;
+    }
+
 
 ### Placeholder Selectors: `%foo`
 


### PR DESCRIPTION
This example is producing invalid css.

```
.funky {
  font: 2px/3px;
    font-family: fantasy;
    font-size: 30em;
    font-weight: bold; }
```

`font:` requires at least 1) a font-size and 2) a font-family: http://www.w3schools.com/cssref/pr_font_font.asp

`.funky{ font: 2px/3px fantasy;}` would be valid, but `.funky{ font: 2px/3px;}` is a style that your browser will chose to ignore. Best to not have invalid css in the docs. Any code examples should be copy/paste-able.

![screen shot 2014-08-01 at 5 30 16 pm](https://cloud.githubusercontent.com/assets/1933021/3786577/3818692e-19dc-11e4-878a-a11a026160ee.png)
