### PR TITLE
[wip] Multi-line map and list support for indented "Sass" syntax

### DIFF
--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -726,12 +726,12 @@ WARNING
 
     def parse_variable(line)
       name, value, flags = line.text.scan(Script::MATCH)[0]
-      multiline_map      = line.children.any?
+      multiline_value    = line.children.any?
 
       raise SyntaxError.new("Invalid variable: \"#{line.text}\".",
-        :line => @line) unless name && (multiline_map || value)
+        :line => @line) unless name && (multiline_value || value)
       raise SyntaxError.new("Illegal nesting: Nothing may be nested beneath variable declarations.",
-        :line => @line + 1) unless multiline_map ^ value
+        :line => @line + 1) unless multiline_value ^ value
       flags = flags ? flags.split(/\s+/) : []
       if (invalid_flag = flags.find {|f| f != '!default' && f != '!global'})
         raise SyntaxError.new("Invalid flag \"#{invalid_flag}\".", :line => @line)
@@ -741,14 +741,9 @@ WARNING
       # otherwise we end up with the offset equal to the value index inside the name:
       # $red_color: red;
       var_lhs_length = 1 + name.length # 1 stands for '$'
-      index = line.text.index(value || '', line.offset + var_lhs_length) || 0
 
-      if value.nil? || value.strip.empty? # multi-line map
-        value = "(" << line.children.map do |l|
-          l.text
-        end.join << ")"
-      end
-
+      value = multiline_value ? multiline_value_to_script(line.children) : value
+      index = line.text.index(value, line.offset + var_lhs_length) || 0
       expr = parse_script(value, :offset => to_parser_offset(line.offset + index))
 
       Tree::VariableNode.new(name, expr, flags.include?('!default'), flags.include?('!global'))
@@ -1127,6 +1122,10 @@ WARNING
       line = options[:line] || @line
       offset = options[:offset] || @offset + 1
       Script.parse(script, line, offset, @options)
+    end
+
+    def multiline_value_to_script(lines)
+      "(#{lines.map {|l| l.text}.join})"
     end
 
     def format_comment_text(text, silent)

--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -742,7 +742,7 @@ WARNING
       # $red_color: red;
       var_lhs_length = 1 + name.length # 1 stands for '$'
 
-      value = multiline_value ? "(#{line.children.map(&:text).join})" : value
+      value = multiline_value ? "(#{line.children.map(&:text).join("\n")})" : value
       index = line.text.index(value, line.offset + var_lhs_length) || 0
       expr = parse_script(value, :offset => to_parser_offset(line.offset + index))
 

--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -742,7 +742,7 @@ WARNING
       # $red_color: red;
       var_lhs_length = 1 + name.length # 1 stands for '$'
 
-      value = multiline_value ? multiline_value_to_script(line.children) : value
+      value = multiline_value ? "(#{line.children.map(&:text).join})" : value
       index = line.text.index(value, line.offset + var_lhs_length) || 0
       expr = parse_script(value, :offset => to_parser_offset(line.offset + index))
 
@@ -1122,10 +1122,6 @@ WARNING
       line = options[:line] || @line
       offset = options[:offset] || @offset + 1
       Script.parse(script, line, offset, @options)
-    end
-
-    def multiline_value_to_script(lines)
-      "(#{lines.map {|l| l.text}.join})"
     end
 
     def format_comment_text(text, silent)

--- a/lib/sass/script.rb
+++ b/lib/sass/script.rb
@@ -7,7 +7,7 @@ module Sass
   # This module contains code that handles the parsing and evaluation of SassScript.
   module Script
     # The regular expression used to parse variables.
-    MATCH = /^\$(#{Sass::SCSS::RX::IDENT})\s*:\s*(.+?)
+    MATCH = /^\$(#{Sass::SCSS::RX::IDENT})\s*:\s*(.+?)?
       (!#{Sass::SCSS::RX::IDENT}(?:\s+!#{Sass::SCSS::RX::IDENT})*)?$/x
 
     # The regular expression used to validate variables without matching.

--- a/lib/sass/tree/visitors/check_nesting.rb
+++ b/lib/sass/tree/visitors/check_nesting.rb
@@ -141,7 +141,8 @@ class Sass::Tree::Visitors::CheckNesting < Sass::Tree::Visitors::Base
   end
 
   VALID_PROP_PARENTS = [Sass::Tree::RuleNode, Sass::Tree::KeyframeRuleNode, Sass::Tree::PropNode,
-                        Sass::Tree::MixinDefNode, Sass::Tree::DirectiveNode, Sass::Tree::MixinNode]
+                        Sass::Tree::MixinDefNode, Sass::Tree::DirectiveNode, Sass::Tree::MixinNode,
+                        Sass::Tree::VariableNode]
   def invalid_prop_parent?(parent, child)
     unless is_any_of?(parent, VALID_PROP_PARENTS)
       "Properties are only allowed within rules, directives, mixin includes, or other properties." +

--- a/test/sass/engine_multiline_test.rb
+++ b/test/sass/engine_multiline_test.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+# -*- coding: utf-8 -*-
+require File.dirname(__FILE__) + '/../test_helper'
+require File.dirname(__FILE__) + '/test_helper'
+require 'sass/engine'
+require 'stringio'
+require 'mock_importer'
+require 'pathname'
+
+class SassEngineMultilineTest < MiniTest::Test
+
+  def test_single_line_map
+    assert_equal(<<CSS, render(<<SASS))
+.debug {
+  inspect: (a: 1, b: 2); }
+CSS
+$foo: (a: 1, b: 2)
+
+.debug
+  inspect: inspect($foo)
+SASS
+  end
+
+  def test_indented_single_line_map
+    assert_equal(<<CSS, render(<<SASS))
+.debug {
+  inspect: (a: 1, b: 2); }
+CSS
+$foo:
+  (a: 1, b: 2)
+
+.debug
+  inspect: inspect($foo)
+SASS
+  end
+
+  def test_multiline_map
+    assert_equal(<<CSS, render(<<SASS))
+.debug {
+  inspect: (a: 1, b: 2); }
+CSS
+$foo:
+  a: 1,
+  b: 2
+
+.debug
+  inspect: inspect($foo)
+SASS
+  end
+
+  private
+
+  def render(sass, options = {})
+    munge_filename options
+    options[:importer] ||= MockImporter.new
+    Sass::Engine.new(sass, options).render
+  end
+
+end

--- a/test/sass/engine_multiline_test.rb
+++ b/test/sass/engine_multiline_test.rb
@@ -48,6 +48,46 @@ $foo:
 SASS
   end
 
+  def test_single_line_list
+    assert_equal(<<CSS, render(<<SASS))
+.debug {
+  inspect: 1, 2; }
+CSS
+$foo: 1, 2
+
+.debug
+  inspect: inspect($foo)
+SASS
+  end
+
+  def test_indented_single_line_list
+    assert_equal(<<CSS, render(<<SASS))
+.debug {
+  inspect: 1, 2; }
+CSS
+$foo:
+  1, 2
+
+.debug
+  inspect: inspect($foo)
+SASS
+  end
+
+  def test_multiline_list
+    assert_equal(<<CSS, render(<<SASS))
+.debug {
+  inspect: "one", 2, "three"; }
+CSS
+$foo:
+  "one",
+  2,
+  "three"
+
+.debug
+  inspect: inspect($foo)
+SASS
+  end
+
   private
 
   def render(sass, options = {})

--- a/test/sass/engine_multiline_test.rb
+++ b/test/sass/engine_multiline_test.rb
@@ -88,6 +88,20 @@ $foo:
 SASS
   end
 
+  def test_multiline_sassscript_errors
+    assert_raise_message(Sass::SyntaxError,
+      "Invalid CSS after \"foo-bar )\": expected expression (e.g. 1px, bold), was \")\"") do
+      render(<<SASS)
+$foo:
+  valid-syntax
+  foo-bar )
+
+.debug
+  inspect: inspect($foo)
+SASS
+    end
+  end
+
   private
 
   def render(sass, options = {})

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -80,6 +80,7 @@ MSG
     "$a: b\n  :c d\n" => "Illegal nesting: Nothing may be nested beneath variable declarations.",
     "$a: b\n  :c d\n" => "Illegal nesting: Nothing may be nested beneath variable declarations.",
     "$a: (b: 1)\n  (c: 1)\n" => "Illegal nesting: Nothing may be nested beneath variable declarations.",
+    "$a: 1, 2\n  2, 3\n" => "Illegal nesting: Nothing may be nested beneath variable declarations.",
     "@import templates/basic\n  foo" => "Illegal nesting: Nothing may be nested beneath import directives.",
     "foo\n  @import foo.css" => "CSS import directives may only be used at the root of a document.",
     "@if true\n  @import foo" => "Import directives may not be used within control directives or mixins.",

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -79,6 +79,7 @@ MSG
     "a\n  :b\n    c" => "Illegal nesting: Only properties may be nested beneath properties.",
     "$a: b\n  :c d\n" => "Illegal nesting: Nothing may be nested beneath variable declarations.",
     "$a: b\n  :c d\n" => "Illegal nesting: Nothing may be nested beneath variable declarations.",
+    "$a: (b: 1)\n  (c: 1)\n" => "Illegal nesting: Nothing may be nested beneath variable declarations.",
     "@import templates/basic\n  foo" => "Illegal nesting: Nothing may be nested beneath import directives.",
     "foo\n  @import foo.css" => "CSS import directives may only be used at the root of a document.",
     "@if true\n  @import foo" => "Import directives may not be used within control directives or mixins.",


### PR DESCRIPTION
This PR contains minimally-invasive, albeit not particularly elegant, patches to allow for multi-line maps and lists as variable values.

Based on the discussion/feature requests here: #216, #1088

**NOT COVERED** is support for other multi-line expressions: mix-in declarations (https://github.com/sass/sass/issues/216#issue-2334772), multi-line properties (https://github.com/sass/sass/issues/216#issuecomment-9028170), etc. From cursory glance, it does look like this would need a rewrite of indented syntax parser.

Would love to get feedback on this…
