### PR TITLE
content-exists() function

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,5 @@ gem 'rubocop', '= 0.33.0'
 
 gem 'rubyforge', :group => :development
 gem 'minitest', '>= 5.0.0', '< 6.0.0', :group => :test
-#gem "sass-spec", :path => "../sass-spec"
-gem "sass-spec", :git => 'https://github.com/sass/sass-spec.git'
+# gem "sass-spec", :path => "../sass-spec"
+gem "sass-spec", :git => 'https://github.com/sass/sass-spec.git', :branch => "content-exists"

--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -23,6 +23,9 @@
   function now accepts a `$bracketed` parameter that controls whether the
   returned list has brackets.
 
+* A new function `content-exists()` will return true when called within
+  a mixin that was passed content for use by the `@content` directive.
+
 ### Backwards Incompatibilities -- Must Read!
 
 * The way [CSS variables][] are handled has changed to better correspond to the

--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -2497,12 +2497,14 @@ The same mixins can be done in the `.sass` shorthand syntax:
       #logo
         background-image: url(/logo.gif)
 
-**Note:** when the `@content` directive is specified more than once or in a loop, the style block will be duplicated with each invocation.
+**Note:** when the `@content` directive is specified more than once or
+ in a loop, the style block will be duplicated with each invocation.
 
 Some mixins may require a passed content block or may have different
 behavior depending on whether a content block was passed. The
-`content-exists()` function will return true when a content block is
-passed to the current mixin and can be used to implement such behaviors.
+[`content-exists()` function](Sass/Script/Functions.html#content_exists-instance_method)
+will return true when a content block is passed to the current
+mixin and can be used to implement such behaviors.
 
 #### Variable Scope and Content Blocks
 

--- a/doc-src/SASS_REFERENCE.md
+++ b/doc-src/SASS_REFERENCE.md
@@ -2499,6 +2499,11 @@ The same mixins can be done in the `.sass` shorthand syntax:
 
 **Note:** when the `@content` directive is specified more than once or in a loop, the style block will be duplicated with each invocation.
 
+Some mixins may require a passed content block or may have different
+behavior depending on whether a content block was passed. The
+`content-exists()` function will return true when a content block is
+passed to the current mixin and can be used to implement such behaviors.
+
 #### Variable Scope and Content Blocks
 
 The block of content passed to a mixin are evaluated in the scope where the block is defined,

--- a/lib/sass/environment.rb
+++ b/lib/sass/environment.rb
@@ -189,13 +189,14 @@ module Sass
       @caller ||= env.is_a?(ReadOnlyEnvironment) ? env : ReadOnlyEnvironment.new(env, env.options)
     end
 
-    # The content passed to this environment but the content's
-    # environment is made readonly if it isn't already.
+    # The content passed to this environment. If the content's environment isn't already
+    # read-only, it's made read-only.
     #
     # @see BaseEnvironment#content
     #
     # @return {[Array<Sass::Tree::Node>, ReadOnlyEnvironment]?} The content nodes and
     #   the lexical environment of the content block.
+    #   Returns `nil` when there is no content in this environment.
     def content
       # Return the cached content from a previous invocation if any
       return @content if @content_cached

--- a/lib/sass/environment.rb
+++ b/lib/sass/environment.rb
@@ -175,6 +175,10 @@ module Sass
 
   # A read-only wrapper for a lexical environment for SassScript.
   class ReadOnlyEnvironment < BaseEnvironment
+    def initialize(parent = nil, options = nil)
+      super
+      @content_cached = nil
+    end
     # The read-only environment of the caller of this environment's mixin or function.
     #
     # @see BaseEnvironment#caller
@@ -190,9 +194,19 @@ module Sass
     # @see BaseEnvironment#content
     # @return {ReadOnlyEnvironment}
     def content
-      return @content if @content
-      env = super
-      @content ||= env.is_a?(ReadOnlyEnvironment) ? env : ReadOnlyEnvironment.new(env, env.options)
+      return @content if @content_cached
+      read_write_content = super
+      if read_write_content
+        tree, env = read_write_content
+        if env && !env.is_a?(ReadOnlyEnvironment)
+          env = ReadOnlyEnvironment.new(env, env.options)
+        end
+        @content_cached = true
+        @content = [tree, env]
+      else
+        @content_cached = true
+        @content = nil
+      end
     end
   end
 

--- a/lib/sass/environment.rb
+++ b/lib/sass/environment.rb
@@ -189,15 +189,21 @@ module Sass
       @caller ||= env.is_a?(ReadOnlyEnvironment) ? env : ReadOnlyEnvironment.new(env, env.options)
     end
 
-    # The read-only content passed to this environment.
+    # The content passed to this environment but the content's
+    # environment is made readonly if it isn't already.
     #
     # @see BaseEnvironment#content
-    # @return {ReadOnlyEnvironment}
+    #
+    # @return {[Array<Sass::Tree::Node>, ReadOnlyEnvironment]?} The content nodes and
+    #   the lexical environment of the content block.
     def content
+      # Return the cached content from a previous invocation if any
       return @content if @content_cached
+      # get the content with a read-write environment from the superclass
       read_write_content = super
       if read_write_content
         tree, env = read_write_content
+        # make the content's environment read-only
         if env && !env.is_a?(ReadOnlyEnvironment)
           env = ReadOnlyEnvironment.new(env, env.options)
         end

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -279,6 +279,9 @@ module Sass::Script
   # \{#mixin_exists mixin-exists($name)}
   # : Returns whether a mixin with the given name exists.
   #
+  # \{#content_exists content-exists()}
+  # : Returns whether the current mixin was passed a content block.
+  #
   # \{#inspect inspect($value)}
   # : Returns the string representation of a value as it would be represented in Sass.
   #
@@ -2423,6 +2426,20 @@ MESSAGE
     end
     declare :mixin_exists, [:name]
 
+    # Check whether a mixin was passed a content block.
+    #
+    # Unless `content-exists()` is called directly from a mixin, an error will be raised.
+    #
+    # @example
+    #   @mixin needs-content {
+    #     @if not content-exists() {
+    #       @error "You must pass a content block!"
+    #     }
+    #     @content;
+    #   }
+    #
+    # @overload content_exists()
+    # @return [Sass::Script::Value::Bool] Whether a content block was passed to the mixin.
     def content_exists
       mixin_frame = environment.stack.frames[-2]
       unless mixin_frame && mixin_frame.type == :mixin

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -2441,6 +2441,8 @@ MESSAGE
     # @overload content_exists()
     # @return [Sass::Script::Value::Bool] Whether a content block was passed to the mixin.
     def content_exists
+      # frames.last is the stack frame for this function,
+      # so we use frames[-2] to get the frame before that.
       mixin_frame = environment.stack.frames[-2]
       unless mixin_frame && mixin_frame.type == :mixin
         raise Sass::SyntaxError.new("Cannot call content-exists() except within a mixin.")

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -2423,6 +2423,15 @@ MESSAGE
     end
     declare :mixin_exists, [:name]
 
+    def content_exists
+      mixin_frame = environment.stack.frames[-2]
+      unless mixin_frame && mixin_frame.type == :mixin
+        raise Sass::SyntaxError.new("Cannot call content-exists() except within a mixin.")
+      end
+      bool(!environment.caller.content.nil?)
+    end
+    declare :content_exists, []
+
     # Return a string containing the value as its Sass representation.
     #
     # @overload inspect($value)

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -2305,6 +2305,8 @@ MESSAGE
         Sass::Util.map_vals(kwargs) {|v| Sass::Script::Tree::Literal.new(v)},
         nil,
         nil)
+      funcall.line = environment.stack.frames.last.line
+      funcall.filename = environment.stack.frames.last.filename
       funcall.options = options
       perform(funcall)
     end

--- a/lib/sass/stack.rb
+++ b/lib/sass/stack.rb
@@ -98,6 +98,16 @@ module Sass
       with_frame(filename, line, :mixin, name) {yield}
     end
 
+    # Pushes a function frame onto the stack.
+    #
+    # @param filename [String] See \{Frame#filename}.
+    # @param line [String] See \{Frame#line}.
+    # @param name [String] See \{Frame#name}.
+    # @yield [] A block in which the new frame is on the stack.
+    def with_function(filename, line, name)
+      with_frame(filename, line, :function, name) {yield}
+    end
+
     def to_s
       (frames.reverse + [nil]).each_cons(2).each_with_index.
           map do |(frame, caller), i|

--- a/lib/sass/stack.rb
+++ b/lib/sass/stack.rb
@@ -108,6 +108,16 @@ module Sass
       with_frame(filename, line, :function, name) {yield}
     end
 
+    # Pushes a function frame onto the stack.
+    #
+    # @param filename [String] See \{Frame#filename}.
+    # @param line [String] See \{Frame#line}.
+    # @param name [String] See \{Frame#name}.
+    # @yield [] A block in which the new frame is on the stack.
+    def with_directive(filename, line, name)
+      with_frame(filename, line, :directive, name) {yield}
+    end
+
     def to_s
       (frames.reverse + [nil]).each_cons(2).each_with_index.
           map do |(frame, caller), i|

--- a/lib/sass/tree/visitors/perform.rb
+++ b/lib/sass/tree/visitors/perform.rb
@@ -492,9 +492,11 @@ WARNING
   def visit_warn(node)
     res = node.expr.perform(@environment)
     res = res.value if res.is_a?(Sass::Script::Value::String)
-    msg = "WARNING: #{res}\n         "
-    msg << @environment.stack.to_s.gsub("\n", "\n         ") << "\n"
-    Sass::Util.sass_warn msg
+    @environment.stack.with_directive(node.filename, node.line, "@warn") do
+      msg = "WARNING: #{res}\n         "
+      msg << @environment.stack.to_s.gsub("\n", "\n         ") << "\n"
+      Sass::Util.sass_warn msg
+    end
     []
   end
 

--- a/test/sass/functions_test.rb
+++ b/test/sass/functions_test.rb
@@ -903,6 +903,7 @@ WARNING
     assert_warning <<MESSAGE do
 DEPRECATION WARNING: Passing blue, a non-string value, to unquote()
 will be an error in future versions of Sass.
+        on line 1 of test_unquote_inline.scss
 MESSAGE
       assert_equal('blue', evaluate('unquote(blue)'))
     end
@@ -1967,7 +1968,7 @@ WARNING
   end
 
   def perform(value, environment = env)
-    Sass::Script::Parser.parse(value, 0, 0).perform(environment)
+    Sass::Script::Parser.parse(value, 1, 0, {:filename => "#{test_name}_inline.scss"}).perform(environment)
   end
 
   def render(sass, options = {})


### PR DESCRIPTION
Closes #1988

Specs are in https://github.com/sass/sass-spec/tree/content-exists/spec/sass_3_5/functions/content-exists

Tasks Remaining:
- [x] CHANGELOG
- [x] Source documentation
- [x] Reference Docs
- [ ] Stop using the sass-spec branch once merged.
