### PR TITLE
Erase link of removed Firefox Add-On

### DIFF
--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -20,7 +20,6 @@ particularly with the help of
 * Many {Sass::Script::Functions useful functions} for manipulating colors and other values
 * Advanced features like [control directives](#control_directives__expressions) for libraries
 * Well-formatted, customizable output
-* [Firebug integration](https://addons.mozilla.org/en-US/firefox/addon/103988)
 
 ## Syntax
 


### PR DESCRIPTION
Add-on 'FireSass' removed by author.

![screenshot](https://cloud.githubusercontent.com/assets/963212/4400247/99d10b14-447d-11e4-90d5-c823cb4b9ab4.png)
