### PR TITLE
Fixes most ruby warnings (master)

### DIFF
--- a/lib/sass/callbacks.rb
+++ b/lib/sass/callbacks.rb
@@ -51,12 +51,12 @@ module Sass
     def define_callback(name)
       class_eval <<RUBY, __FILE__, __LINE__ + 1
 def on_#{name}(&block)
-  @_sass_callbacks ||= {}
+  @_sass_callbacks = {} unless defined? @_sass_callbacks
   (@_sass_callbacks[#{name.inspect}] ||= []) << block
 end
 
 def run_#{name}(*args)
-  return unless @_sass_callbacks
+  return unless defined? @_sass_callbacks
   return unless @_sass_callbacks[#{name.inspect}]
   @_sass_callbacks[#{name.inspect}].each {|c| c[*args]}
 end

--- a/lib/sass/css.rb
+++ b/lib/sass/css.rb
@@ -35,6 +35,7 @@ module Sass
       # Backwards compatibility
       @options[:old] = true if @options[:alternate] == false
       @template = template
+      @checked_encoding = false
     end
 
     # Converts the CSS template into Sass or SCSS code.

--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -265,6 +265,9 @@ module Sass
     def initialize(template, options = {})
       @options = self.class.normalize_options(options)
       @template = template
+      @checked_encoding = false
+      @filename = nil
+      @line = nil
     end
 
     # Render the template to CSS.

--- a/lib/sass/environment.rb
+++ b/lib/sass/environment.rb
@@ -86,7 +86,14 @@ module Sass
     def initialize(parent = nil, options = nil)
       @parent = parent
       @options = options || (parent && parent.options) || {}
-      @stack = Sass::Stack.new if @parent.nil?
+      @stack = @parent.nil? ? Sass::Stack.new : nil
+      @caller = nil
+      @content = nil
+      @filename = nil
+      @functions = nil
+      @mixins = nil
+      @selector = nil
+      @vars = nil
     end
 
     # Returns whether this is the global environment.

--- a/lib/sass/script/lexer.rb
+++ b/lib/sass/script/lexer.rb
@@ -156,6 +156,8 @@ module Sass
         @options = options
         @interpolation_stack = []
         @prev = nil
+        @tok = nil
+        @next_tok = nil
       end
 
       # Returns whether or not there's whitespace before the given token.

--- a/lib/sass/script/parser.rb
+++ b/lib/sass/script/parser.rb
@@ -29,6 +29,8 @@ module Sass
       def initialize(str, line, offset, options = {})
         @options = options
         @lexer = lexer_class.new(str, line, offset, options)
+        @stop_at = nil
+        @expected = nil
       end
 
       # Parses a SassScript expression within an interpolated segment (`#{}`).
@@ -234,7 +236,7 @@ RUBY
         def unary(op, sub)
           class_eval <<RUBY, __FILE__, __LINE__ + 1
             def unary_#{op}
-              return #{sub} unless tok = try_tok(:#{op})
+              return #{sub} unless try_tok(:#{op})
               start_pos = source_position
               node(Tree::UnaryOperation.new(assert_expr(:unary_#{op}), :#{op}), start_pos)
             end

--- a/lib/sass/script/value/base.rb
+++ b/lib/sass/script/value/base.rb
@@ -22,6 +22,7 @@ module Sass::Script::Value
     def initialize(value = nil)
       value.freeze unless value.nil? || value == true || value == false
       @value = value
+      @options = nil
     end
 
     # Sets the options hash for this node,

--- a/lib/sass/script/value/number.rb
+++ b/lib/sass/script/value/number.rb
@@ -71,6 +71,7 @@ module Sass::Script::Value
       super(value)
       @numerator_units = numerator_units
       @denominator_units = denominator_units
+      @options = nil
       normalize!
     end
 

--- a/lib/sass/scss/parser.rb
+++ b/lib/sass/scss/parser.rb
@@ -28,6 +28,8 @@ module Sass
         @line = line
         @offset = offset
         @strs = []
+        @expected = nil
+        @throw_error = false
       end
 
       # Parses an SCSS document.

--- a/lib/sass/tree/node.rb
+++ b/lib/sass/tree/node.rb
@@ -90,6 +90,8 @@ module Sass
 
       def initialize
         @children = []
+        @filename = nil
+        @options = nil
       end
 
       # Sets the options hash for the node and all its children.

--- a/lib/sass/tree/visitors/check_nesting.rb
+++ b/lib/sass/tree/visitors/check_nesting.rb
@@ -4,6 +4,8 @@ class Sass::Tree::Visitors::CheckNesting < Sass::Tree::Visitors::Base
 
   def initialize
     @parents = []
+    @parent = nil
+    @current_mixin_def = nil
   end
 
   def visit(node)

--- a/lib/sass/tree/visitors/convert.rb
+++ b/lib/sass/tree/visitors/convert.rb
@@ -18,6 +18,7 @@ class Sass::Tree::Visitors::Convert < Sass::Tree::Visitors::Base
     @tabs = 0
     # 2 spaces by default
     @tab_chars = @options[:indent] || "  "
+    @is_else = false
   end
 
   def visit_children(parent)

--- a/lib/sass/tree/visitors/perform.rb
+++ b/lib/sass/tree/visitors/perform.rb
@@ -150,6 +150,8 @@ class Sass::Tree::Visitors::Perform < Sass::Tree::Visitors::Base
 
   def initialize(env)
     @environment = env
+    @in_keyframes = false
+    @at_root_without_rule = false
   end
 
   # If an exception is raised, this adds proper metadata to the backtrace.

--- a/lib/sass/tree/visitors/to_css.rb
+++ b/lib/sass/tree/visitors/to_css.rb
@@ -13,7 +13,9 @@ class Sass::Tree::Visitors::ToCss < Sass::Tree::Visitors::Base
     @line = 1
     @offset = 1
     @result = ""
-    @source_mapping = Sass::Source::Map.new if build_source_mapping
+    @source_mapping = build_source_mapping ? Sass::Source::Map.new : nil
+    @lstrip = nil
+    @in_directive = false
   end
 
   # Runs the visitor on `node`.

--- a/test/sass/compiler_test.rb
+++ b/test/sass/compiler_test.rb
@@ -84,7 +84,7 @@ class CompilerTest < MiniTest::Test
 
     private
     def create_listener(*args, &on_filesystem_event)
-      options = args.pop if args.last.is_a?(Hash)
+      args.pop if args.last.is_a?(Hash)
       @fake_listener = FakeListener.new(*args, &on_filesystem_event)
       @fake_listener.on_start!(&run_during_start)
       @fake_listener


### PR DESCRIPTION
Rake since v11+ defaults to showing ruby warnings in the test task,
generating lots of noise when the tests use the sass gems.

This fixes most of the warnings present on the compilation code path in
Sass.
