### PR TITLE
At-Root Documentation Fix

### DIFF
--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -1800,24 +1800,32 @@ the document, rather than being nested beneath their parent selectors. It can
 either be used with a single inline selector:
 
     .parent {
+      ...
       @at-root .child { ... }
     }
 
-or with a block containing multiple selectors:
+Which would produce:
+
+    .parent { ... }
+    .child { ... }
+
+Or it can be used with a block containing multiple selectors:
 
     .parent {
+      ...
       @at-root {
         .child1 { ... }
         .child2 { ... }
       }
+      .step-child { ... }
     }
 
-These produce, respectively:
+Which would output the following:
 
     .parent { ... }
-
     .child1 { ... }
     .child2 { ... }
+    .parent .step-child { ... }
 
 #### `@at-root (without: ...)` and `@at-root (with: ...)`
 


### PR DESCRIPTION
Rewriting the section, as it was confusingly written. Mentioned in issue #1462 

```
It can either be used with a single inline selector:

    .parent {
      ...
      @at-root .child { ... }
    }

Which would produce:

    .parent { ... }
    .child { ... }

Or it can be used with a block containing multiple selectors:

    .parent {
      ...
      @at-root {
        .child1 { ... }
        .child2 { ... }
      }
      .step-child { ... }
    }

Which would output the following:

    .parent { ... }
    .child1 { ... }
    .child2 { ... }
    .parent .step-child { ... }

```
