### PR TITLE
Avoid slicing twice when once suffices

### DIFF
--- a/lib/sass/scss/parser.rb
+++ b/lib/sass/scss/parser.rb
@@ -156,13 +156,12 @@ module Sass
         else
           value = Sass::Engine.parse_interp(
             text, line, @scanner.pos - text.size, :filename => @filename)
-          string_before_comment = @scanner.string[0...@scanner.pos - text.length]
-          newline_before_comment = string_before_comment.rindex("\n")
+          newline_before_comment = @scanner.string.rindex("\n", @scanner.pos - text.length)
           last_line_before_comment =
             if newline_before_comment
-              string_before_comment[newline_before_comment + 1..-1]
+              @scanner.string[newline_before_comment + 1...@scanner.pos - text.length]
             else
-              string_before_comment
+              @scanner.string[0...@scanner.pos - text.length]
             end
           value.unshift(last_line_before_comment.gsub(/[^\s]/, ' '))
         end


### PR DESCRIPTION
The old approach duplicated a comment twice when there was a newline
before it. This can be avoided by passing a parameter to rindex to
indicate where it needs to start searching.
