### PR TITLE
Store line number in Sequence#line=

### DIFF
--- a/lib/sass/selector/sequence.rb
+++ b/lib/sass/selector/sequence.rb
@@ -10,7 +10,7 @@ module Sass
       # @return [Fixnum]
       def line=(line)
         members.each {|m| m.line = line if m.is_a?(SimpleSequence)}
-        line
+        @line = line
       end
 
       # Sets the name of the file in which this selector was declared,


### PR DESCRIPTION
The [`scss-lint` project](https://github.com/brigade/scss-lint) performs a number of static checks against SCSS
code to find style offenses.

`Sequence` objects were returning `nil` when calling `#line`. This was
because `Sequence#line=` was not recording the actual line in an
instance variable like its superclass `AbstractSequence`. Fix this by ensuring the line
number is stored in `@line`.

This will allow the `scss-lint` project to implement
https://github.com/brigade/scss-lint/issues/456
