### PR TITLE
Use the default umask (0666) when creating cache files

### DIFF
--- a/lib/sass/cache_stores/filesystem.rb
+++ b/lib/sass/cache_stores/filesystem.rb
@@ -36,7 +36,7 @@ module Sass
       def _store(key, version, sha, contents)
         compiled_filename = path_to(key)
         FileUtils.mkdir_p(File.dirname(compiled_filename))
-        Sass::Util.atomic_create_and_write_file(compiled_filename, 0600) do |f|
+        Sass::Util.atomic_create_and_write_file(compiled_filename) do |f|
           f.puts(version)
           f.puts(sha)
           f.write(contents)


### PR DESCRIPTION
Issue description: in a multi-user environment others
cannot delete the .sass-cache folder since files are
created with umask 0600.

Fixes #1623.
