### PR TITLE
Fix extra semicolon compressed

### DIFF
--- a/lib/sass/tree/visitors/to_css.rb
+++ b/lib/sass/tree/visitors/to_css.rb
@@ -338,7 +338,7 @@ class Sass::Tree::Visitors::ToCss < Sass::Tree::Visitors::Base
 
       with_tabs(tabs) do
         node.children.each_with_index do |child, i|
-          output(separator) if i > 0
+          output(separator) if i > 0 && @result[-1, 1] != separator
           visit(child)
         end
       end

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -3263,6 +3263,18 @@ CSS
 SASS
   end
 
+  def test_compressed_unknown_directive_semicolons
+    assert_equal(<<RESULT, render(<<SOURCE, :style => :compressed))
+foo{@foo;a:b;@bar;}
+RESULT
+foo
+  @foo
+  a: b
+  @bar
+
+SOURCE
+  end
+
   private
 
   def assert_hash_has(hash, expected)


### PR DESCRIPTION
This PR is a possible fix for https://github.com/sass/sass/issues/1772 where-in extra semi-colons are added to at-rules nested in rule block in compressed mode.

Closes #1772 
