### PR TITLE
Set the end_pos of a ListLiteral to the end_pos of its last element.

### DIFF
--- a/lib/sass/script/parser.rb
+++ b/lib/sass/script/parser.rb
@@ -308,6 +308,7 @@ RUBY
           end
           return list unless (e = interpolation)
           list.elements << e
+          list.source_range.end_pos = e.source_range.end_pos
         end
         list
       end


### PR DESCRIPTION
Fixes #1799 

New output:

```
bundle exec ./bin/sass --scss <<EOF
> @each \$a, \$b in (foo, bar), (baz, quux) { }
> EOF
LIST `(("foo", "bar"), ("baz", "quux"))` HAS RANGE: (1:16 to 1:39)
```

For clarity, here's the positions of the string I gave it:

```
@each $a, $b in (foo, bar), (baz, quux) { }
   0   0   1   1   2   2   2   3   3   4
   4   8   2   6   0   4   8   2   6   0
               ________________________
16 to 39 are >> (foo, bar), (baz, quux)<<
               ------------------------
```
