### PR TITLE
Fix exception on Sass::Importers::Filesystem#eql?

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -3,6 +3,10 @@
 * Table of contents
 {:toc}
 
+## 3.4.6 (Unreleased)
+
+* Fix exception on `Sass::Importers::Filesystem#eql?`.
+
 ## 3.4.5 (19 September 2014)
 
 * Fix `sass-convert --recursive`.

--- a/lib/sass/importers/filesystem.rb
+++ b/lib/sass/importers/filesystem.rb
@@ -51,7 +51,7 @@ module Sass
       end
 
       def eql?(other)
-        root.eql?(other.root)
+        !other.nil? && other.respond_to?(:root) && root.eql?(other.root)
       end
 
       # @see Base#directories_to_watch

--- a/test/sass/importer_test.rb
+++ b/test/sass/importer_test.rb
@@ -405,6 +405,15 @@ MESSAGE
     File.join(fixture_dir, path)
   end
 
+  def test_filesystem_importer_eql
+    importer = Sass::Importers::Filesystem.new('.')
+    assert importer.eql?(Sass::Importers::Filesystem.new('.'))
+    assert importer.eql?(ReversedExtImporter.new('.'))
+    assert !importer.eql?(Sass::Importers::Filesystem.new('foo'))
+    assert !importer.eql?(nil)
+    assert !importer.eql?('foo')
+  end
+
   def test_absolute_files_across_template_locations
     importer = Sass::Importers::Filesystem.new(absolutize 'templates')
     refute_nil importer.mtime(absolutize('more_templates/more1.sass'), {})


### PR DESCRIPTION
`Sass::Importers::Filesystem#eql?` raises an exception if `other` is `nil` or `other` doesn't respond to `root` method.

I found this bug when I executed `Compass.configuration.sass_load_paths.uniq` (`NoMethodError` is occasionally raised):

``` bash
$ ruby -e 'require "compass"; p Compass.configuration.sass_load_paths'
[/home/nitoyon/sass, /path/to/gems/compass-core-1.0.1/stylesheets, Compass::SpriteImporter]

$ ruby -e 'require "compass"; Compass.configuration.sass_load_paths.uniq'
/path/to/gems/sass-3.4.3/lib/sass/importers/filesystem.rb:54:in `eql?': undefined method `root' for
Compass::SpriteImporter:Compass::SpriteImporter (NoMethodError)
        from -e:1:in `uniq'
        from -e:1:in `<main>'
```
