### PR TITLE
WIP: Nested Map Functions

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -10,9 +10,14 @@
 
 * Add a `$weight` parameter to `invert()`.
 
-* Add support for nested maps with `map-get()` and `map-has-key()` by passing more than 2 arguments
+* Add support for nested maps with `map-get()` and `map-has-key()` by passing
+  more than 2 arguments.
 
-* Add support for setting changes deeply into a nested hash by providing a new syntax for set that is generally non-destructive with the signature `map-set($map, $keys..., $value)` 
+* Add support for setting changes deeply into a nested hash by providing a new
+  syntax for set that is generally non-destructive with the signature
+  `map-set($map, $keys..., $value)`.
+
+* Add support for additional keys passed to `map-merge($map1, $keys..., $map2)`, allowing for nested Map merges.
 
 ### Backwards Incompatibilities -- Must Read!
 

--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -10,6 +10,10 @@
 
 * Add a `$weight` parameter to `invert()`.
 
+* Add support for nested maps with `map-get()` and `map-has-key()` by passing more than 2 arguments
+
+* Add support for merging changes deeply into a nested hash by providing a new syntax for merge that is generally non-destructive with the signature `map-merge($map, $keys, $value)` 
+
 ### Backwards Incompatibilities -- Must Read!
 
 Certain ways of using `#{}` without quotes in property and variable values,

--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -17,7 +17,8 @@
   syntax for set that is generally non-destructive with the signature
   `map-set($map, $keys..., $value)`.
 
-* Add support for additional keys passed to `map-merge($map1, $keys..., $map2)`, allowing for nested Map merges.
+* Add support for additional keys passed to `map-merge($map1, $keys..., $map2)`,
+  allowing for nested Map merges.
 
 ### Backwards Incompatibilities -- Must Read!
 

--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -12,7 +12,7 @@
 
 * Add support for nested maps with `map-get()` and `map-has-key()` by passing more than 2 arguments
 
-* Add support for merging changes deeply into a nested hash by providing a new syntax for merge that is generally non-destructive with the signature `map-merge($map, $keys, $value)` 
+* Add support for setting changes deeply into a nested hash by providing a new syntax for set that is generally non-destructive with the signature `map-set($map, $keys..., $value)` 
 
 ### Backwards Incompatibilities -- Must Read!
 

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -2103,7 +2103,7 @@ MESSAGE
       end
     end
     declare :map_merge, [:map1, :map2]
-    declare :map_merge, [:map1, :keys, :value]
+    declare :map_merge, [:map1, :keys, :value], :var_args => true
 
     # Returns a new map with keys removed.
     #
@@ -2125,7 +2125,7 @@ MESSAGE
       hash.delete_if {|key, _| keys.include?(key)}
       map(hash)
     end
-    declare :map_remove, [:map, :key], :var_args => true
+    declare :map_remove, [:map, :keys], :var_args => true
 
     # Returns a list of all keys in a map.
     #
@@ -2162,6 +2162,7 @@ MESSAGE
     # @example
     #   map-has-key(("foo": 1, "bar": 2), "foo") => true
     #   map-has-key(("foo": 1, "bar": 2), "baz") => false
+    #   map-has-key((foo: (bar: 1)), foo, bar)   => true
     # @overload map_has_key($map, $keys)
     #   @param $map [Sass::Script::Value::Map]
     #   @param $keys [[Sass::Script::Value::Base]]
@@ -2173,7 +2174,7 @@ MESSAGE
         map = map.to_h[key] || false
       end)
     end
-    declare :map_has_key, [:map, :keys]
+    declare :map_has_key, [:map, :keys], :var_args => true
 
     # Returns the map of named arguments passed to a function or mixin that
     # takes a variable argument list. The argument names are strings, and they

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -2092,9 +2092,9 @@ MESSAGE
     #   @param $map2 [Sass::Script::Value::Map]
     # @return [Sass::Script::Value::Map]
     # @raise [ArgumentError] if either parameter is not a map
-    def map_merge(map1, *args)
+    def map_merge(map1, *keys)
       assert_type map1, :Map, :map1
-      *keys, map2 = args
+      map2 = keys.pop
       if map1.is_a? Sass::Script::Value::List
         map1 = map(map1.to_h)
       end
@@ -2102,17 +2102,21 @@ MESSAGE
       map1.recursive_merge(keys, map2)
     end
     declare :map_merge, [:map1, :map2]
-    declare :map_merge, [:map1], var_args: true
+    declare :map_merge, [:map1], :var_args => true
 
-    # @overload map_set($map, $keys, $value)
+    # @example
+    #   map-set((a: 1), b, 2) => (a: 1, b: 2)
+    #   map-set((a: (a: 1)), a, b, 2) => (a: (a: 1, b: 2))
+    #   map-set((), a, b, c) => (a: (b: c))
+    # @overload map-set($map, $keys..., $value)
     #   @param $map1 [Sass::Script::Value::Map]
     #   @param $keys [[Sass::Script::Value::Base]]
     #   @param $value [Sass::Script::Value::Base]
     # @return [Sass::Script::Value::Map]
     # @raise [ArgumentError] if the first parameter is not a map
-    def map_set(map, *args)
+    def map_set(map, *keys)
       assert_type map, :Map, :map
-      *keys, new_value = args
+      new_value = keys.pop
       if map.is_a? Sass::Script::Value::List
         map = map(map.to_h)
       end
@@ -2144,7 +2148,7 @@ MESSAGE
       hash.delete_if {|key, _| keys.include?(key)}
       map(hash)
     end
-    declare :map_remove, [:map], var_args: true
+    declare :map_remove, [:map], :var_args => true
     declare :map_remove, [:map, :key]
 
     # Returns a list of all keys in a map.

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -2124,7 +2124,6 @@ MESSAGE
     end
     declare :map_set, [:map, :keys, :value], :var_args => true
 
-
     # Returns a new map with keys removed.
     #
     # Like all map functions, `map-merge()` returns a new map rather than

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -196,11 +196,13 @@ module Sass::Script
   # Maps in Sass are immutable; all map functions return a new map rather than
   # updating the existing map in-place.
   #
-  # \{#map_get map-get($map, $key)}
-  # : Returns the value in a map associated with a given key.
+  # \{#map_get map-get($map, $keys)}
+  # : Returns the value in a map (or nested map) associated with a given series of keys.
   #
   # \{#map_merge map-merge($map1, $map2)}
   # : Merges two maps together into a new map.
+  # \{#map_merge map-merge($map, keys, value)
+  # : Merges in the specified nested keys into a new map
   #
   # \{#map_remove map-remove($map, $keys...)}
   # : Returns a new map with keys removed.
@@ -211,8 +213,8 @@ module Sass::Script
   # \{#map_values map-values($map)}
   # : Returns a list of all values in a map.
   #
-  # \{#map_has_key map-has-key($map, $key)}
-  # : Returns whether a map has a value associated with a given key.
+  # \{#map_has_key map-has-key($map, $keys)}
+  # : Returns whether a map has a value associated with a given key or keys.
   #
   # \{#keywords keywords($args)}
   # : Returns the keywords passed to a function that takes variable arguments.
@@ -2040,15 +2042,23 @@ MESSAGE
     #   map-get(("foo": 1, "bar": 2), "baz") => null
     # @overload map_get($map, $key)
     #   @param $map [Sass::Script::Value::Map]
-    #   @param $key [Sass::Script::Value::Base]
-    # @return [Sass::Script::Value::Base] The value indexed by `$key`, or `null`
+    #   @param $keys [[Sass::Script::Value::Base]]
+    # @return [Sass::Script::Value::Base] The value indexed by `$keys`, or `null`
     #   if the map doesn't contain the given key
     # @raise [ArgumentError] if `$map` is not a map
-    def map_get(map, key)
+    def map_get(map, *keys)
       assert_type map, :Map, :map
-      map.to_h[key] || null
+      result = map
+      keys.each do |key|
+        if result.is_a?(Sass::Script::Value::Map) || result.is_a?(Hash)
+          result = result.to_h[key]
+        else
+          return null
+        end
+      end
+      result || null
     end
-    declare :map_get, [:map, :key]
+    declare :map_get, [:map, :key], :var_args => true
 
     # Merges two maps together into a new map. Keys in `$map2` will take
     # precedence over keys in `$map1`.
@@ -2065,17 +2075,35 @@ MESSAGE
     # @example
     #   map-merge(("foo": 1), ("bar": 2)) => ("foo": 1, "bar": 2)
     #   map-merge(("foo": 1, "bar": 2), ("bar": 3)) => ("foo": 1, "bar": 3)
+    #   map-merge(("foo": 1, "bar": 2), bar, 3) => ("foo": 1, "bar": 3)
+    #   map-merge((a: (b: c)), a, b, d) => (a: (b: d))
     # @overload map_merge($map1, $map2)
     #   @param $map1 [Sass::Script::Value::Map]
     #   @param $map2 [Sass::Script::Value::Map]
     # @return [Sass::Script::Value::Map]
     # @raise [ArgumentError] if either parameter is not a map
-    def map_merge(map1, map2)
+    # @overload map_merge($map1, $keys, $value)
+    #   @param $map1 [Sass::Script::Value::Map]
+    #   @param $keys [[Sass::Script::Value::Base]]
+    #   @param $value [Sass::Script::Value::Base]
+    # @return [Sass::Script::Value::Map]
+    # @raise [ArgumentError] if the first parameter is not a map
+    def map_merge(map1, *args)
       assert_type map1, :Map, :map1
-      assert_type map2, :Map, :map2
-      map(map1.to_h.merge(map2.to_h))
+      # If we only have one argument, it must be a map
+      if args.size == 1
+        map2 = args.first
+        assert_type map2, :Map, :map2
+        map(map1.to_h.merge(map2.to_h))
+      else # Using the keyed version
+        if map1.is_a? Sass::Script::Value::List
+          map1 = map(map1.to_h)
+        end
+        map1.surgical_merge(*args)
+      end
     end
     declare :map_merge, [:map1, :map2]
+    declare :map_merge, [:map1, :keys, :value]
 
     # Returns a new map with keys removed.
     #
@@ -2134,16 +2162,18 @@ MESSAGE
     # @example
     #   map-has-key(("foo": 1, "bar": 2), "foo") => true
     #   map-has-key(("foo": 1, "bar": 2), "baz") => false
-    # @overload map_has_key($map, $key)
+    # @overload map_has_key($map, $keys)
     #   @param $map [Sass::Script::Value::Map]
-    #   @param $key [Sass::Script::Value::Base]
+    #   @param $keys [[Sass::Script::Value::Base]]
     # @return [Sass::Script::Value::Bool]
     # @raise [ArgumentError] if `$map` is not a map
-    def map_has_key(map, key)
+    def map_has_key(map, *keys)
       assert_type map, :Map, :map
-      bool(map.to_h.has_key?(key))
+      bool(keys.all? do |key|
+        map = map.to_h[key] || false
+      end)
     end
-    declare :map_has_key, [:map, :key]
+    declare :map_has_key, [:map, :keys]
 
     # Returns the map of named arguments passed to a function or mixin that
     # takes a variable argument list. The argument names are strings, and they

--- a/lib/sass/script/value/map.rb
+++ b/lib/sass/script/value/map.rb
@@ -43,15 +43,11 @@ module Sass::Script::Value
       Bool.new(other.is_a?(Map) && value == other.value)
     end
 
-    # Walks the Map, directed by the list
-    # of keys specified in the `keys` array
-    # creating nested Maps as needed, and
-    # when there is only one key left,
-    # setting the value to what is specified
-    # in `new_value`.
+    # Walks the Map, directed by the list of keys specified in the `keys` array
+    # creating nested Maps as needed, and when there is only one key left,
+    # setting the value to what is specified in `new_value`.
     #
-    # If a nested map specified in a key
-    # doesn't exist, it is created.
+    # If a nested map specified in a key doesn't exist, it is created.
     #
     # @param keys [Array<Value>]
     # @param new_value [Value]
@@ -68,9 +64,8 @@ module Sass::Script::Value
       Map.new(new_map)
     end
 
-    # Returns a new map, after following the
-    # nestd keys specified in the second argument, until
-    # a final merge is called with the last value.
+    # Returns a new map, after following the nestd keys specified in the second
+    # argument, until a final merge is called with the last value.
     #
     # @param keys [Array<Value>]
     # @param map_to_merge [Map]

--- a/lib/sass/script/value/map.rb
+++ b/lib/sass/script/value/map.rb
@@ -43,6 +43,17 @@ module Sass::Script::Value
       Bool.new(other.is_a?(Map) && value == other.value)
     end
 
+    def surgical_merge(my_key, *keys)
+      new_map = value.dup
+      if keys.size == 1
+        new_map[my_key] = keys.last
+      else
+        child = new_map[my_key] || Map.new({})
+        new_map[my_key] = child.surgical_merge(*keys)
+      end
+      Map.new(new_map)
+    end
+
     def hash
       @hash ||= value.hash
     end

--- a/lib/sass/script/value/map.rb
+++ b/lib/sass/script/value/map.rb
@@ -43,13 +43,46 @@ module Sass::Script::Value
       Bool.new(other.is_a?(Map) && value == other.value)
     end
 
-    def surgical_merge(my_key, *keys)
+    # Walks the Map, directed by the list
+    # of keys specified in the `keys` array
+    # creating nested Maps as needed, and
+    # when there is only one key left,
+    # setting the value to what is specified
+    # in `new_value`.
+    #
+    # If a nested map specified in a key
+    # doesn't exist, it is created.
+    #
+    # @param keys [Array<Value>]
+    # @param new_value [Value]
+    # @return new_map [Map]
+    def recursive_set(keys = [], new_value)
       new_map = value.dup
-      if keys.size == 1
-        new_map[my_key] = keys.last
-      else
+      my_key, *child_keys = keys
+      if child_keys.any?
         child = new_map[my_key] || Map.new({})
-        new_map[my_key] = child.surgical_merge(*keys)
+        new_map[my_key] = child.recursive_set(child_keys, new_value)
+      else
+        new_map[my_key] = new_value
+      end
+      Map.new(new_map)
+    end
+
+    # Returns a new map, after following the
+    # nestd keys specified in the second argument, until
+    # a final merge is called with the last value.
+    #
+    # @param keys [Array<Value>]
+    # @param map_to_merge [Map]
+    # @return new_map [Map]
+    def recursive_merge(keys = [], map_to_merge)
+      new_map = value.dup
+      my_key, *child_keys = keys
+      if my_key
+        child = new_map[my_key] || Map.new({})
+        new_map[my_key] = child.recursive_merge(child_keys, map_to_merge)
+      else
+        new_map = new_map.merge(map_to_merge.to_h)
       end
       Map.new(new_map)
     end

--- a/lib/sass/script/value/map.rb
+++ b/lib/sass/script/value/map.rb
@@ -56,7 +56,7 @@ module Sass::Script::Value
     # @param keys [Array<Value>]
     # @param new_value [Value]
     # @return new_map [Map]
-    def recursive_set(keys = [], new_value)
+    def recursive_set(keys, new_value)
       new_map = value.dup
       my_key, *child_keys = keys
       if child_keys.any?
@@ -75,7 +75,7 @@ module Sass::Script::Value
     # @param keys [Array<Value>]
     # @param map_to_merge [Map]
     # @return new_map [Map]
-    def recursive_merge(keys = [], map_to_merge)
+    def recursive_merge(keys, map_to_merge)
       new_map = value.dup
       my_key, *child_keys = keys
       if my_key

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -1453,9 +1453,13 @@ SCSS
   def test_map_has_key
     assert_equal "true", evaluate("map-has-key((foo: 1, bar: 1), foo)")
     assert_equal "true", evaluate("map-has-key((foo: (bar: 1)), foo, bar)")
+    assert_equal "true", evaluate("map-has-key((foo: ()), foo)")
     assert_equal "false", evaluate("map-has-key((foo: 1, bar: 1), baz)")
     assert_equal "false", evaluate("map-has-key((), foo)")
     assert_equal "false", evaluate("map-has-key((foo: (bar: 1)), foo, bing)")
+    assert_equal "false", evaluate("map-has-key((foo: bar), foo, bar)")
+    assert_equal "false", evaluate("map-has-key((), a, b, c, d, e)")
+    assert_equal "false", evaluate("map-has-key((foo: ()), foo, bar)")
   end
 
   def test_map_has_key_checks_type

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -1389,18 +1389,29 @@ SCSS
       perform("map-merge((foo: 1, bar: 2), ())").to_sass)
 
     # Here, we test when the second argument is an array of keys, plus a value
-    assert_equal("(foo: 1, bar: (bing: ping))",
-      perform("map-merge((foo: 1, bar: (bing: bong)), bar, bing, ping)").to_sass)
-    assert_equal("(foo: 1, bar: (bing: bong, ping: pong))",
-      perform("map-merge((foo: 1, bar: (bing: bong)), bar, ping, pong)").to_sass)
-    # Create a nested Map, if it didn't exist already
-    assert_equal("(a: (b: c))",
-      perform("map-merge((), a, b, c)").to_sass)
+    assert_equal("(a: b, c: d)",
+            perform("map-merge((a: b), (c: d))").to_sass)
+    assert_equal("(a: (b: c, d: e))",
+            perform("map-merge((a: (b: c)), a, (d: e))").to_sass)
+    assert_equal("(a: (d: e))",
+            perform("map-merge((a: (b: c)), (a: (d: e)))").to_sass)
   end
 
   def test_map_merge_checks_type
     assert_error_message("$map1: 12 is not a map for `map-merge'", "map-merge(12, (foo: 1))")
     assert_error_message("$map2: 12 is not a map for `map-merge'", "map-merge((foo: 1), 12)")
+  end
+
+  def test_map_set
+    assert_equal("(foo: 1, bar: (bing: ping))",
+      perform("map-set((foo: 1, bar: (bing: bong)), bar, bing, ping)").to_sass)
+    assert_equal("(foo: 1, bar: (bing: bong, ping: pong))",
+      perform("map-set((foo: 1, bar: (bing: bong)), bar, ping, pong)").to_sass)
+    # Create a nested Map, if it didn't exist already
+    assert_equal("(a: (b: c))",
+      perform("map-set((), a, b, c)").to_sass)
+    assert_equal("(b: d, a: (b: c))",
+      perform("map-set((b: d), a, b, c)").to_sass)
   end
 
   def test_map_remove


### PR DESCRIPTION
Now, map-merge, map-get, and map-has-key all accept various forms of nested Map logic as per @nex3's specifications in #1739, with the addition of a nested compatible map-has-key.

Removed the weird commit that snuck in to the previous request and hopefully bought us Ruby 1.8.7 compatibility again.
