### PR TITLE
Logger & Number threadsafety

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -9,6 +9,9 @@
   and can now be configured to output to any IO object. This can help
   services and processes that wrap Sass compilation reliably extract
   warnings in a concurrent environment.
+* Setting the numeric precision by assigning to
+  `Sass::Script::Value::Number.precision` is now thread safe. To set for
+  all threads, be sure to set the precision on the main thread.
 
 ## 3.4.22 (28 March 2016)
 

--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -3,6 +3,13 @@
 * Table of contents
 {:toc}
 
+## 3.4.23 (UNRELEASED)
+
+* The Sass logger is now instantiated on a per-thread/per-fiber basis
+  and can now be configured to output to any IO object. This can help
+  services and processes that wrap Sass compilation reliably extract
+  warnings in a concurrent environment.
+
 ## 3.4.22 (28 March 2016)
 
 * Sass now runs without warnings when running ruby with code style

--- a/lib/sass/logger.rb
+++ b/lib/sass/logger.rb
@@ -6,8 +6,12 @@ require "sass/logger/delayed"
 
 module Sass
   class << self
-    attr_accessor :logger
-  end
+    def logger=(l)
+      Thread.current[:sass_logger] = l
+    end
 
-  self.logger = Sass::Logger::Base.new
+    def logger
+      Thread.current[:sass_logger] ||= Sass::Logger::Base.new
+    end
+  end
 end

--- a/lib/sass/logger/base.rb
+++ b/lib/sass/logger/base.rb
@@ -5,6 +5,7 @@ class Sass::Logger::Base
 
   attr_accessor :log_level
   attr_accessor :disabled
+  attr_accessor :io
 
   log_level :trace
   log_level :debug
@@ -12,8 +13,9 @@ class Sass::Logger::Base
   log_level :warn
   log_level :error
 
-  def initialize(log_level = :debug)
+  def initialize(log_level = :debug, io = nil)
     self.log_level = log_level
+    self.io = io
   end
 
   def logging_level?(level)
@@ -25,6 +27,10 @@ class Sass::Logger::Base
   end
 
   def _log(level, message)
-    Kernel.warn(message)
+    if io
+      io.puts(message)
+    else
+      Kernel.warn(message)
+    end
   end
 end


### PR DESCRIPTION
These global settings make sass unreliable in a concurrent environment. Using Thread locals now to maintain the present API while avoiding concurrency issues.
