### PR TITLE
Omit leading zero for numbers in compressed mode.

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -16,6 +16,9 @@
 * Rounding numbers now respects Sass's precision setting for numbers very
   close to half an integer.
 
+* In compressed mode, numbers between -1 and 1 now have the
+  leading 0 omitted.
+
 ## 3.4.19 (09 October 2015)
 
 * Sass numeric equality now better handles float-point errors. Any

--- a/lib/sass/script/parser.rb
+++ b/lib/sass/script/parser.rb
@@ -538,6 +538,7 @@ RUBY
         tok = try_tok(:number)
         return selector unless tok
         num = tok.value
+        num.options = @options
         num.original = num.to_s
         literal_node(num, tok.source_range.start_pos)
       end

--- a/lib/sass/script/value/number.rb
+++ b/lib/sass/script/value/number.rb
@@ -289,6 +289,9 @@ module Sass::Script::Value
       # and confusing.
       str = ("%0.#{self.class.precision}f" % value).gsub(/0*$/, '') if str.include?('e')
 
+      if @options && options[:style] == :compressed
+        str.sub!(/^(-)?0\./, '\1.')
+      end
       unitless? ? str : "#{str}#{unit_str}"
     end
     alias_method :to_sass, :inspect

--- a/test/sass/script_test.rb
+++ b/test/sass/script_test.rb
@@ -1171,12 +1171,21 @@ SASS
     assert_equal "true", resolve("29 == (29 / 7 * 7)")
   end
 
+  def test_compressed_output_of_numbers_with_leading_zeros
+    assert_equal "1.5", resolve("1.5", :style => :compressed)
+    assert_equal ".5", resolve("0.5", :style => :compressed)
+    assert_equal "-.5", resolve("-0.5", :style => :compressed)
+    assert_equal "0.5", resolve("0.5", :style => :compact)
+  end
+
+
   private
 
   def resolve(str, opts = {}, environment = env)
     munge_filename opts
     val = eval(str, opts, environment)
     assert_kind_of Sass::Script::Value::Base, val
+    val.options = opts
     val.is_a?(Sass::Script::Value::String) ? val.value : val.to_s
   end
 


### PR DESCRIPTION
This saves a few bytes now and then.

Addresses part of issue #847.
