### PR TITLE
Use tr instead of gsub for single characters

### DIFF
--- a/lib/sass/scss/parser.rb
+++ b/lib/sass/scss/parser.rb
@@ -215,12 +215,12 @@ module Sass
       end
 
       def special_directive(name, start_pos)
-        sym = name.gsub('-', '_').to_sym
+        sym = name.tr('-', '_').to_sym
         DIRECTIVES.include?(sym) && send("#{sym}_directive", start_pos)
       end
 
       def prefixed_directive(name, start_pos)
-        sym = deprefix(name).gsub('-', '_').to_sym
+        sym = deprefix(name).tr('-', '_').to_sym
         PREFIXED_DIRECTIVES.include?(sym) && send("#{sym}_directive", name, start_pos)
       end
 


### PR DESCRIPTION
Suggested by fasterer gem for better performance. It's not likely to be a big change in performance (as it doesn't seem to be in a method called very often), but it seems slightly clearer to me as well to use tr instead of gsub for such a simple replace.
