### PR TITLE
Mitigate race in template_location_array

### DIFF
--- a/lib/sass/plugin/configuration.rb
+++ b/lib/sass/plugin/configuration.rb
@@ -85,33 +85,41 @@ module Sass
       # See the {file:SASS_REFERENCE.md#template_location-option `:template_location` option}
       # for details.
       #
+      # Modifications to the returned array may not be persistent.  Use {#add_template_location}
+      # and {#remove_template_location} instead.
+      #
       # @return [Array<(String, String)>]
       #   An array of `[template_location, css_location]` pairs.
       def template_location_array
-        old_template_location = options[:template_location]
-        normalize_template_location!
-        options[:template_location]
-      ensure
-        options[:template_location] = old_template_location
+        convert_template_location(options[:template_location], options[:css_location])
       end
 
       private
 
-      def normalize_template_location!
-        return if options[:template_location].is_a?(Array)
-        options[:template_location] =
-          case options[:template_location]
-          when nil
-            if options[:css_location]
-              [[File.join(options[:css_location], 'sass'), options[:css_location]]]
-            else
-              []
-            end
-          when String
-            [[options[:template_location], options[:css_location]]]
+      # Returns the given template location, as an array. If it's already an array,
+      # it is returned unmodified. Otherwise, a new array is created and returned.
+      #
+      # @return [Array<(String, String)>]
+      #   An array of `[template_location, css_location]` pairs.
+      def convert_template_location(template_location, css_location)
+        return template_location if template_location.is_a?(Array)
+        case template_location
+        when nil
+          if css_location
+            [[File.join(css_location, 'sass'), css_location]]
           else
-            options[:template_location].to_a
+            []
           end
+        when String
+          [[template_location, css_location]]
+        else
+          template_location.to_a
+        end
+      end
+
+      def normalize_template_location!
+        options[:template_location] = convert_template_location(
+            options[:template_location], options[:css_location])
       end
     end
   end


### PR DESCRIPTION
Fixes #1835 by mitigating the race where template_location_array is executed concurrently by multiple threads.  This does not fix the race, but makes the behavior more deterministic by not relying on shared state.  In theory, the array could be created multiple times if two threads both start working on it at once.  This means you could still see a race with the add_ or remove_ methods modifying an array that is then discarded, but this should be far less likely than the crash we see now.

Existing behavior is preserved (and better documented).

I'm not sure which branch this should be merged into; stable seems to be the default but it seems improbable that this is intended to be the place changes like this land first.
