### PR TITLE
Add link to full list of SassScript functions.

### DIFF
--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -1072,6 +1072,8 @@ is compiled to:
 
     p {
       color: #ff0000; }
+      
+See {Sass::Script::Functions this page} for a full list of available functions.
 
 #### Keyword Arguments
 


### PR DESCRIPTION
There are a couple links to the `Sass::Script::Functions` page in the reference doc, but not one under the main "Functions" heading, which was the first place I checked.

Thought it might be useful to add one!
