### PR TITLE
Clarify that sass-convert doesn't generate CSS

### DIFF
--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -52,6 +52,9 @@ using the `sass-convert` command line tool:
 
     # Convert SCSS to Sass
     $ sass-convert style.scss style.sass
+    
+Note that this command does *not* generate CSS files. For that, use
+the `sass` command described elsewhere.
 
 ## Using Sass
 


### PR DESCRIPTION
I wanted to convert SCSS to CSS, opened the docs, searched for "convert" and tried the first thing I saw – took me a few minutes to figure out my mistake.

I did something like

```
sass-convert foo.scss foo.css
```

which modified the syntax but did not actually render it into CSS.

I see at least [one other person](http://stackoverflow.com/questions/22779642/sass-not-compiling-brackets-and-not-importing) made the same mistake :)

The text leading up to the `sass-convert` example makes it very clear what it's for, but if you're in a "find the command to convert SASS to CSS" mindset and just scan through the document, it's still an easy mistake to make. Hopefully this change helps the next person.

A possibly better solution would be to show an error or warning if the output file ends in ".css". Any thoughts on that?
