### PR TITLE
freeze strings

### DIFF
--- a/lib/sass/environment.rb
+++ b/lib/sass/environment.rb
@@ -32,7 +32,7 @@ module Sass
       def inherited_hash_writer(name)
         class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def set_#{name}(name, value)
-            name = name.tr('_', '-')
+            name = name.tr('_'.freeze, '-'.freeze)
             @#{name}s[name] = value unless try_set_#{name}(name, value)
           end
 

--- a/lib/sass/importers/filesystem.rb
+++ b/lib/sass/importers/filesystem.rb
@@ -84,7 +84,7 @@ module Sass
       # If a full uri is passed, this removes the root from it
       # otherwise returns the name unchanged
       def remove_root(name)
-        if name.index(@root + "/") == 0
+        if name.index(@root + '/'.freeze) == 0
           name[(@root.length + 1)..-1]
         else
           name
@@ -122,7 +122,7 @@ module Sass
         end
 
         # JRuby chokes when trying to import files from JARs when the path starts with './'.
-        ret.map {|f, s| [f.sub(/^\.\//, ''), s]}
+        ret.map {|f, s| [f.sub(/^\.\//, ''.freeze), s]}
       end
 
       def escape_glob_characters(name)
@@ -189,7 +189,7 @@ WARNING
       def split(name)
         extension = nil
         dirname, basename = File.dirname(name), File.basename(name)
-        if basename =~ /^(.*)\.(#{extensions.keys.map {|e| Regexp.escape(e)}.join('|')})$/
+        if basename =~ /^(.*)\.(#{extensions.keys.map {|e| Regexp.escape(e)}.join('|'.freeze)})$/
           basename = $1
           extension = $2
         end

--- a/lib/sass/media.rb
+++ b/lib/sass/media.rb
@@ -31,7 +31,7 @@ module Sass::Media
     #
     # @return [String]
     def to_css
-      queries.map {|q| q.to_css}.join(', ')
+      queries.map {|q| q.to_css}.join(', '.freeze)
     end
 
     # Returns the Sass/SCSS code for the media query list.

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -879,7 +879,7 @@ module Sass::Script
              a.value =~ /^[a-zA-Z]+\s*=/
          end
         # Support the proprietary MS alpha() function
-        return identifier("alpha(#{args.map {|a| a.to_s}.join(", ")})")
+        return identifier("alpha(#{args.map {|a| a.to_s}.join(", ".freeze)})")
       end
 
       raise ArgumentError.new("wrong number of arguments (#{args.size} for 1)") if args.size != 1
@@ -1607,7 +1607,7 @@ MESSAGE
     # @return [Sass::Script::Value::String] The unquoted string name of the
     #   value's type
     def type_of(value)
-      identifier(value.class.name.gsub(/Sass::Script::Value::/, '').downcase)
+      identifier(value.class.name.gsub(/Sass::Script::Value::/, ''.freeze).downcase)
     end
     declare :type_of, [:value]
 

--- a/lib/sass/script/lexer.rb
+++ b/lib/sass/script/lexer.rb
@@ -438,9 +438,9 @@ MESSAGE
       def scan(re)
         str = @scanner.scan(re)
         return unless str
-        c = str.count("\n")
+        c = str.count("\n".freeze)
         @line += c
-        @offset = (c == 0 ? @offset + str.size : str.size - str.rindex("\n"))
+        @offset = (c == 0 ? @offset + str.size : str.size - str.rindex("\n".freeze))
         str
       end
 

--- a/lib/sass/script/tree/funcall.rb
+++ b/lib/sass/script/tree/funcall.rb
@@ -156,13 +156,13 @@ module Sass::Script::Tree
     # it with a cross-browser implementation for functions that require vendor prefixes
     # in the generated css.
     def to_value(args)
-      Sass::Script::Value::String.new("#{name}(#{args.join(', ')})")
+      Sass::Script::Value::String.new("#{name}(#{args.join(', '.freeze)})")
     end
 
     private
 
     def ruby_name
-      @ruby_name ||= @name.tr('-', '_')
+      @ruby_name ||= @name.tr('-'.freeze, '_'.freeze)
     end
 
     def perform_arg(argument, environment, name)

--- a/lib/sass/script/value/color.rb
+++ b/lib/sass/script/value/color.rb
@@ -594,7 +594,7 @@ module Sass::Script::Value
     end
 
     def hex_str
-      red, green, blue = rgb.map {|num| num.to_s(16).rjust(2, '0')}
+      red, green, blue = rgb.map {|num| num.to_s(16).rjust(2, '0'.freeze)}
       "##{red}#{green}#{blue}"
     end
 

--- a/lib/sass/script/value/helpers.rb
+++ b/lib/sass/script/value/helpers.rb
@@ -247,7 +247,7 @@ module Sass::Script::Value
         raise ArgumentError.new("Malformed unit string: #{unit_string}")
       end
       numerator_units = num_over_denominator[0].split(/ *\* */)
-      denominator_units = (num_over_denominator[1] || "").split(/ *\* */)
+      denominator_units = (num_over_denominator[1] || ''.freeze).split(/ *\* */)
       [[numerator_units, "numerator"], [denominator_units, "denominator"]].each do |units, name|
         if unit_string =~ /\// && units.size == 0
           raise ArgumentError.new("Malformed unit string: #{unit_string}")

--- a/lib/sass/script/value/number.rb
+++ b/lib/sass/script/value/number.rb
@@ -279,7 +279,7 @@ module Sass::Script::Value
       # Ruby will occasionally print in scientific notation if the number is
       # small enough. That's technically valid CSS, but it's not well-supported
       # and confusing.
-      str = ("%0.#{self.class.precision}f" % value).gsub(/0*$/, '') if str.include?('e')
+      str = ("%0.#{self.class.precision}f" % value).gsub(/0*$/, ''.freeze) if str.include?('e'.freeze)
 
       unitless? ? str : "#{str}#{unit_str}"
     end
@@ -365,10 +365,10 @@ module Sass::Script::Value
     # numerator_unit1 * numerator_unit2 / denominator_unit1 * denominator_unit2
     # @return [String] a string that represents the units in this number
     def unit_str
-      rv = @numerator_units.sort.join("*")
+      rv = @numerator_units.sort.join('*'.freeze)
       if @denominator_units.any?
-        rv << "/"
-        rv << @denominator_units.sort.join("*")
+        rv << '/'.freeze
+        rv << @denominator_units.sort.join('*'.freeze)
       end
       rv
     end

--- a/lib/sass/script/value/string.rb
+++ b/lib/sass/script/value/string.rb
@@ -81,7 +81,7 @@ module Sass::Script::Value
 
     # @see Value#to_s
     def to_s(opts = {})
-      return @value.gsub(/\n\s*/, ' ') if opts[:quote] == :none || @type == :identifier
+      return @value.gsub(/\n\s*/, ' '.freeze) if opts[:quote] == :none || @type == :identifier
       Sass::Script::Value::String.quote(value, opts[:quote])
     end
 

--- a/lib/sass/scss/parser.rb
+++ b/lib/sass/scss/parser.rb
@@ -108,7 +108,7 @@ module Sass
           if @template.is_a?(StringScanner)
             @template
           else
-            Sass::Util::MultibyteStringScanner.new(@template.gsub("\r", ""))
+            Sass::Util::MultibyteStringScanner.new(@template.gsub("\r".freeze, ''.freeze))
           end
       end
 

--- a/lib/sass/scss/static_parser.rb
+++ b/lib/sass/scss/static_parser.rb
@@ -111,14 +111,14 @@ module Sass
         # The combinator here allows the "> E" hack
         val = combinator || simple_selector_sequence
         return unless val
-        nl = str {ss}.include?("\n")
+        nl = str {ss}.include?("\n".freeze)
         res = []
         res << val
         res << "\n" if nl
 
         while (val = combinator || simple_selector_sequence)
           res << val
-          res << "\n" if str {ss}.include?("\n")
+          res << "\n".freeze if str {ss}.include?("\n".freeze)
         end
         seq = Selector::Sequence.new(res.compact)
 

--- a/lib/sass/selector/comma_sequence.rb
+++ b/lib/sass/selector/comma_sequence.rb
@@ -160,7 +160,7 @@ module Sass
 
       # @see AbstractSequence#to_s
       def to_s
-        @members.join(", ").gsub(", \n", ",\n")
+        @members.join(', '.freeze).gsub(", \n".freeze, ",\n".freeze)
       end
 
       private

--- a/lib/sass/selector/pseudo.rb
+++ b/lib/sass/selector/pseudo.rb
@@ -109,7 +109,7 @@ module Sass
       #
       # @return [String]
       def normalized_name
-        @normalized_name ||= name.gsub(/^-[a-zA-Z0-9]+-/, '')
+        @normalized_name ||= name.gsub(/^-[a-zA-Z0-9]+-/, ''.freeze)
       end
 
       # @see Selector#to_s

--- a/lib/sass/selector/sequence.rb
+++ b/lib/sass/selector/sequence.rb
@@ -158,7 +158,7 @@ module Sass
 
       # @see AbstractSequence#to_s
       def to_s
-        @members.join(" ").gsub(/ ?\n ?/, "\n")
+        @members.join(' '.freeze).gsub(/ ?\n ?/, "\n".freeze)
       end
 
       # Returns a string representation of the sequence.
@@ -166,7 +166,7 @@ module Sass
       #
       # @return [String]
       def inspect
-        members.map {|m| m.inspect}.join(" ")
+        members.map {|m| m.inspect}.join(' '.freeze)
       end
 
       # Add to the {SimpleSequence#sources} sets of the child simple sequences.

--- a/lib/sass/tree/directive_node.rb
+++ b/lib/sass/tree/directive_node.rb
@@ -43,13 +43,13 @@ module Sass::Tree
 
     # @return [String] The name of the directive, including `@`.
     def name
-      @name ||= value.first.gsub(/ .*$/, '')
+      @name ||= value.first.gsub(/ .*$/, ''.freeze)
     end
 
     # Strips out any vendor prefixes and downcases the directive name.
     # @return [String] The normalized name of the directive.
     def normalized_name
-      @normalized_name ||= name.gsub(/^(@)(?:-[a-zA-Z0-9]+-)?/, '\1').downcase
+      @normalized_name ||= name.gsub(/^(@)(?:-[a-zA-Z0-9]+-)?/, '\1'.freeze).downcase
     end
 
     def bubbles?

--- a/lib/sass/tree/function_node.rb
+++ b/lib/sass/tree/function_node.rb
@@ -23,7 +23,7 @@ module Sass
       # Strips out any vendor prefixes.
       # @return [String] The normalized name of the directive.
       def normalized_name
-        @normalized_name ||= name.gsub(/^(?:-[a-zA-Z0-9]+-)?/, '\1')
+        @normalized_name ||= name.gsub(/^(?:-[a-zA-Z0-9]+-)?/, '\1'.freeze)
       end
 
       # @param name [String] The function name

--- a/lib/sass/tree/visitors/perform.rb
+++ b/lib/sass/tree/visitors/perform.rb
@@ -193,7 +193,7 @@ class Sass::Tree::Visitors::Perform < Sass::Tree::Visitors::Base
   def visit_comment(node)
     return [] if node.invisible?
     node.resolved_value = run_interp_no_strip(node.value)
-    node.resolved_value.gsub!(/\\([\\#])/, '\1')
+    node.resolved_value.gsub!(/\\([\\#])/, '\1'.freeze)
     node
   end
 
@@ -480,8 +480,8 @@ WARNING
   def visit_warn(node)
     res = node.expr.perform(@environment)
     res = res.value if res.is_a?(Sass::Script::Value::String)
-    msg = "WARNING: #{res}\n         "
-    msg << @environment.stack.to_s.gsub("\n", "\n         ") << "\n"
+    msg = "WARNING: #{res}\n         ".freeze
+    msg << @environment.stack.to_s.gsub("\n".freeze, "\n         ".freeze) << "\n".freeze
     Sass::Util.sass_warn msg
     []
   end

--- a/lib/sass/tree/visitors/to_css.rb
+++ b/lib/sass/tree/visitors/to_css.rb
@@ -55,10 +55,10 @@ class Sass::Tree::Visitors::ToCss < Sass::Tree::Visitors::Base
   def erase!(chars)
     return if chars == 0
     str = @result.slice!(-chars..-1)
-    newlines = str.count("\n")
+    newlines = str.count("\n".freeze)
     if newlines > 0
       @line -= newlines
-      @offset = @result[@result.rindex("\n") || 0..-1].size
+      @offset = @result[@result.rindex("\n".freeze) || 0..-1].size
     else
       @offset -= chars
     end
@@ -284,8 +284,8 @@ class Sass::Tree::Visitors::ToCss < Sass::Tree::Visitors::Base
         next if seq.has_placeholder?
         rule_part = seq.to_s
         if node.style == :compressed
-          rule_part.gsub!(/([^,])\s*\n\s*/m, '\1 ')
-          rule_part.gsub!(/\s*([,+>])\s*/m, '\1')
+          rule_part.gsub!(/([^,])\s*\n\s*/m, '\1 '.freeze)
+          rule_part.gsub!(/\s*([,+>])\s*/m, '\1'.freeze)
           rule_part.strip!
         end
         rule_part

--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -911,7 +911,7 @@ module Sass
 
       begin
         # If the string is valid, preprocess it according to section 3.3 of CSS Syntax Level 3.
-        return str.encode("UTF-8").gsub(/\r\n?|\f/, "\n").tr("\u0000", "�"), str.encoding
+        return str.encode("UTF-8").gsub(/\r\n?|\f/, "\n".freeze).tr("\u0000", '�'.freeze), str.encoding
       rescue EncodingError
         find_encoding_error(str)
       end

--- a/lib/sass/util/normalized_map.rb
+++ b/lib/sass/util/normalized_map.rb
@@ -20,7 +20,7 @@ module Sass
       #
       # This can be overridden to create other normalization behaviors.
       def normalize(key)
-        key.tr("-", "_")
+        key.tr('-'.freeze, '_'.freeze)
       end
 
       # Returns the version of `key` as it was stored before


### PR DESCRIPTION
While loading a rails application using Let it Go, I discovered some strings that needed some freezing:

``` ruby
9722) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sass-3.4.16/lib/sass/environment.rb
  - 9722) String#tr on line 35
9214) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sass-3.4.16/lib/sass/selector/sequence.rb
  - 4228) String#gsub on line 161
  - 2860) Array#join on line 161
  - 2114) Array#join on line 161
  - 8) String#gsub on line 161
  - 4) Array#join on line 161
8928) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sass-3.4.16/lib/sass/importers/filesystem.rb
  - 7434) String#sub on line 125
  - 747) Array#join on line 192
  - 747) String#index on line 87
6424) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sass-3.4.16/lib/sass/util/normalized_map.rb
  - 5356) String#tr on line 23
  - 1068) String#tr on line 23
5297) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sass-3.4.16/lib/sass/script/value/string.rb
  - 3574) String#gsub on line 84
  - 689) String#gsub on line 84
  - 610) String#gsub on line 84
  - 287) String#gsub on line 84
  - 104) String#gsub on line 84
  - 14) String#gsub on line 84
  - 10) String#gsub on line 84
  - 5) String#gsub on line 84
  - 4) String#gsub on line 84
2448) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sass-3.4.16/lib/sass/tree/visitors/to_css.rb
  - 1856) String#gsub! on line 291
  - 296) String#count on line 58
  - 296) String#rindex on line 61
2288) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sass-3.4.16/lib/sass/util.rb
  - 1144) String#tr on line 914
  - 1144) String#gsub on line 914
1825) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sass-3.4.16/lib/sass/script/value/number.rb
  - 918) String#include? on line 282
  - 907) Array#join on line 368
1152) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sass-3.4.16/lib/sass/script/lexer.rb
  - 576) String#count on line 441
  - 288) String#count on line 441
  - 288) String#count on line 441
879) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sass-3.4.16/lib/sass/selector/pseudo.rb
  - 879) String#gsub on line 112
640) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sass-3.4.16/lib/sass/script/tree/funcall.rb
  - 488) String#tr on line 165
  - 152) Array#join on line 159
600) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sass-3.4.16/lib/sass/scss/parser.rb
  - 576) String#gsub on line 111
  - 16) String#gsub on line 111
  - 8) String#gsub on line 111
574) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sass-3.4.16/lib/sass/media.rb
  - 287) Array#join on line 34
  - 287) Array#join on line 34
200) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sass-3.4.16/lib/sass/script/value/helpers.rb
  - 200) String#split on line 250
129) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sass-3.4.16/lib/sass/script/value/color.rb
  - 129) String#rjust on line 597
90) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sass-3.4.16/lib/sass/tree/visitors/perform.rb
  - 87) String#gsub! on line 196
  - 3) String#gsub on line 483
66) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sass-3.4.16/lib/sass/tree/function_node.rb
  - 66) String#gsub on line 26
33) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sass-3.4.16/lib/sass/script/functions.rb
  - 20) Array#join on line 882
  - 13) String#gsub on line 1610
20) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sass-3.4.16/lib/sass/selector/comma_sequence.rb
  - 12) String#gsub on line 163
  - 8) Array#join on line 163
8) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sass-3.4.16/lib/sass/scss/static_parser.rb
  - 8) String#include? on line 114
8) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sass-3.4.16/lib/sass/tree/directive_node.rb
  - 4) String#gsub on line 52
  - 4) String#gsub on line 46
```

That's 50,545 less string allocations.
