### PR TITLE
Add set-nth to the list functions group in the function documentation

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -10,6 +10,8 @@
 * `@extend` resolution and `is-superselector()` no longer consider `.foo > .baz`
   to be a superselector of `.foo > .bar > .baz`.
 
+* Update documentation for `set-nth`
+
 ## 3.4.6 (16 October 2014)
 
 * Parent selectors now work in selector pseudoclasses (for example, `:not(&)`).

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -170,6 +170,9 @@ module Sass::Script
   # \{#nth nth($list, $n)}
   # : Returns a specific item in a list.
   #
+  # \{#length set-nth($list, $n, $value)}
+  # : Replaces the nth item in a list.
+  #
   # \{#join join($list1, $list2, \[$separator\])}
   # : Joins together two lists into one.
   #


### PR DESCRIPTION
This PR updates the functions reference documentation by adding `set-nth` to the list functions table.

![screen shot 2014-10-29 at 3 28 02 pm](https://cloud.githubusercontent.com/assets/579928/4821091/00bf98de-5f24-11e4-86d3-dd1d752836cc.png)
