### PR TITLE
Remove warnings for @comment tag when compiling docs

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -9,3 +9,5 @@
 --protected
 --no-private
 --no-highlight
+--tag             comment
+--hide-tag        comment


### PR DESCRIPTION
I saw this when viewing issue #1872.
