### PR TITLE
Add appveyor.yml config to run tests on Appveyor Windows CI service

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,48 @@
+# see: http://www.appveyor.com/docs/build-configuration
+
+init:
+  - git config --global core.autocrlf input
+
+clone_folder: c:\projects\sass
+
+# list some environment info
+install:
+  - ps: Get-Date
+  - ruby -v
+  - gem -v
+  - gem list bundler
+  - bundle install
+
+# any building is done during test using rake
+build: off
+
+# run rake
+test_script:
+  - ps: Write-Host "Getting ready to test..." -ForegroundColor Magenta
+  - cd C:\projects\sass
+  - bundle exec rake
+
+after_test:
+  - ps: Get-Date
+
+on_success:
+  - ps: Write-Host "Done testing (SUCCESS)" -ForegroundColor Green
+  
+on_failure:
+  - ps: Write-Host "Done testing (FAILURE)" -ForegroundColor Red
+
+environment:
+
+  # by specifying these two platforms (x64/x86) we get a 1x2 build matrix with 
+  #    the specified environment settings. However the build still uses the stock Ruby
+  matrix:
+  - platform: x64
+    MATHN: true
+    RUBOCOP: false
+    
+  - platform: x86
+    MATHN: false
+    RUBOCOP: false
+
+matrix:
+  fast_finish: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,11 +5,15 @@ init:
 
 clone_folder: c:\projects\sass
 
+version: "{build}"
+
 # list some environment info
 install:
   - ps: Get-Date
+  - ps: $env:Path = $env:RUBYPATH + "\bin;" + $env:Path
   - ruby -v
   - gem -v
+  - gem install bundler
   - gem list bundler
   - bundle install
 
@@ -33,16 +37,36 @@ on_failure:
 
 environment:
 
-  # by specifying these two platforms (x64/x86) we get a 1x2 build matrix with 
-  #    the specified environment settings. However the build still uses the stock Ruby
   matrix:
-  - platform: x64
+  - myEnv: 193-mathn-true
     MATHN: true
     RUBOCOP: false
-    
-  - platform: x86
+    RUBYPATH: C:\Ruby193
+  
+  - myEnv: 193-mathn-false
     MATHN: false
     RUBOCOP: false
+    RUBYPATH: C:\Ruby193
+
+  - myEnv: 200-mathn-true
+    MATHN: true
+    RUBOCOP: false
+    RUBYPATH: C:\Ruby200
+  
+  - myEnv: 200-mathn-false
+    MATHN: false
+    RUBOCOP: false
+    RUBYPATH: C:\Ruby200
+
+  - myEnv: 200-mathn-true-x64
+    MATHN: true
+    RUBOCOP: false
+    RUBYPATH: C:\Ruby200-x64
+  
+  - myEnv: 200-mathn-false-x64
+    MATHN: false
+    RUBOCOP: false
+    RUBYPATH: C:\Ruby200-x64
 
 matrix:
   fast_finish: false


### PR DESCRIPTION
Add Appveyor configuration file so this can be built on the Appveyor CI service (windows).

This basically runs the same script as Travis-CI does using `rake`

To get this going on the sass repo one of the project owners needs to:
- login at https://ci.appveyor.com/signup/free using your Github account
- use the "+ new project" on top of the page to select and add the Compass project
- merge this PR

BTW this service is free for opensource projects (http://www.appveyor.com/pricing)
