### PR TITLE
Nested Map Functions

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -12,7 +12,7 @@
 
 * Add support for nested maps with `map-get()` and `map-has-key()` by passing more than 2 arguments
 
-* Add support for merging changes deeply into a nested hash by providing a new syntax for merge that is generally non-destructive with the signature `map-merge($map, $keys, $value)` 
+* Add support for setting changes deeply into a nested hash by providing a new syntax for set that is generally non-destructive with the signature `map-set($map, $keys..., $value)` 
 
 ## 3.4.20 (Unreleased)
 

--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -10,6 +10,10 @@
 
 * Add a `$weight` parameter to `invert()`.
 
+* Add support for nested maps with `map-get()` and `map-has-key()` by passing more than 2 arguments
+
+* Add support for merging changes deeply into a nested hash by providing a new syntax for merge that is generally non-destructive with the signature `map-merge($map, $keys, $value)` 
+
 ## 3.4.20 (Unreleased)
 
 * Fix a bug with the rounding changes from 3.4.14 and 3.4.15 where some negative
@@ -130,7 +134,7 @@
 * When converting a space-separated list with `sass-convert`, add
   parentheses when they make it easier to read even if they aren't
   strictly required.
-  
+
 ### Deprecations -- Must Read!
 
 * Compiling directories on the command line without using either

--- a/lib/sass.rb
+++ b/lib/sass.rb
@@ -47,7 +47,7 @@ module Sass
   #
   # @param contents [String] The contents of the Sass file.
   # @param options [{Symbol => Object}] An options hash;
-  #   see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}
+  #   see {file:SASS_REFERENCE.md#options the Sass options documentation}
   # @raise [Sass::SyntaxError] if there's an error in the document
   # @raise [Encoding::UndefinedConversionError] if the source encoding
   #   cannot be converted to UTF-8
@@ -69,7 +69,7 @@ module Sass
   #
   #   @param filename [String] The path to the Sass, SCSS, or CSS file on disk.
   #   @param options [{Symbol => Object}] An options hash;
-  #     see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}
+  #     see {file:SASS_REFERENCE.md#options the Sass options documentation}
   #   @return [String] The compiled CSS.
   #
   # @overload compile_file(filename, css_filename, options = {})
@@ -77,7 +77,7 @@ module Sass
   #
   #   @param filename [String] The path to the Sass, SCSS, or CSS file on disk.
   #   @param options [{Symbol => Object}] An options hash;
-  #     see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}
+  #     see {file:SASS_REFERENCE.md#options the Sass options documentation}
   #   @param css_filename [String] The location to which to write the compiled CSS.
   def self.compile_file(filename, *args)
     options = args.last.is_a?(Hash) ? args.pop : {}

--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -168,7 +168,7 @@ module Sass
     # default values and resolving aliases.
     #
     # @param options [{Symbol => Object}] The options hash;
-    #   see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}
+    #   see {file:SASS_REFERENCE.md#options the Sass options documentation}
     # @return [{Symbol => Object}] The normalized options hash.
     # @private
     def self.normalize_options(options)
@@ -222,7 +222,7 @@ module Sass
     #
     # @param filename [String] The path to the Sass or SCSS file
     # @param options [{Symbol => Object}] The options hash;
-    #   See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+    #   See {file:SASS_REFERENCE.md#options the Sass options documentation}.
     # @return [Sass::Engine] The Engine for the given Sass or SCSS file.
     # @raise [Sass::SyntaxError] if there's an error in the document.
     def self.for_file(filename, options)
@@ -240,7 +240,7 @@ module Sass
     end
 
     # The options for the Sass engine.
-    # See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+    # See {file:SASS_REFERENCE.md#options the Sass options documentation}.
     #
     # @return [{Symbol => Object}]
     attr_reader :options
@@ -259,7 +259,7 @@ module Sass
     #   that overrides the Ruby encoding
     #   (see {file:SASS_REFERENCE.md#encodings the encoding documentation})
     # @param options [{Symbol => Object}] An options hash.
-    #   See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+    #   See {file:SASS_REFERENCE.md#options the Sass options documentation}.
     # @see {Sass::Engine.for_file}
     # @see {Sass::Plugin}
     def initialize(template, options = {})

--- a/lib/sass/environment.rb
+++ b/lib/sass/environment.rb
@@ -81,7 +81,7 @@ module Sass
     inherited_hash_reader :function
 
     # @param options [{Symbol => Object}] The options hash. See
-    #   {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+    #   {file:SASS_REFERENCE.md#options the Sass options documentation}.
     # @param parent [Environment] See \{#parent}
     def initialize(parent = nil, options = nil)
       @parent = parent

--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -31,7 +31,7 @@ module Sass::Plugin
     # Creates a new compiler.
     #
     # @param opts [{Symbol => Object}]
-    #   See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+    #   See {file:SASS_REFERENCE.md#options the Sass options documentation}.
     def initialize(opts = {})
       @watched_files = Set.new
       options.merge!(opts)

--- a/lib/sass/plugin/configuration.rb
+++ b/lib/sass/plugin/configuration.rb
@@ -25,7 +25,7 @@ module Sass
       end
 
       # An options hash.
-      # See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+      # See {file:SASS_REFERENCE.md#options the Sass options documentation}.
       #
       # @return [{Symbol => Object}]
       def options

--- a/lib/sass/plugin/staleness_checker.rb
+++ b/lib/sass/plugin/staleness_checker.rb
@@ -39,7 +39,7 @@ module Sass
       # for checking the staleness of several stylesheets at once.
       #
       # @param options [{Symbol => Object}]
-      #   See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+      #   See {file:SASS_REFERENCE.md#options the Sass options documentation}.
       def initialize(options)
         # URIs that are being actively checked for staleness. Protects against
         # import loops.

--- a/lib/sass/script.rb
+++ b/lib/sass/script.rb
@@ -21,7 +21,7 @@ module Sass
     # @param offset [Fixnum] The number of characters in on `line` that the SassScript started.
     #   Used for error reporting
     # @param options [{Symbol => Object}] An options hash;
-    #   see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}
+    #   see {file:SASS_REFERENCE.md#options the Sass options documentation}
     # @return [Script::Tree::Node] The root node of the parse tree
     def self.parse(value, line, offset, options = {})
       Parser.parse(value, line, offset, options)

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -196,13 +196,16 @@ module Sass::Script
   # Maps in Sass are immutable; all map functions return a new map rather than
   # updating the existing map in-place.
   #
-  # \{#map_get map-get($map, $keys)}
+  # \{#map_get map-get($map, $keys...)}
   # : Returns the value in a map (or nested map) associated with a given series of keys.
   #
   # \{#map_merge map-merge($map1, $map2)}
   # : Merges two maps together into a new map.
-  # \{#map_merge map-merge($map, keys, value)
-  # : Merges in the specified nested keys into a new map
+  # \{#map_merge map-merge($map1, $keys..., $map2)}
+  # : Merges a map into another map, nested with the specified keys
+  #
+  # \{#map_set map-set($map, $keys..., $value)
+  # : Sets in the specified keys into a new map, supporting one or more keys, creating nested maps as needed
   #
   # \{#map_remove map-remove($map, $keys...)}
   # : Returns a new map with keys removed.
@@ -213,7 +216,7 @@ module Sass::Script
   # \{#map_values map-values($map)}
   # : Returns a list of all values in a map.
   #
-  # \{#map_has_key map-has-key($map, $keys)}
+  # \{#map_has_key map-has-key($map, $keys...)}
   # : Returns whether a map has a value associated with a given key or keys.
   #
   # \{#keywords keywords($args)}
@@ -2063,7 +2066,7 @@ MESSAGE
       assert_type map, :Map, :map
       result = map
       keys.each do |key|
-        if result.is_a?(Sass::Script::Value::Map) || result.is_a?(Hash)
+        if result.is_a?(Sass::Script::Value::Map)
           result = result.to_h[key]
         else
           return null
@@ -2071,7 +2074,8 @@ MESSAGE
       end
       result || null
     end
-    declare :map_get, [:map, :key], :var_args => true
+    declare :map_get, [:map, :key]
+    declare :map_get, [:map], :var_args => true
 
     # Merges two maps together into a new map. Keys in `$map2` will take
     # precedence over keys in `$map1`.
@@ -2095,28 +2099,40 @@ MESSAGE
     #   @param $map2 [Sass::Script::Value::Map]
     # @return [Sass::Script::Value::Map]
     # @raise [ArgumentError] if either parameter is not a map
-    # @overload map_merge($map1, $keys, $value)
+    # @overload map_merge($map1, $keys..., $map2)
+    #   @param $map1 [Sass::Script::Value::Map]
+    #   @param $keys [[Sass::Script::Value]]
+    #   @param $map2 [Sass::Script::Value::Map]
+    # @return [Sass::Script::Value::Map]
+    # @raise [ArgumentError] if either parameter is not a map
+    def map_merge(map1, *args)
+      assert_type map1, :Map, :map1
+      *keys, map2 = args
+      if map1.is_a? Sass::Script::Value::List
+        map1 = map(map1.to_h)
+      end
+      assert_type map2, :Map, :map2
+      map1.recursive_merge(keys, map2)
+    end
+    declare :map_merge, [:map1, :map2]
+    declare :map_merge, [:map1], var_args: true
+
+    # @overload map_set($map, $keys, $value)
     #   @param $map1 [Sass::Script::Value::Map]
     #   @param $keys [[Sass::Script::Value::Base]]
     #   @param $value [Sass::Script::Value::Base]
     # @return [Sass::Script::Value::Map]
     # @raise [ArgumentError] if the first parameter is not a map
-    def map_merge(map1, *args)
-      assert_type map1, :Map, :map1
-      # If we only have one argument, it must be a map
-      if args.size == 1
-        map2 = args.first
-        assert_type map2, :Map, :map2
-        map(map1.to_h.merge(map2.to_h))
-      else # Using the keyed version
-        if map1.is_a? Sass::Script::Value::List
-          map1 = map(map1.to_h)
-        end
-        map1.surgical_merge(*args)
+    def map_set(map, *args)
+      assert_type map, :Map, :map
+      *keys, new_value = args
+      if map.is_a? Sass::Script::Value::List
+        map = map(map.to_h)
       end
+      map.recursive_set(keys, new_value)
     end
-    declare :map_merge, [:map1, :map2]
-    declare :map_merge, [:map1, :keys, :value], :var_args => true
+    declare :map_set, [:map, :keys, :value], :var_args => true
+
 
     # Returns a new map with keys removed.
     #
@@ -2130,6 +2146,9 @@ MESSAGE
     # @overload map_remove($map, $keys...)
     #   @param $map  [Sass::Script::Value::Map]
     #   @param $keys [[Sass::Script::Value::Base]]
+    # @overload map_remove($map, $key)
+    #   @param $map  [Sass::Script::Value::Map]
+    #   @param $keys [Sass::Script::Value::Base]
     # @return [Sass::Script::Value::Map]
     # @raise [ArgumentError] if `$map` is not a map
     def map_remove(map, *keys)
@@ -2138,7 +2157,8 @@ MESSAGE
       hash.delete_if {|key, _| keys.include?(key)}
       map(hash)
     end
-    declare :map_remove, [:map, :keys], :var_args => true
+    declare :map_remove, [:map], var_args: true
+    declare :map_remove, [:map, :key]
 
     # Returns a list of all keys in a map.
     #

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -2116,7 +2116,7 @@ MESSAGE
       end
     end
     declare :map_merge, [:map1, :map2]
-    declare :map_merge, [:map1, :keys, :value]
+    declare :map_merge, [:map1, :keys, :value], :var_args => true
 
     # Returns a new map with keys removed.
     #
@@ -2138,7 +2138,7 @@ MESSAGE
       hash.delete_if {|key, _| keys.include?(key)}
       map(hash)
     end
-    declare :map_remove, [:map, :key], :var_args => true
+    declare :map_remove, [:map, :keys], :var_args => true
 
     # Returns a list of all keys in a map.
     #
@@ -2175,6 +2175,7 @@ MESSAGE
     # @example
     #   map-has-key(("foo": 1, "bar": 2), "foo") => true
     #   map-has-key(("foo": 1, "bar": 2), "baz") => false
+    #   map-has-key((foo: (bar: 1)), foo, bar)   => true
     # @overload map_has_key($map, $keys)
     #   @param $map [Sass::Script::Value::Map]
     #   @param $keys [[Sass::Script::Value::Base]]
@@ -2186,7 +2187,7 @@ MESSAGE
         map = map.to_h[key] || false
       end)
     end
-    declare :map_has_key, [:map, :keys]
+    declare :map_has_key, [:map, :keys], :var_args => true
 
     # Returns the map of named arguments passed to a function or mixin that
     # takes a variable argument list. The argument names are strings, and they

--- a/lib/sass/script/lexer.rb
+++ b/lib/sass/script/lexer.rb
@@ -147,7 +147,7 @@ module Sass
       # @param offset [Fixnum] The 1-based character (not byte) offset in the line in the source.
       #   Used for error reporting and sourcemap building
       # @param options [{Symbol => Object}] An options hash;
-      #   see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}
+      #   see {file:SASS_REFERENCE.md#options the Sass options documentation}
       def initialize(str, line, offset, options)
         @scanner = str.is_a?(StringScanner) ? str : Sass::Util::MultibyteStringScanner.new(str)
         @line = line

--- a/lib/sass/script/parser.rb
+++ b/lib/sass/script/parser.rb
@@ -25,7 +25,7 @@ module Sass
       # @param offset [Fixnum] The character (not byte) offset where the script starts in the line.
       #   Used for error reporting and sourcemap building
       # @param options [{Symbol => Object}] An options hash;
-      #   see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}
+      #   see {file:SASS_REFERENCE.md#options the Sass options documentation}
       def initialize(str, line, offset, options = {})
         @options = options
         @lexer = lexer_class.new(str, line, offset, options)

--- a/lib/sass/script/tree/node.rb
+++ b/lib/sass/script/tree/node.rb
@@ -25,7 +25,7 @@ module Sass::Script::Tree
 
     # Sets the options hash for this node,
     # as well as for all child nodes.
-    # See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+    # See {file:SASS_REFERENCE.md#options the Sass options documentation}.
     #
     # @param options [{Symbol => Object}] The options
     def options=(options)

--- a/lib/sass/script/value/base.rb
+++ b/lib/sass/script/value/base.rb
@@ -26,7 +26,7 @@ module Sass::Script::Value
 
     # Sets the options hash for this node,
     # as well as for all child nodes.
-    # See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+    # See {file:SASS_REFERENCE.md#options the Sass options documentation}.
     #
     # @param options [{Symbol => Object}] The options
     attr_writer :options

--- a/lib/sass/script/value/map.rb
+++ b/lib/sass/script/value/map.rb
@@ -43,6 +43,17 @@ module Sass::Script::Value
       Bool.new(other.is_a?(Map) && value == other.value)
     end
 
+    def surgical_merge(my_key, *keys)
+      new_map = value.dup
+      if keys.size == 1
+        new_map[my_key] = keys.last
+      else
+        child = new_map[my_key] || Map.new({})
+        new_map[my_key] = child.surgical_merge(*keys)
+      end
+      Map.new(new_map)
+    end
+
     def hash
       @hash ||= value.hash
     end

--- a/lib/sass/script/value/map.rb
+++ b/lib/sass/script/value/map.rb
@@ -43,13 +43,46 @@ module Sass::Script::Value
       Bool.new(other.is_a?(Map) && value == other.value)
     end
 
-    def surgical_merge(my_key, *keys)
+    # Walks the Map, directed by the list
+    # of keys specified in the `keys` array
+    # creating nested Maps as needed, and
+    # when there is only one key left,
+    # setting the value to what is specified
+    # in `new_value`.
+    #
+    # If a nested map specified in a key
+    # doesn't exist, it is created.
+    #
+    # @param keys [Array<Value>]
+    # @param new_value [Value]
+    # @return new_map [Map]
+    def recursive_set(keys = [], new_value)
       new_map = value.dup
-      if keys.size == 1
-        new_map[my_key] = keys.last
-      else
+      my_key, *child_keys = keys
+      if child_keys.any?
         child = new_map[my_key] || Map.new({})
-        new_map[my_key] = child.surgical_merge(*keys)
+        new_map[my_key] = child.recursive_set(child_keys, new_value)
+      else
+        new_map[my_key] = new_value
+      end
+      Map.new(new_map)
+    end
+
+    # Returns a new map, after following the
+    # nestd keys specified in the second argument, until
+    # a final merge is called with the last value.
+    #
+    # @param keys [Array<Value>]
+    # @param map_to_merge [Map]
+    # @return new_map [Map]
+    def recursive_merge(keys = [], map_to_merge)
+      new_map = value.dup
+      my_key, *child_keys = keys
+      if my_key
+        child = new_map[my_key] || Map.new({})
+        new_map[my_key] = child.recursive_merge(child_keys, map_to_merge)
+      else
+        new_map = new_map.merge(map_to_merge.to_h)
       end
       Map.new(new_map)
     end

--- a/lib/sass/tree/node.rb
+++ b/lib/sass/tree/node.rb
@@ -83,7 +83,7 @@ module Sass
       attr_writer :filename
 
       # The options hash for the node.
-      # See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+      # See {file:SASS_REFERENCE.md#options the Sass options documentation}.
       #
       # @return [{Symbol => Object}]
       attr_reader :options
@@ -149,7 +149,7 @@ module Sass
       # @return [Boolean]
       def invisible?; false; end
 
-      # The output style. See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+      # The output style. See {file:SASS_REFERENCE.md#options the Sass options documentation}.
       #
       # @return [Symbol]
       def style

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -1387,18 +1387,29 @@ SCSS
       perform("map-merge((foo: 1, bar: 2), ())").to_sass)
 
     # Here, we test when the second argument is an array of keys, plus a value
-    assert_equal("(foo: 1, bar: (bing: ping))",
-      perform("map-merge((foo: 1, bar: (bing: bong)), bar, bing, ping)").to_sass)
-    assert_equal("(foo: 1, bar: (bing: bong, ping: pong))",
-      perform("map-merge((foo: 1, bar: (bing: bong)), bar, ping, pong)").to_sass)
-    # Create a nested Map, if it didn't exist already
-    assert_equal("(a: (b: c))",
-      perform("map-merge((), a, b, c)").to_sass)
+    assert_equal("(a: b, c: d)",
+            perform("map-merge((a: b), (c: d))").to_sass)
+    assert_equal("(a: (b: c, d: e))",
+            perform("map-merge((a: (b: c)), a, (d: e))").to_sass)
+    assert_equal("(a: (d: e))",
+            perform("map-merge((a: (b: c)), (a: (d: e)))").to_sass)
   end
 
   def test_map_merge_checks_type
     assert_error_message("$map1: 12 is not a map for `map-merge'", "map-merge(12, (foo: 1))")
     assert_error_message("$map2: 12 is not a map for `map-merge'", "map-merge((foo: 1), 12)")
+  end
+
+  def test_map_set
+    assert_equal("(foo: 1, bar: (bing: ping))",
+      perform("map-set((foo: 1, bar: (bing: bong)), bar, bing, ping)").to_sass)
+    assert_equal("(foo: 1, bar: (bing: bong, ping: pong))",
+      perform("map-set((foo: 1, bar: (bing: bong)), bar, ping, pong)").to_sass)
+    # Create a nested Map, if it didn't exist already
+    assert_equal("(a: (b: c))",
+      perform("map-set((), a, b, c)").to_sass)
+    assert_equal("(b: d, a: (b: c))",
+      perform("map-set((b: d), a, b, c)").to_sass)
   end
 
   def test_map_remove

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -1357,10 +1357,20 @@ SCSS
   end
 
   def test_map_get
+    # Simple maps should be able to be found with a single key
     assert_equal "1", evaluate("map-get((foo: 1, bar: 2), foo)")
     assert_equal "2", evaluate("map-get((foo: 1, bar: 2), bar)")
+
+    # Nested maps should return values, if found and matching the keys
+    assert_equal "d", evaluate("map-get((a: (b: (c: d))), a, b, c)")
+
+    # map-get should return a 'null' if the key isn't found
     assert_equal "null", perform("map-get((foo: 1, bar: 2), baz)").to_sass
     assert_equal "null", perform("map-get((), foo)").to_sass
+
+    # map-get should return a 'null' if the nested map key isn't found
+    assert_equal "null", perform("map-get((a: b), a, b, c, m)").to_sass
+    assert_equal "null", perform("map-get((a: (b: (c: d))), a, b, c, m)").to_sass
   end
 
   def test_map_get_checks_type
@@ -1368,12 +1378,22 @@ SCSS
   end
 
   def test_map_merge
+    # These are the version where the second argument is a map
     assert_equal("(foo: 1, bar: 2, baz: 3)",
       perform("map-merge((foo: 1, bar: 2), (baz: 3))").to_sass)
     assert_equal("(foo: 1, bar: 2)",
       perform("map-merge((), (foo: 1, bar: 2))").to_sass)
     assert_equal("(foo: 1, bar: 2)",
       perform("map-merge((foo: 1, bar: 2), ())").to_sass)
+
+    # Here, we test when the second argument is an array of keys, plus a value
+    assert_equal("(foo: 1, bar: (bing: ping))",
+      perform("map-merge((foo: 1, bar: (bing: bong)), bar, bing, ping)").to_sass)
+    assert_equal("(foo: 1, bar: (bing: bong, ping: pong))",
+      perform("map-merge((foo: 1, bar: (bing: bong)), bar, ping, pong)").to_sass)
+    # Create a nested Map, if it didn't exist already
+    assert_equal("(a: (b: c))",
+      perform("map-merge((), a, b, c)").to_sass)
   end
 
   def test_map_merge_checks_type
@@ -1419,8 +1439,10 @@ SCSS
 
   def test_map_has_key
     assert_equal "true", evaluate("map-has-key((foo: 1, bar: 1), foo)")
+    assert_equal "true", evaluate("map-has-key((foo: (bar: 1)), foo, bar)")
     assert_equal "false", evaluate("map-has-key((foo: 1, bar: 1), baz)")
     assert_equal "false", evaluate("map-has-key((), foo)")
+    assert_equal "false", evaluate("map-has-key((foo: (bar: 1)), foo, bing)")
   end
 
   def test_map_has_key_checks_type


### PR DESCRIPTION
Now, map-merge, map-get, and map-has-key all accept various forms of nested Map logic as per @nex3's specifications in #1739, with the addition of a nested compatible map-has-key.
