### PR TITLE
Remove extra parens; fixes #1565

### DIFF
--- a/lib/sass/script/value/map.rb
+++ b/lib/sass/script/value/map.rb
@@ -57,7 +57,7 @@ module Sass::Script::Value
 
       to_sass = lambda do |value|
         if value.is_a?(Map) || (value.is_a?(List) && value.separator == :comma)
-          "(#{value.to_sass(opts)})"
+          "#{value.to_sass(opts)}"
         else
           value.to_sass(opts)
         end

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -1621,7 +1621,7 @@ SCSS
     assert_equal "null", evaluate("inspect(null)")
     assert_equal "1px null 3px", evaluate("inspect(1px null 3px)")
     assert_equal "(a: 1, b: 2)", evaluate("inspect((a: 1, b: 2))")
-    assert_equal "(\"a\": 1, \"b\": (\"c\": \"d\"))", evaluate("inspect(( 'a': 1, 'b': ( 'c': 'd')))")
+    assert_equal "(a: 1, b: (c: d))", evaluate("inspect((a: 1, b: (c: d)))")
   end
 
   def test_random

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -1621,6 +1621,7 @@ SCSS
     assert_equal "null", evaluate("inspect(null)")
     assert_equal "1px null 3px", evaluate("inspect(1px null 3px)")
     assert_equal "(a: 1, b: 2)", evaluate("inspect((a: 1, b: 2))")
+    assert_equal "(\"a\": 1, \"b\": (\"c\": \"d\"))", evaluate("inspect(( 'a': 1, 'b': ( 'c': 'd')))")
   end
 
   def test_random


### PR DESCRIPTION
Remove extra set of parentheses from inspect function when inspecting a map that contains children lists
