### PR TITLE
Add alpha to Color#hsla

### DIFF
--- a/lib/sass/script/value/color.rb
+++ b/lib/sass/script/value/color.rb
@@ -382,7 +382,7 @@ module Sass::Script::Value
     # @return [Array<Fixnum>] A frozen four-element array of the hue,
     #   saturation, lightness, and alpha values (respectively) of the color
     def hsla
-      [hue, saturation, lightness].freeze
+      [hue, saturation, lightness, alpha].freeze
     end
 
     # The SassScript `==` operation.


### PR DESCRIPTION
`Color#hsla` was not returning an array with the proper arity, missing the alpha channel. This adds it back.
