### PR TITLE
fix cicular require warning

### DIFF
--- a/lib/sass/script/tree/funcall.rb
+++ b/lib/sass/script/tree/funcall.rb
@@ -1,5 +1,5 @@
 require 'sass/script/functions'
-require 'sass/util/normalized_map'
+require 'sass/util'
 
 module Sass::Script::Tree
   # A SassScript parse node representing a function call.

--- a/lib/sass/util/normalized_map.rb
+++ b/lib/sass/util/normalized_map.rb
@@ -1,5 +1,4 @@
 require 'delegate'
-require 'sass/util'
 
 module Sass
   module Util


### PR DESCRIPTION
`sass/util` required `sass/util/normalized_map` and
`sass/util/normalized_map` required `sass/util`

Circular requires are considered dangerous, so I pulled the `sass/util`
require out of `sass/util/normalized_map` and changed
`sass/script/tree/funcall` to require `sass/util` instead of directly
requiring the normalized map file
