### PR TITLE
Handle floating point errors more gracefully.

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -3,6 +3,12 @@
 * Table of contents
 {:toc}
 
+## 3.4.19 (UNRELEASED)
+
+* Sass numeric equality now better handles float-point errors. Any
+  numbers that are within 1 / (10 ^ (precision + 1)) of each other are
+  now considered equal.
+
 ## 3.4.18 (25 August 2015)
 
 * A fix in 3.4.17 to address unecessary semi-colons in compressed mode

--- a/lib/sass/script/value/number.rb
+++ b/lib/sass/script/value/number.rb
@@ -43,12 +43,20 @@ module Sass::Script::Value
     def self.precision=(digits)
       @precision = digits.round
       @precision_factor = 10.0**@precision
+      @epsilon = 1 / (@precision_factor * 10)
     end
 
     # the precision factor used in numeric output
     # it is derived from the `precision` method.
     def self.precision_factor
       @precision_factor ||= 10.0**precision
+    end
+
+    # epsilon is used in checking equality of floating point numbers. Any
+    # numbers within an epsilon of each other are considered functionally equal
+    # it is derived from the current numeric `precision`.
+    def self.epsilon
+      @epsilon ||= 1 / (precision_factor * 10)
     end
 
     # Used so we don't allocate two new arrays for each new number.
@@ -200,7 +208,7 @@ module Sass::Script::Value
       rescue Sass::UnitConversionError
         return Bool::FALSE
       end
-      Bool.new(this.value == other.value)
+      Bool.new(basically_equal?(this.value, other.value))
     end
 
     def hash
@@ -211,7 +219,7 @@ module Sass::Script::Value
     # Hash-equality must be transitive, so it just compares the exact value,
     # numerator units, and denominator units.
     def eql?(other)
-      value == other.value && numerator_units == other.numerator_units &&
+      basically_equal?(value, other.value) && numerator_units == other.numerator_units &&
         denominator_units == other.denominator_units
     end
 
@@ -294,7 +302,7 @@ module Sass::Script::Value
 
     # @return [Boolean] Whether or not this number is an integer.
     def int?
-      value % 1 == 0.0
+      basically_equal?(value % 1, 0.0)
     end
 
     # @return [Boolean] Whether or not this number has no units.
@@ -375,11 +383,19 @@ module Sass::Script::Value
 
     private
 
+    def basically_equal?(num1, num2)
+      self.class.basically_equal?(num1, num2)
+    end
+
+    def self.basically_equal?(num1, num2)
+      (num1 - num2).abs < epsilon
+    end
+
     # @private
     def self.round(num)
       if num.is_a?(Float) && (num.infinite? || num.nan?)
         num
-      elsif num % 1 == 0.0
+      elsif basically_equal?(num % 1, 0.0)
         num.to_i
       else
         ((num * precision_factor).round / precision_factor).to_f

--- a/test/sass/script_test.rb
+++ b/test/sass/script_test.rb
@@ -1162,6 +1162,13 @@ SASS
     assert_equal "NaN", resolve("(0.0/0.0)")
   end
 
+  def test_equality_uses_an_epsilon
+    # At least on my machine, this calculation introduces a floating point error:
+    # 29.0 / 7 * 7
+    # => 29.000000000000004
+    assert_equal "true", resolve("29 == (29 / 7 * 7)")
+  end
+
   private
 
   def resolve(str, opts = {}, environment = env)


### PR DESCRIPTION
In SassScript, `(29 / 7 * 7) == 29` returns false. Which is bad because anyone who knows math (or in this case, @mknadler) can see this should be true instead.

This PR creates the concept of a floating point epsilon which is derived from the current sass script precision. Any two numbers will now be considered equal if they are within an `epsilon` of each other. If the stylesheet's precision is increased by 1, the epsilon gets divided by 10.

The default precision is `5` and so the default epsilon is `1 / (10 ** (5 + 1))` or `0.000001`.
