### PR TITLE
Adding a command line option --sourcemap-filename=custom.css.map

### DIFF
--- a/lib/sass/exec/sass_scss.rb
+++ b/lib/sass/exec/sass_scss.rb
@@ -172,8 +172,6 @@ MESSAGE
         @options[:sourcemap] = (type || :auto).to_sym
       end
 
-      # If the user gives --sourcemap-filename, we write out the sourcemap file there
-      # The default is to write in the same location
       opts.on(:OPTIONAL, '--sourcemap-filename=FILE', 'The destination sourcemap file') do |smd|
         @options[:sourcemap_filename] = smd
       end

--- a/lib/sass/exec/sass_scss.rb
+++ b/lib/sass/exec/sass_scss.rb
@@ -52,7 +52,9 @@ END
       super
 
       if @options[:sourcemap] != :none && @options[:output_filename]
-        @options[:sourcemap_filename] = Sass::Util.sourcemap_name(@options[:output_filename])
+        if !@options[:sourcemap_filename]
+          @options[:sourcemap_filename] = Sass::Util.sourcemap_name(@options[:output_filename])
+        end
       end
 
       @options[:for_engine][:filename] = @options[:filename]
@@ -168,6 +170,12 @@ MESSAGE
         end
 
         @options[:sourcemap] = (type || :auto).to_sym
+      end
+
+      # If the user gives --sourcemap-filename, we write out the sourcemap file there
+      # The default is to write in the same location
+      opts.on(:OPTIONAL, '--sourcemap-filename=FILE', 'The destination of the sourcemap file') do |smd|
+        @options[:sourcemap_filename] = smd
       end
 
       opts.on('-s', '--stdin', :NONE,

--- a/lib/sass/exec/sass_scss.rb
+++ b/lib/sass/exec/sass_scss.rb
@@ -52,7 +52,7 @@ END
       super
 
       if @options[:sourcemap] != :none && @options[:output_filename]
-        if !@options[:sourcemap_filename]
+        unless @options[:sourcemap_filename]
           @options[:sourcemap_filename] = Sass::Util.sourcemap_name(@options[:output_filename])
         end
       end
@@ -174,7 +174,7 @@ MESSAGE
 
       # If the user gives --sourcemap-filename, we write out the sourcemap file there
       # The default is to write in the same location
-      opts.on(:OPTIONAL, '--sourcemap-filename=FILE', 'The destination of the sourcemap file') do |smd|
+      opts.on(:OPTIONAL, '--sourcemap-filename=FILE', 'The destination sourcemap file') do |smd|
         @options[:sourcemap_filename] = smd
       end
 

--- a/lib/sass/exec/sass_scss.rb
+++ b/lib/sass/exec/sass_scss.rb
@@ -134,22 +134,7 @@ END
       end
     end
 
-    def input_and_output(opts)
-      opts.separator ''
-      opts.separator 'Input and Output:'
-
-      if @default_syntax == :sass
-        opts.on('--scss',
-                'Use the CSS-superset SCSS syntax.') do
-          @options[:for_engine][:syntax] = :scss
-        end
-      else
-        opts.on('--sass',
-                'Use the indented Sass syntax.') do
-          @options[:for_engine][:syntax] = :sass
-        end
-      end
-
+    def sourcemap_options(opts)
       # This is optional for backwards-compatibility with Sass 3.3, which didn't
       # enable sourcemaps by default and instead used "--sourcemap" to do so.
       opts.on(:OPTIONAL, '--sourcemap=TYPE',
@@ -172,9 +157,30 @@ MESSAGE
         @options[:sourcemap] = (type || :auto).to_sym
       end
 
+      # This lets the user place the generated .map file at a location of his liking
       opts.on(:OPTIONAL, '--sourcemap-filename=FILE', 'The destination sourcemap file') do |smd|
         @options[:sourcemap_filename] = smd
       end
+    end
+
+    def input_and_output(opts)
+      opts.separator ''
+      opts.separator 'Input and Output:'
+
+      if @default_syntax == :sass
+        opts.on('--scss',
+                'Use the CSS-superset SCSS syntax.') do
+          @options[:for_engine][:syntax] = :scss
+        end
+      else
+        opts.on('--sass',
+                'Use the indented Sass syntax.') do
+          @options[:for_engine][:syntax] = :sass
+        end
+      end
+
+      # New function to stay under function size limit
+      sourcemap_options(opts)
 
       opts.on('-s', '--stdin', :NONE,
               'Read input from standard input instead of an input file.',


### PR DESCRIPTION
It is sometimes required that the sourcemap file be placed in a location that is different from the original scss/sass file. This command line does just that.
