### PR TITLE
Work with ruby 2.3's --enable-frozen-string-literal

### DIFF
--- a/lib/sass/scss/parser.rb
+++ b/lib/sass/scss/parser.rb
@@ -1022,7 +1022,7 @@ WARNING
       end
 
       def str
-        @strs.push ""
+        @strs.push String.new("")
         yield
         @strs.last
       ensure

--- a/lib/sass/tree/visitors/to_css.rb
+++ b/lib/sass/tree/visitors/to_css.rb
@@ -12,7 +12,7 @@ class Sass::Tree::Visitors::ToCss < Sass::Tree::Visitors::Base
     @tabs = 0
     @line = 1
     @offset = 1
-    @result = ""
+    @result = String.new("")
     @source_mapping = build_source_mapping ? Sass::Source::Map.new : nil
     @lstrip = nil
     @in_directive = false


### PR DESCRIPTION
These changes are the minimal ones necessary to allow Roda's specs
to pass.  There may well be other changes that are required.
