### PR TITLE
fix from_hex method.Now he leading hash is really optional

### DIFF
--- a/lib/sass/script/value/color.rb
+++ b/lib/sass/script/value/color.rb
@@ -283,7 +283,7 @@ module Sass::Script::Value
       green = $2.ljust(2, $2).to_i(16)
       blue  = $3.ljust(2, $3).to_i(16)
 
-      hex_string = '##{hex_string}' unless hex_string[0] == ?#
+      hex_string = "##{hex_string}" unless hex_string[0] == ?#
       attrs = {:red => red, :green => green, :blue => blue, :representation => hex_string}
       attrs[:alpha] = alpha if alpha
       new(attrs)

--- a/test/sass/script_test.rb
+++ b/test/sass/script_test.rb
@@ -31,6 +31,11 @@ class SassScriptTest < MiniTest::Test
     assert_equal 0, Sass::Script::Value::Color.new([1, 2, 3, -0.1]).alpha
   end
 
+  def test_color_from_hex
+    assert_equal Sass::Script::Value::Color.new([0,0,0]), Sass::Script::Value::Color.from_hex('000000')
+    assert_equal Sass::Script::Value::Color.new([0,0,0]), Sass::Script::Value::Color.from_hex('#000000')
+  end
+
   def test_string_escapes
     assert_equal "'", resolve("\"'\"")
     assert_equal '"', resolve("\"\\\"\"")


### PR DESCRIPTION
##### summary

 The description of method say that the leading hash is optional, and it was not. Now it is optional and return a valid color instance

```
before:
  Color.from_hex('000000') => ##{hex_string}

now return the correct hex color
```
