### PR TITLE
chaning comments for Sass::engine

### DIFF
--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -84,7 +84,7 @@ module Sass
   # This class handles the parsing and compilation of the Sass template.
   # Example usage:
   #
-  #     template = File.load('stylesheets/sassy.sass')
+  #     template = File.read('stylesheets/sassy.sass')
   #     sass_engine = Sass::Engine.new(template)
   #     output = sass_engine.render
   #     puts output


### PR DESCRIPTION
Template should be a 'string', so `File.read` should be use here. See also http://stackoverflow.com/questions/12627252/difference-between-file-load-and-file-read-in-ruby
