### PR TITLE
Dynamic @include. Closes #626.

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -23,6 +23,14 @@
   function now accepts a `$bracketed` parameter that controls whether the
   returned list has brackets.
 
+* A mixin may now be included dynamically, Sass provides a built-in
+  mixin named `mixin` that will include a mixin named the value of the
+  first argument passed to it and pass all remaining arguments to it. E.g.
+  `@include mixin("my-mixin", 2px)` will include the mixin named
+  `my-mixin` as if one had typed `@include my-mixin(2px)`. This is the
+  corollary to the `call()` function for functions and allows
+  mixin names to be the result of arbitrary SassScript expressions.
+
 ### Backwards Incompatibilities -- Must Read!
 
 * The way [CSS variables][] are handled has changed to better correspond to the

--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -2534,6 +2534,53 @@ passed block are related to the other styles around where the block is defined. 
       }
     }
 
+### Including a Mixin Dynamically
+
+There are times when it is convenient to call a mixin based on the
+result of a SassScript expression.
+
+For example, a library might want to delegate some styling to the
+application by allowing the application to register a mixin that the
+library would include where appropriate. Sometimes a content block is
+sufficient for that purpose but in many cases it is not. So instead a
+library can provide a way to register a mixin, or a library could have a
+naming convention and check if a user has defined such a mixin (via
+`mixin-exists`) based on a name constructed from a script expression.
+
+To including a mixin dynamically, Sass provides a built-in mixin named
+`mixin` that has the signature `@mixin mixin($mixin-name, $args...)`
+which will include the mixin named `$mixin-name` by passing it all the
+argument remaining arguments. This is similar to the built-in `call`
+method.
+
+Example:
+
+    @mixin border-styles($theme-base-color) {
+      border: 1px dashed darken($theme-base-color, 10%);
+      border-radius: 10px;
+    }
+    @mixin background-styles($theme-base-color) {
+      background: $theme-base-color url(logo.png);
+    }
+    .my-fancy-element {
+      @each $type in (background, font, border, color) {
+        $mixin-name: "#{$type}-styles";
+        @if mixin-exists($mixin-name) {
+          @include mixin($mixin-name, red);
+        }
+      }
+    }
+
+Compiles to:
+
+    .my-fancy-element {
+      background: red url(logo.png);
+      border: 1px dashed #cc0000;
+      border-radius: 10px;
+    }
+
+Note: The mixin name when performing a dynamic include must be passed as
+the first positional argument; it cannot be passed keyword-style.
 
 ## Function Directives {#function_directives}
 

--- a/lib/sass/script/value/arg_list.rb
+++ b/lib/sass/script/value/arg_list.rb
@@ -32,5 +32,13 @@ module Sass::Script::Value
       @keywords_accessed = true
       @keywords
     end
+
+    # Remove the first positional argument from the ArgList and return
+    # it along with a new arglist that is the remaining arguments
+    #
+    # @return [Value]
+    def shift
+      [value.first, ArgList.new(value[1..-1] || [], @keywords, separator)]
+    end
   end
 end

--- a/lib/sass/tree/visitors/perform.rb
+++ b/lib/sass/tree/visitors/perform.rb
@@ -346,13 +346,12 @@ WARNING
 
   # Runs a mixin.
   def visit_mixin(node)
-    mixin_name = nil
+    mixin_name = node.name
     @environment.stack.with_mixin(node.filename, node.line, node.name) do
       args = node.args.map {|a| a.perform(@environment)}
       keywords = Sass::Util.map_vals(node.keywords) {|v| v.perform(@environment)}
       splat = self.class.perform_splat(node.splat, keywords, node.kwarg_splat, @environment)
 
-      mixin_name = node.name
       # We let any existing mixin named `mixin` shadow dynamic includes
       # for backwards compatability even though it will break the hell
       # out of libraries if anyone does this.
@@ -386,7 +385,7 @@ WARNING
       end
     end
   rescue Sass::SyntaxError => e
-    e.modify_backtrace(:mixin => mixin_name || node.name, :line => node.line)
+    e.modify_backtrace(:mixin => mixin_name, :line => node.line)
     e.add_backtrace(:line => node.line)
     raise e
   end

--- a/test/sass/scss/scss_test.rb
+++ b/test/sass/scss/scss_test.rb
@@ -4221,4 +4221,70 @@ p {\r\n   margin: 0;\r\n}
 SCSS
   end
 
+  def test_dynamic_include
+    assert_equal(<<CSS, render(<<SCSS))
+.foo {
+  invoked-with: 1px, 2px; }
+
+.foo {
+  invoked-with: passed as argument list; }
+CSS
+@mixin foo($args...) {
+  .foo { invoked-with: $args }
+}
+@include mixin(foo, 1px, 2px);
+$arglist: (foo, passed as argument list);
+@include mixin($arglist...);
+SCSS
+  end
+
+  def test_dynamic_includes_dynamic_include
+    assert_equal(<<CSS, render(<<SCSS))
+.foo {
+  invoked-with: 1px, 2px; }
+
+.foo {
+  invoked-with: passed as argument list; }
+CSS
+@mixin foo($args...) {
+  .foo { invoked-with: $args }
+}
+@include mixin(mixin, foo, 1px, 2px);
+$arglist: (mixin, foo, passed as argument list);
+@include mixin($arglist...);
+SCSS
+  end
+
+  def test_dynamic_include_prefers_local_definition
+    assert_equal(<<CSS, render(<<SCSS))
+.mixin {
+  dear-god-why: 2px; }
+CSS
+@mixin mixin($dear-god-why) {
+  .mixin { dear-god-why: $dear-god-why }
+}
+@include mixin(2px);
+SCSS
+  end
+
+  def test_dynamic_include_missing_name
+    assert_raise_message(Sass::SyntaxError,
+      "First argument to a dynamic include must be a string.") {render(<<SCSS)}
+@include mixin(2px);
+SCSS
+  end
+
+  def test_dynamic_include_undefined_mixin
+    assert_raise_message(Sass::SyntaxError, "Error: Undefined mixin 'foo'.") {render(<<SCSS)}
+@include mixin(foo);
+SCSS
+  end
+
+  def test_dynamic_include_undefined_mixin
+    assert_raise_message(Sass::SyntaxError,
+     "First argument to a dynamic include must be a string.") {render(<<SCSS)}
+@include mixin;
+SCSS
+  end
+
 end


### PR DESCRIPTION
Implements the most requested feature: #626.

The following tasks remain:
- [x] sass-spec tests.
- [x] CHANGELOG.
- [x] Language Reference docs

This feature adds the ability to include a mixin dynamically. It is the mixin equivalent to the `call()` function. A new "magic" mixin named `mixin` is exposed who's behavior is to take in the arguments and call another mixin, taking the first positional argument as the mixin name to call. The mixin name can be passed a normal positional argument or it can be passed as a "splat" argument. 

We are not deprecating any mixin named `mixin` at this time because 3.5 will only break backwards compat for CSS syntax support. Like all global functions defined by the Sass core, this mixin can be overridden by a user-defined mixin named `mixin`. Instead, if a user defined a mixin named `mixin` they will not be able to use dynamic includes, nor will any of the libraries that they include. In Sass 4.0, the special mixin named `mixin` can be `@use`d thus preventing any possible namespace collision.

Given that in practice, people probably don't have a mixin named `mixin` this seems like an acceptable risk and one that is easily worked around.

Code review summary:
- [x] Add backtrace info for dynamic calls
- [x] Simply initialization of mixin_name
- [ ] Remove Test::Unit tests in favor of sass-spec tests
- [x] Test backtrace line #'s
- [x] Test passing keyword arguments both explicitly and through a captured arglist
