### PR TITLE
Documentation: Fix anchor to Sass options

### DIFF
--- a/lib/sass.rb
+++ b/lib/sass.rb
@@ -47,7 +47,7 @@ module Sass
   #
   # @param contents [String] The contents of the Sass file.
   # @param options [{Symbol => Object}] An options hash;
-  #   see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}
+  #   see {file:SASS_REFERENCE.md#options the Sass options documentation}
   # @raise [Sass::SyntaxError] if there's an error in the document
   # @raise [Encoding::UndefinedConversionError] if the source encoding
   #   cannot be converted to UTF-8
@@ -69,7 +69,7 @@ module Sass
   #
   #   @param filename [String] The path to the Sass, SCSS, or CSS file on disk.
   #   @param options [{Symbol => Object}] An options hash;
-  #     see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}
+  #     see {file:SASS_REFERENCE.md#options the Sass options documentation}
   #   @return [String] The compiled CSS.
   #
   # @overload compile_file(filename, css_filename, options = {})
@@ -77,7 +77,7 @@ module Sass
   #
   #   @param filename [String] The path to the Sass, SCSS, or CSS file on disk.
   #   @param options [{Symbol => Object}] An options hash;
-  #     see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}
+  #     see {file:SASS_REFERENCE.md#options the Sass options documentation}
   #   @param css_filename [String] The location to which to write the compiled CSS.
   def self.compile_file(filename, *args)
     options = args.last.is_a?(Hash) ? args.pop : {}

--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -168,7 +168,7 @@ module Sass
     # default values and resolving aliases.
     #
     # @param options [{Symbol => Object}] The options hash;
-    #   see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}
+    #   see {file:SASS_REFERENCE.md#options the Sass options documentation}
     # @return [{Symbol => Object}] The normalized options hash.
     # @private
     def self.normalize_options(options)
@@ -222,7 +222,7 @@ module Sass
     #
     # @param filename [String] The path to the Sass or SCSS file
     # @param options [{Symbol => Object}] The options hash;
-    #   See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+    #   See {file:SASS_REFERENCE.md#options the Sass options documentation}.
     # @return [Sass::Engine] The Engine for the given Sass or SCSS file.
     # @raise [Sass::SyntaxError] if there's an error in the document.
     def self.for_file(filename, options)
@@ -240,7 +240,7 @@ module Sass
     end
 
     # The options for the Sass engine.
-    # See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+    # See {file:SASS_REFERENCE.md#options the Sass options documentation}.
     #
     # @return [{Symbol => Object}]
     attr_reader :options
@@ -259,7 +259,7 @@ module Sass
     #   that overrides the Ruby encoding
     #   (see {file:SASS_REFERENCE.md#encodings the encoding documentation})
     # @param options [{Symbol => Object}] An options hash.
-    #   See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+    #   See {file:SASS_REFERENCE.md#options the Sass options documentation}.
     # @see {Sass::Engine.for_file}
     # @see {Sass::Plugin}
     def initialize(template, options = {})

--- a/lib/sass/environment.rb
+++ b/lib/sass/environment.rb
@@ -81,7 +81,7 @@ module Sass
     inherited_hash_reader :function
 
     # @param options [{Symbol => Object}] The options hash. See
-    #   {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+    #   {file:SASS_REFERENCE.md#options the Sass options documentation}.
     # @param parent [Environment] See \{#parent}
     def initialize(parent = nil, options = nil)
       @parent = parent

--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -31,7 +31,7 @@ module Sass::Plugin
     # Creates a new compiler.
     #
     # @param opts [{Symbol => Object}]
-    #   See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+    #   See {file:SASS_REFERENCE.md#options the Sass options documentation}.
     def initialize(opts = {})
       @watched_files = Set.new
       options.merge!(opts)

--- a/lib/sass/plugin/configuration.rb
+++ b/lib/sass/plugin/configuration.rb
@@ -25,7 +25,7 @@ module Sass
       end
 
       # An options hash.
-      # See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+      # See {file:SASS_REFERENCE.md#options the Sass options documentation}.
       #
       # @return [{Symbol => Object}]
       def options

--- a/lib/sass/plugin/staleness_checker.rb
+++ b/lib/sass/plugin/staleness_checker.rb
@@ -39,7 +39,7 @@ module Sass
       # for checking the staleness of several stylesheets at once.
       #
       # @param options [{Symbol => Object}]
-      #   See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+      #   See {file:SASS_REFERENCE.md#options the Sass options documentation}.
       def initialize(options)
         # URIs that are being actively checked for staleness. Protects against
         # import loops.

--- a/lib/sass/script.rb
+++ b/lib/sass/script.rb
@@ -21,7 +21,7 @@ module Sass
     # @param offset [Fixnum] The number of characters in on `line` that the SassScript started.
     #   Used for error reporting
     # @param options [{Symbol => Object}] An options hash;
-    #   see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}
+    #   see {file:SASS_REFERENCE.md#options the Sass options documentation}
     # @return [Script::Tree::Node] The root node of the parse tree
     def self.parse(value, line, offset, options = {})
       Parser.parse(value, line, offset, options)

--- a/lib/sass/script/lexer.rb
+++ b/lib/sass/script/lexer.rb
@@ -147,7 +147,7 @@ module Sass
       # @param offset [Fixnum] The 1-based character (not byte) offset in the line in the source.
       #   Used for error reporting and sourcemap building
       # @param options [{Symbol => Object}] An options hash;
-      #   see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}
+      #   see {file:SASS_REFERENCE.md#options the Sass options documentation}
       def initialize(str, line, offset, options)
         @scanner = str.is_a?(StringScanner) ? str : Sass::Util::MultibyteStringScanner.new(str)
         @line = line

--- a/lib/sass/script/parser.rb
+++ b/lib/sass/script/parser.rb
@@ -25,7 +25,7 @@ module Sass
       # @param offset [Fixnum] The character (not byte) offset where the script starts in the line.
       #   Used for error reporting and sourcemap building
       # @param options [{Symbol => Object}] An options hash;
-      #   see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}
+      #   see {file:SASS_REFERENCE.md#options the Sass options documentation}
       def initialize(str, line, offset, options = {})
         @options = options
         @lexer = lexer_class.new(str, line, offset, options)

--- a/lib/sass/script/tree/node.rb
+++ b/lib/sass/script/tree/node.rb
@@ -25,7 +25,7 @@ module Sass::Script::Tree
 
     # Sets the options hash for this node,
     # as well as for all child nodes.
-    # See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+    # See {file:SASS_REFERENCE.md#options the Sass options documentation}.
     #
     # @param options [{Symbol => Object}] The options
     def options=(options)

--- a/lib/sass/script/value/base.rb
+++ b/lib/sass/script/value/base.rb
@@ -26,7 +26,7 @@ module Sass::Script::Value
 
     # Sets the options hash for this node,
     # as well as for all child nodes.
-    # See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+    # See {file:SASS_REFERENCE.md#options the Sass options documentation}.
     #
     # @param options [{Symbol => Object}] The options
     attr_writer :options

--- a/lib/sass/tree/node.rb
+++ b/lib/sass/tree/node.rb
@@ -83,7 +83,7 @@ module Sass
       attr_writer :filename
 
       # The options hash for the node.
-      # See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+      # See {file:SASS_REFERENCE.md#options the Sass options documentation}.
       #
       # @return [{Symbol => Object}]
       attr_reader :options
@@ -149,7 +149,7 @@ module Sass
       # @return [Boolean]
       def invisible?; false; end
 
-      # The output style. See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+      # The output style. See {file:SASS_REFERENCE.md#options the Sass options documentation}.
       #
       # @return [Symbol]
       def style


### PR DESCRIPTION
Sass options live now under

   http://sass-lang.com/documentation/file.SASS_REFERENCE.html#options

and not

   http://sass-lang.com/documentation/file.SASS_REFERENCE.html#sass_options
