### PR TITLE
Update rubocop to 0.33.0 for ruby 1.9.3 or above

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,130 +1,130 @@
 inherit_from: .rubocop_todo.yml
 
-AccessorMethodName:
+Style/AccessorMethodName:
   # We have good reasons for choosing our method names.
   Enabled: false
-AlignParameters:
+Style/AlignParameters:
   # Natalie doesn't like to align parameters to the method call.
   Enabled: false
-BlockNesting:
+Metrics/BlockNesting:
   # We'll catch this in code review. There are some legitimate uses.
   Enabled: false
-CharacterLiteral:
+Style/CharacterLiteral:
   # Character literals are pretty useful when working with text like we do.
   Enabled: false
-ClassLength:
+Metrics/ClassLength:
   # It's not worth bending over backwards to avoid long classes.
   Enabled: false
-CollectionMethods:
+Style/CollectionMethods:
   PreferredMethods:
     collect: 'map'
     reduce: 'inject'
     detect: 'find'
     find_all: 'select'
-CyclomaticComplexity:
+Metrics/CyclomaticComplexity:
   # It's difficult to reason about what will reduce cyclomatic complexity.
   Enabled: false
-Documentation:
+Style/Documentation:
   # TODO: We need to add a bunch of docs before we can enable this.
   Enabled: false
-DotPosition:
+Style/DotPosition:
   # This check doesn't want chained method invocation to end with a dot.
   # But we like to do that.
   Enabled: false
-EmptyLineBetweenDefs:
+Style/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: true
-Encoding:
+Style/Encoding:
   # We use utf-8 comments when utf-8 characters are in use.
   Enabled: false
-EndAlignment:
+Lint/EndAlignment:
   # Our alignment style differs significantly
   # and this doesn't seem to be a big deal.
   Enabled: false
-FormatString:
+Style/FormatString:
   # We like the string % operator.
   Enabled: false
-HandleExceptions:
+Lint/HandleExceptions:
   # We legitimately ignore exceptions in some cases and this is easy to catch in code review.
   Enabled: false
-HashSyntax:
+Style/HashSyntax:
   # We are a 1.8 compatable project still.
   Enabled: false
-DeprecatedHashMethods:
+Style/DeprecatedHashMethods:
   # has_xxx? reads better.
   Enabled: false
-IfUnlessModifier:
+Style/IfUnlessModifier:
   # We don't feel strongly about this.
   Enabled: false
-IndentationConsistency:
+Style/IndentationConsistency:
   # We use indentation to convey meaning more often than we screw it up.
   Enabled: false
-IndentationWidth:
+Style/IndentationWidth:
   Enabled: false
-BlockAlignment:
+Lint/BlockAlignment:
   Enabled: false
-Lambda:
+Style/Lambda:
   # We are a 1.8 compatible project still.
   Enabled: false
-LineLength:
+Metrics/LineLength:
   Enabled: true
   Max: 110
-Loop:
+Lint/Loop:
   # This isn't a big deal.
   Enabled: false
-MethodLength:
+Metrics/MethodLength:
   # TODO: This max should actually be 25 but that will require significant refactoring.
   Max: 50
   CountComments: false
-ModuleFunction:
+Style/ModuleFunction:
   # The module_function declaration makes methods private so it means you can't use the module as a module.
   Enabled: false
-ParenthesesAroundCondition:
+Style/ParenthesesAroundCondition:
   AllowSafeAssignment: true
-PerlBackrefs:
+Style/PerlBackrefs:
   # We like perl backrefs.
   Enabled: false
-PredicateName:
+Style/PredicateName:
   # We have good reasons for choosing our method names.
   Enabled: false
-RaiseArgs:
+Style/RaiseArgs:
   # We prefer "raise Exception.new(msg)".
   EnforcedStyle: compact
-RedundantReturn:
+Style/RedundantReturn:
   # We allow explicit returns for multiple return values.
   AllowMultipleReturnValues: true
-Semicolon:
+Style/Semicolon:
   # Makes a good line separator
   Enabled: false
-SignalException:
+Style/SignalException:
   # We like saying raise.
   Enabled: false
-SingleLineBlockParams:
+Style/SingleLineBlockParams:
   # We have good reasons for choosing our argument names.
   Enabled: false
-SingleLineMethods:
+Style/SingleLineMethods:
   # We like single line methods for simple methods.
   Enabled: false
 # We prefer "foo {|arg| body}".
-SpaceBeforeBlockBraces:
+Style/SpaceBeforeBlockBraces:
   EnforcedStyle: space
-SpaceInsideBlockBraces:
+Style/SpaceInsideBlockBraces:
   EnforcedStyle: no_space
   SpaceBeforeBlockParameters: false
-SpaceInsideHashLiteralBraces:
+Style/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
-StringLiterals:
+Style/StringLiterals:
   # They say to not use double quoted strings unless there is interpolation.
   # While this gives a marginal parse time speedup, it makes working with
   # strings annoying.
   Enabled: false
-TrailingComma:
+Style/TrailingComma:
   Enabled: false
-TrivialAccessors:
+Style/TrivialAccessors:
   AllowPredicates: true
   ExactNameMatch: true
-WhenThen:
+Style/WhenThen:
   # We like semi-colons.
   Enabled: false
-WhileUntilModifier:
+Style/WhileUntilModifier:
   # We don't feel strongly about this.
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,19 +1,43 @@
 inherit_from: .rubocop_todo.yml
 
+Lint/BlockAlignment:
+  Enabled: false
+Lint/EndAlignment:
+  # Our alignment style differs significantly
+  # and this doesn't seem to be a big deal.
+  Enabled: false
+Lint/HandleExceptions:
+  # We legitimately ignore exceptions in some cases and this is easy to catch in code review.
+  Enabled: false
+Lint/Loop:
+  # This isn't a big deal.
+  Enabled: false
+
+Metrics/BlockNesting:
+  # We'll catch this in code review. There are some legitimate uses.
+  Enabled: false
+Metrics/ClassLength:
+  # It's not worth bending over backwards to avoid long classes.
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  # It's difficult to reason about what will reduce cyclomatic complexity.
+  Enabled: false
+Metrics/LineLength:
+  Enabled: true
+  Max: 110
+Metrics/MethodLength:
+  # TODO: This max should actually be 25 but that will require significant refactoring.
+  Max: 50
+  CountComments: false
+
 Style/AccessorMethodName:
   # We have good reasons for choosing our method names.
   Enabled: false
 Style/AlignParameters:
   # Natalie doesn't like to align parameters to the method call.
   Enabled: false
-Metrics/BlockNesting:
-  # We'll catch this in code review. There are some legitimate uses.
-  Enabled: false
 Style/CharacterLiteral:
   # Character literals are pretty useful when working with text like we do.
-  Enabled: false
-Metrics/ClassLength:
-  # It's not worth bending over backwards to avoid long classes.
   Enabled: false
 Style/CollectionMethods:
   PreferredMethods:
@@ -21,8 +45,8 @@ Style/CollectionMethods:
     reduce: 'inject'
     detect: 'find'
     find_all: 'select'
-Metrics/CyclomaticComplexity:
-  # It's difficult to reason about what will reduce cyclomatic complexity.
+Style/DeprecatedHashMethods:
+  # has_xxx? reads better.
   Enabled: false
 Style/Documentation:
   # TODO: We need to add a bunch of docs before we can enable this.
@@ -36,21 +60,11 @@ Style/EmptyLineBetweenDefs:
 Style/Encoding:
   # We use utf-8 comments when utf-8 characters are in use.
   Enabled: false
-Lint/EndAlignment:
-  # Our alignment style differs significantly
-  # and this doesn't seem to be a big deal.
-  Enabled: false
 Style/FormatString:
   # We like the string % operator.
   Enabled: false
-Lint/HandleExceptions:
-  # We legitimately ignore exceptions in some cases and this is easy to catch in code review.
-  Enabled: false
 Style/HashSyntax:
   # We are a 1.8 compatable project still.
-  Enabled: false
-Style/DeprecatedHashMethods:
-  # has_xxx? reads better.
   Enabled: false
 Style/IfUnlessModifier:
   # We don't feel strongly about this.
@@ -60,21 +74,9 @@ Style/IndentationConsistency:
   Enabled: false
 Style/IndentationWidth:
   Enabled: false
-Lint/BlockAlignment:
-  Enabled: false
 Style/Lambda:
   # We are a 1.8 compatible project still.
   Enabled: false
-Metrics/LineLength:
-  Enabled: true
-  Max: 110
-Lint/Loop:
-  # This isn't a big deal.
-  Enabled: false
-Metrics/MethodLength:
-  # TODO: This max should actually be 25 but that will require significant refactoring.
-  Max: 50
-  CountComments: false
 Style/ModuleFunction:
   # The module_function declaration makes methods private so it means you can't use the module as a module.
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,7 +65,7 @@ Lambda:
   Enabled: false
 LineLength:
   Enabled: true
-  Max: 100
+  Max: 110
 Loop:
   # This isn't a big deal.
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+inherit_from: .rubocop_todo.yml
+
 AccessorMethodName:
   # We have good reasons for choosing our method names.
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,7 +38,7 @@ EndAlignment:
   # Our alignment style differs significantly
   # and this doesn't seem to be a big deal.
   Enabled: false
-FavorSprintf:
+FormatString:
   # We like the string % operator.
   Enabled: false
 HandleExceptions:
@@ -47,7 +47,7 @@ HandleExceptions:
 HashSyntax:
   # We are a 1.8 compatable project still.
   Enabled: false
-HashMethods:
+DeprecatedHashMethods:
   # has_xxx? reads better.
   Enabled: false
 IfUnlessModifier:
@@ -102,9 +102,11 @@ SingleLineBlockParams:
 SingleLineMethods:
   # We like single line methods for simple methods.
   Enabled: false
-SpaceAroundBlockBraces:
-  # We prefer "foo {|arg| body}".
-  EnforcedStyle: no_space_inside_braces
+# We prefer "foo {|arg| body}".
+SpaceBeforeBlockBraces:
+  EnforcedStyle: space
+SpaceInsideBlockBraces:
+  EnforcedStyle: no_space
   SpaceBeforeBlockParameters: false
 SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space

--- a/.rubocop_0.18.0.yml
+++ b/.rubocop_0.18.0.yml
@@ -1,0 +1,126 @@
+AccessorMethodName:
+  # We have good reasons for choosing our method names.
+  Enabled: false
+AlignParameters:
+  # Natalie doesn't like to align parameters to the method call.
+  Enabled: false
+BlockNesting:
+  # We'll catch this in code review. There are some legitimate uses.
+  Enabled: false
+CharacterLiteral:
+  # Character literals are pretty useful when working with text like we do.
+  Enabled: false
+ClassLength:
+  # It's not worth bending over backwards to avoid long classes.
+  Enabled: false
+CollectionMethods:
+  PreferredMethods:
+    collect: 'map'
+    reduce: 'inject'
+    detect: 'find'
+    find_all: 'select'
+CyclomaticComplexity:
+  # It's difficult to reason about what will reduce cyclomatic complexity.
+  Enabled: false
+Documentation:
+  # TODO: We need to add a bunch of docs before we can enable this.
+  Enabled: false
+DotPosition:
+  # This check doesn't want chained method invocation to end with a dot.
+  # But we like to do that.
+  Enabled: false
+EmptyLineBetweenDefs:
+  AllowAdjacentOneLineDefs: true
+Encoding:
+  # We use utf-8 comments when utf-8 characters are in use.
+  Enabled: false
+EndAlignment:
+  # Our alignment style differs significantly
+  # and this doesn't seem to be a big deal.
+  Enabled: false
+FavorSprintf:
+  # We like the string % operator.
+  Enabled: false
+HandleExceptions:
+  # We legitimately ignore exceptions in some cases and this is easy to catch in code review.
+  Enabled: false
+HashSyntax:
+  # We are a 1.8 compatable project still.
+  Enabled: false
+HashMethods:
+  # has_xxx? reads better.
+  Enabled: false
+IfUnlessModifier:
+  # We don't feel strongly about this.
+  Enabled: false
+IndentationConsistency:
+  # We use indentation to convey meaning more often than we screw it up.
+  Enabled: false
+IndentationWidth:
+  Enabled: false
+BlockAlignment:
+  Enabled: false
+Lambda:
+  # We are a 1.8 compatible project still.
+  Enabled: false
+LineLength:
+  Enabled: true
+  Max: 100
+Loop:
+  # This isn't a big deal.
+  Enabled: false
+MethodLength:
+  # TODO: This max should actually be 25 but that will require significant refactoring.
+  Max: 50
+  CountComments: false
+ModuleFunction:
+  # The module_function declaration makes methods private so it means you can't use the module as a module.
+  Enabled: false
+ParenthesesAroundCondition:
+  AllowSafeAssignment: true
+PerlBackrefs:
+  # We like perl backrefs.
+  Enabled: false
+PredicateName:
+  # We have good reasons for choosing our method names.
+  Enabled: false
+RaiseArgs:
+  # We prefer "raise Exception.new(msg)".
+  EnforcedStyle: compact
+RedundantReturn:
+  # We allow explicit returns for multiple return values.
+  AllowMultipleReturnValues: true
+Semicolon:
+  # Makes a good line separator
+  Enabled: false
+SignalException:
+  # We like saying raise.
+  Enabled: false
+SingleLineBlockParams:
+  # We have good reasons for choosing our argument names.
+  Enabled: false
+SingleLineMethods:
+  # We like single line methods for simple methods.
+  Enabled: false
+SpaceAroundBlockBraces:
+  # We prefer "foo {|arg| body}".
+  EnforcedStyle: no_space_inside_braces
+  SpaceBeforeBlockParameters: false
+SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+StringLiterals:
+  # They say to not use double quoted strings unless there is interpolation.
+  # While this gives a marginal parse time speedup, it makes working with
+  # strings annoying.
+  Enabled: false
+TrailingComma:
+  Enabled: false
+TrivialAccessors:
+  AllowPredicates: true
+  ExactNameMatch: true
+WhenThen:
+  # We like semi-colons.
+  Enabled: false
+WhileUntilModifier:
+  # We don't feel strongly about this.
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,0 +1,84 @@
+Lint/AssignmentInCondition:
+  Enabled: false
+Lint/FormatParameterMismatch:
+  Enabled: false
+Lint/NestedMethodDefinition:
+  Enabled: false
+Lint/NonLocalExitFromIterator:
+  Enabled: false
+Lint/StringConversionInInterpolation:
+  Enabled: false
+Lint/UselessAccessModifier:
+  Enabled: false
+Lint/UnneededDisable:
+  Enabled: false
+Lint/UnusedBlockArgument:
+  Enabled: false
+Lint/UnusedMethodArgument:
+  Enabled: false
+Metrics/AbcSize:
+  Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
+Performance/FlatMap:
+  Enabled: false
+Performance/ReverseEach:
+  Enabled: false
+Performance/StringReplacement:
+  Enabled: false
+Style/BarePercentLiterals:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/ClassCheck:
+  Enabled: false
+Style/ClosingParenthesisIndentation:
+  Enabled: false
+Style/DoubleNegation:
+  Enabled: false
+Style/EachWithObject:
+  Enabled: false
+Style/EmptyLinesAroundBlockBody:
+  Enabled: false
+Style/ExtraSpacing:
+  Enabled: false
+Style/FirstParameterIndentation:
+  Enabled: false
+Style/GuardClause:
+  Enabled: false
+Style/IndentHash:
+  Enabled: false
+Style/LineEndConcatenation:
+  Enabled: false
+Style/Next:
+  Enabled: false
+Style/MultilineOperationIndentation:
+  Enabled: false
+Style/MultilineTernaryOperator:
+  Enabled: false
+Style/ParallelAssignment:
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  Enabled: false
+Style/RegexpLiteral:
+  Enabled: false
+Style/SelfAssignment:
+  Enabled: false
+Style/SingleSpaceBeforeFirstArg:
+  Enabled: false
+Style/SpaceAroundOperators:
+  Enabled: false
+Style/SpaceInsideRangeLiteral:
+  Enabled: false
+Style/SpaceInsideStringInterpolation:
+  Enabled: false
+Style/StringLiteralsInInterpolation:
+  Enabled: false
+Style/StructInheritance:
+  Enabled: false
+Style/SymbolProc:
+  Enabled: false
+Style/TrailingUnderscoreVariable:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,13 @@ gem 'rake'
 # Pin this version since Rubocop occasionally adds new cops in
 # incremental releases and we don't want out builds going red because
 # of that.
-gem 'rubocop', '= 0.18.0' unless RUBY_VERSION =~ /^1\.8/
+unless RUBY_VERSION =~ /^1\.8/
+  unless RUBY_VERSION < '1.9.3'
+    gem 'rubocop', '= 0.33.0'
+  else
+    gem 'rubocop', '= 0.18.0'
+  end
+end
 
 if RUBY_VERSION =~ /^1\.8/
   gem 'listen', '~> 1.1.0'

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,9 @@ end
 
 if RUBY_VERSION !~ /^(1\.8)/ && (ENV.has_key?("RUBOCOP") && ENV["RUBOCOP"] == "true" || !(ENV.has_key?("RUBOCOP") || ENV.has_key?("TEST")))
   require 'rubocop/rake_task'
-  Rubocop::RakeTask.new do |t|
+  RuboCop = Rubocop unless defined?(RuboCop)
+  RuboCop::RakeTask.new do |t|
+    t.options = ['-c', '.rubocop_0.18.0.yml'] if RUBY_VERSION < '1.9.3'
     t.patterns = FileList["lib/**/*"]
   end
 else


### PR DESCRIPTION
I noticed that I could not run tests with ruby 2.2. I got error when I ran `bundle exec rake test`.

```
$ bundle exec rake test
warning: parser/current is loading parser/ruby21, which recognizes
warning: 2.1-compliant syntax, but you are running 2.2.2.
rake aborted!
NameError: uninitialized constant Parser::Ruby21
```

so I would like to propose to update rubocop.
