### PR TITLE
Remove 1 8 6 workarounds

### DIFF
--- a/lib/sass/importers/filesystem.rb
+++ b/lib/sass/importers/filesystem.rb
@@ -150,8 +150,7 @@ module Sass
             full_path.gsub!(REDUNDANT_DIRECTORY, File::SEPARATOR)
             [Sass::Util.cleanpath(full_path).to_s, s]
           end
-        end
-        found = Sass::Util.flatten(found, 1)
+        end.flatten(1)
         return if found.empty?
 
         if found.size > 1 && !@same_name_warnings.include?(found.first.first)

--- a/lib/sass/selector/sequence.rb
+++ b/lib/sass/selector/sequence.rb
@@ -228,11 +228,11 @@ module Sass
           next if current.empty?
           current = current.dup
           last_current = [current.pop]
-          prefixes = Sass::Util.flatten(prefixes.map do |prefix|
+          prefixes = prefixes.map do |prefix|
             sub = subweave(prefix, current)
             next [] unless sub
             sub.map {|seqs| seqs + last_current}
-          end, 1)
+          end.flatten(1)
         end
         prefixes
       end
@@ -551,7 +551,7 @@ module Sass
       def trim(seqses)
         # Avoid truly horrific quadratic behavior. TODO: I think there
         # may be a way to get perfect trimming without going quadratic.
-        return Sass::Util.flatten(seqses, 1) if seqses.size > 100
+        return seqses.flatten(1) if seqses.size > 100
 
         # Keep the results in a separate array so we can be sure we aren't
         # comparing against an already-trimmed selector. This ensures that two
@@ -586,7 +586,7 @@ module Sass
             end
           end
         end
-        Sass::Util.flatten(result, 1)
+        result.flatten(1)
       end
 
       def _hash

--- a/lib/sass/selector/simple_sequence.rb
+++ b/lib/sass/selector/simple_sequence.rb
@@ -337,7 +337,7 @@ MESSAGE
 
       def _eql?(other)
         other.base.eql?(base) && other.pseudo_elements == pseudo_elements &&
-          Sass::Util.set_eql?(other.rest, rest) && other.subject? == subject?
+          other.rest.eql?(rest) && other.subject? == subject?
       end
     end
   end

--- a/lib/sass/selector/simple_sequence.rb
+++ b/lib/sass/selector/simple_sequence.rb
@@ -332,7 +332,7 @@ MESSAGE
       end
 
       def _hash
-        [base, Sass::Util.set_hash(rest)].hash
+        [base, rest.hash].hash
       end
 
       def _eql?(other)

--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -783,15 +783,6 @@ module Sass
                    (RUBY_VERSION_COMPONENTS[0] == 1 && RUBY_VERSION_COMPONENTS[1] < 9)
     end
 
-    # Whether or not this is running under Ruby 1.8.6 or lower.
-    # Note that lower versions are not officially supported.
-    #
-    # @return [Boolean]
-    def ruby1_8_6?
-      return @ruby1_8_6 if defined?(@ruby1_8_6)
-      @ruby1_8_6 = ruby1_8? && RUBY_VERSION_COMPONENTS[2] < 7
-    end
-
     # Whether or not this is running under Ruby 1.9.2 exactly.
     #
     # @return [Boolean]

--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -276,7 +276,7 @@ module Sass
     #     #  [2, 4, 5]]
     def paths(arrs)
       arrs.inject([[]]) do |paths, arr|
-        flatten(arr.map {|e| paths.map {|path| path + [e]}}, 1)
+        arr.map {|e| paths.map {|path| path + [e]}}.flatten(1)
       end
     end
 
@@ -841,7 +841,7 @@ module Sass
       end
 
       return Hash[pairs_or_hash] unless ruby1_8?
-      (pairs_or_hash.is_a?(NormalizedMap) ? NormalizedMap : OrderedHash)[*flatten(pairs_or_hash, 1)]
+      (pairs_or_hash.is_a?(NormalizedMap) ? NormalizedMap : OrderedHash)[*pairs_or_hash.flatten(1)]
     end
 
     unless ruby1_8?
@@ -985,17 +985,6 @@ module Sass
     # @return [Fixnum] The ASCII code of `c`.
     def ord(c)
       ruby1_8? ? c[0] : c.ord
-    end
-
-    # Flattens the first `n` nested arrays in a cross-version manner.
-    #
-    # @param arr [Array] The array to flatten
-    # @param n [Fixnum] The number of levels to flatten
-    # @return [Array] The flattened array
-    def flatten(arr, n)
-      return arr.flatten(n) unless ruby1_8_6?
-      return arr if n == 0
-      arr.inject([]) {|res, e| e.is_a?(Array) ? res.concat(flatten(e, n - 1)) : res << e}
     end
 
     # Flattens the first level of nested arrays in `arrs`. Unlike

--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -1005,16 +1005,6 @@ module Sass
       result
     end
 
-    # Returns the hash code for a set in a cross-version manner.
-    # Aggravatingly, this is order-dependent in Ruby 1.8.6.
-    #
-    # @param set [Set]
-    # @return [Fixnum] The order-independent hashcode of `set`
-    def set_hash(set)
-      return set.hash unless ruby1_8_6?
-      set.map {|e| e.hash}.uniq.sort.hash
-    end
-
     # Tests the hash-equality of two sets in a cross-version manner.
     # Aggravatingly, this is order-dependent in Ruby 1.8.6.
     #

--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -1005,17 +1005,6 @@ module Sass
       result
     end
 
-    # Tests the hash-equality of two sets in a cross-version manner.
-    # Aggravatingly, this is order-dependent in Ruby 1.8.6.
-    #
-    # @param set1 [Set]
-    # @param set2 [Set]
-    # @return [Boolean] Whether or not the sets are hashcode equal
-    def set_eql?(set1, set2)
-      return set1.eql?(set2) unless ruby1_8_6?
-      set1.to_a.uniq.sort_by {|e| e.hash}.eql?(set2.to_a.uniq.sort_by {|e| e.hash})
-    end
-
     # Like `Object#inspect`, but preserves non-ASCII characters rather than
     # escaping them under Ruby 1.9.2.  This is necessary so that the
     # precompiled Haml template can be `#encode`d into `@options[:encoding]`

--- a/lib/sass/util/subset_map.rb
+++ b/lib/sass/util/subset_map.rb
@@ -78,8 +78,7 @@ module Sass
             next unless subset.subset?(set)
             [index, subenum]
           end
-        end
-        res = Sass::Util.flatten(res, 1)
+        end.flatten(1)
         res.compact!
         res.uniq!
         res.sort!

--- a/test/sass/source_map_test.rb
+++ b/test/sass/source_map_test.rb
@@ -881,11 +881,12 @@ JSON
     source_ranges = build_ranges(source, source_file_name)
     target_ranges = build_ranges(css)
     map = Sass::Source::Map.new
-    Sass::Util.flatten(source_ranges.map do |(name, sources)|
+    source_ranges.map do |(name, sources)|
         assert(sources.length == 1, "#{sources.length} source ranges encountered for annotation #{name}")
         assert(target_ranges[name], "No target ranges for annotation #{name}")
         target_ranges[name].map {|target_range| [sources.first, target_range]}
-      end, 1).
+      end.
+      flatten(1).
       sort_by {|(_, target)| [target.start_pos.line, target.start_pos.offset]}.
       each {|(s2, target)| map.add(s2, target)}
     map

--- a/test/sass/util_test.rb
+++ b/test/sass/util_test.rb
@@ -213,21 +213,6 @@ class UtilTest < MiniTest::Test
     assert_equal([1, 4, 6, 2, 5, 3], flatten_vertically([[1, 2, 3], [4, 5], 6]))
   end
 
-  def test_set_eql
-    assert(set_eql?(Set[1, 2, 3], Set[3, 2, 1]))
-    assert(set_eql?(Set[1, 2, 3], Set[1, 2, 3]))
-
-    s1 = Set[]
-    s1 << 1
-    s1 << 2
-    s1 << 3
-    s2 = Set[]
-    s2 << 3
-    s2 << 2
-    s2 << 1
-    assert(set_eql?(s1, s2))
-  end
-
   def test_extract_and_inject_values
     test = lambda {|arr| assert_equal(arr, with_extracted_values(arr) {|str| str})}
 

--- a/test/sass/util_test.rb
+++ b/test/sass/util_test.rb
@@ -213,21 +213,6 @@ class UtilTest < MiniTest::Test
     assert_equal([1, 4, 6, 2, 5, 3], flatten_vertically([[1, 2, 3], [4, 5], 6]))
   end
 
-  def test_set_hash
-    assert(set_hash(Set[1, 2, 3]) == set_hash(Set[3, 2, 1]))
-    assert(set_hash(Set[1, 2, 3]) == set_hash(Set[1, 2, 3]))
-
-    s1 = Set[]
-    s1 << 1
-    s1 << 2
-    s1 << 3
-    s2 = Set[]
-    s2 << 3
-    s2 << 2
-    s2 << 1
-    assert(set_hash(s1) == set_hash(s2))
-  end
-
   def test_set_eql
     assert(set_eql?(Set[1, 2, 3], Set[3, 2, 1]))
     assert(set_eql?(Set[1, 2, 3], Set[1, 2, 3]))

--- a/test/sass/util_test.rb
+++ b/test/sass/util_test.rb
@@ -206,20 +206,6 @@ class UtilTest < MiniTest::Test
     assert_equal(98, ord("bar"))
   end
 
-  def test_flatten
-    assert_equal([1, 2, 3], flatten([1, 2, 3], 0))
-    assert_equal([1, 2, 3], flatten([1, 2, 3], 1))
-    assert_equal([1, 2, 3], flatten([1, 2, 3], 2))
-
-    assert_equal([[1, 2], 3], flatten([[1, 2], 3], 0))
-    assert_equal([1, 2, 3], flatten([[1, 2], 3], 1))
-    assert_equal([1, 2, 3], flatten([[1, 2], 3], 2))
-
-    assert_equal([[[1], 2], [3], 4], flatten([[[1], 2], [3], 4], 0))
-    assert_equal([[1], 2, 3, 4], flatten([[[1], 2], [3], 4], 1))
-    assert_equal([1, 2, 3, 4], flatten([[[1], 2], [3], 4], 2))
-  end
-
   def test_flatten_vertically
     assert_equal([1, 2, 3], flatten_vertically([1, 2, 3]))
     assert_equal([1, 3, 5, 2, 4, 6], flatten_vertically([[1, 2], [3, 4], [5, 6]]))


### PR DESCRIPTION
There are still a few helper methods around that are only used for ruby 1.8.6 workarounds, but the gemspec has set a minimal version of ruby 1.8.7 for a long time (and for example arr.flatten(n) was already widely used instead of the Sass::Utils#flatten method, meaning sass wouldn't work on ruby 1.8.6 anyway). So it seems cleaner to clean up the code by removing these workarounds.
