### PR TITLE
Fix typo in set-nth documentation

### DIFF
--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -170,7 +170,7 @@ module Sass::Script
   # \{#nth nth($list, $n)}
   # : Returns a specific item in a list.
   #
-  # \{#length set-nth($list, $n, $value)}
+  # \{#set-nth set-nth($list, $n, $value)}
   # : Replaces the nth item in a list.
   #
   # \{#join join($list1, $list2, \[$separator\])}


### PR DESCRIPTION
This PR fixes a typo in the `set-nth` documentation. 

See https://github.com/sass/sass/pull/1492/files#r19643445
