### PR TITLE
Fixed an error caused by compiling :not selectors.

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -3,6 +3,11 @@
 * Table of contents
 {:toc}
 
+## 3.4.7 (tbc)
+
+* Fixed a bug introduced in 3.4.6 where `:not` selectors were causing a
+compilation error.
+
 ## 3.4.6 (16 October 2014)
 
 * Parent selectors now work in selector pseudoclasses (for example, `:not(&)`).

--- a/lib/sass/selector/pseudo.rb
+++ b/lib/sass/selector/pseudo.rb
@@ -51,9 +51,9 @@ module Sass
       # Returns a copy of this with \{#selector} set to \{#new\_selector}.
       #
       # @param new_selector [CommaSequence]
-      # @return [Array<Simple>]
+      # @return [CommaSequence]
       def with_selector(new_selector)
-        result = Pseudo.new(syntactic_type, name, arg,
+        Pseudo.new(syntactic_type, name, arg,
           CommaSequence.new(new_selector.members.map do |seq|
             next seq unless seq.members.length == 1
             sseq = seq.members.first
@@ -86,10 +86,16 @@ module Sass
               []
             end
           end.flatten))
+      end
 
-        # Older browsers support :not but only with a single complex selector.
-        # In order to support those browsers, we break up the contents of a :not
-        # unless it originally contained a selector list.
+      # Older browsers support :not but only with a single complex selector.
+      # In order to support those browsers, we break up the contents of a :not
+      # unless it originally contained a selector list.
+      #
+      # @param extended [CommaSequence]
+      # @return [Array<Simple>]
+      def with_selector_and_to_array(extended)
+        result = with_selector(extended)
         return [result] unless normalized_name == 'not'
         return [result] if selector.members.length > 1
         result.selector.members.map do |seq|

--- a/lib/sass/selector/simple_sequence.rb
+++ b/lib/sass/selector/simple_sequence.rb
@@ -165,7 +165,7 @@ module Sass
           next sel if extended == sel.selector
           extended.members.reject! {|seq| seq.has_placeholder?}
           modified_original = true
-          result = sel.with_selector(extended)
+          result = sel.with_selector_and_to_array(extended)
           result.each {|new_sel| seen_with_pseudo_selectors << [new_sel]}
           result
         end.flatten

--- a/test/sass/extend_test.rb
+++ b/test/sass/extend_test.rb
@@ -64,6 +64,18 @@ CSS
 SASS
   end
 
+  def test_nested_pseudo_selectors
+    assert_equal <<CSS, render(<<SCSS)
+.foo .bar:not(.baz), .bang .bar:not(.baz) {
+  a: b; }
+CSS
+.foo {
+  .bar:not(.baz) {a: b}
+}
+.bang {@extend .foo}
+SCSS
+  end
+
   def test_multiple_targets
     assert_equal <<CSS, render(<<SCSS)
 .foo, .bar {


### PR DESCRIPTION
Fixes #1476 

From what I can see it is [this commit](https://github.com/sass/sass/commit/c717726c4307899bec87482673bfb7fb6fe1f509) which has introduced the bug. The fact that it now [returns an Array](https://github.com/sass/sass/blob/c717726c4307899bec87482673bfb7fb6fe1f509/lib/sass/selector/pseudo.rb#L93-L97) is not being handled in [this method](https://github.com/sass/sass/blob/stable/lib/sass/selector/abstract_sequence.rb#L96) - it is expecting an instance of the `Sass::Selector::Pseudo` class, but is instead now given an `Array` containing the instance.

This PR reverts the changes made in the `with_selector` method, and adds the introduced `:not` logic into a new method which is called in the relevant place.

Let me know if this is any good and if I need to update anything, including the changelog.
