### PR TITLE
docs: add examples about behavior of null

### DIFF
--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -2023,6 +2023,9 @@ is compiled to:
     p {
       border: 1px solid; }
 
+You can explicitly test for `$var == false` or `$var == null` if you want to
+distinguish between these.
+
 The `@if` statement can be followed by several `@else if` statements
 and one `@else` statement.
 If the `@if` statement fails,

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -1611,6 +1611,7 @@ MESSAGE
     #   type-of(true)   => bool
     #   type-of(#fff)   => color
     #   type-of(blue)   => color
+    #   type-of(null)   => null
     # @overload type_of($value)
     #   @param $value [Sass::Script::Value::Base] The value to inspect
     # @return [Sass::Script::Value::String] The unquoted string name of the
@@ -2263,6 +2264,7 @@ MESSAGE
     # @example
     #   $a-false-value: false;
     #   variable-exists(a-false-value) => true
+    #   variable-exists(a-null-value) => true
     #
     #   variable-exists(nonexistent) => false
     #
@@ -2283,6 +2285,7 @@ MESSAGE
     # @example
     #   $a-false-value: false;
     #   global-variable-exists(a-false-value) => true
+    #   global-variable-exists(a-null-value) => true
     #
     #   .foo {
     #     $some-var: false;


### PR DESCRIPTION
I was wandering how I can find out whether a variable is `null`. I guess the right answer is simply `$var == null`, but coming from JavaScript I am careful about stuff like this (and I guess others are, too).

I found that the docs are not very clear about the behavior of `null`, so I added some examples. I did not find a good place for the `$var == null` example though. If you have an idea where this could fit in I would like to add this, too.
