### PR TITLE
Fixed a typo in documentation

### DIFF
--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -663,7 +663,7 @@ is compiled to:
 
 ### Data Types
 
-SassScript supports six main data types:
+SassScript supports seven main data types:
 
 * numbers (e.g. `1.2`, `13`, `10px`)
 * strings of text, with and without quotes (e.g. `"foo"`, `'bar'`, `baz`)


### PR DESCRIPTION
SassScript now supports **seven** data types since 3.3, not _six_.
