### PR TITLE
Simple supports clause in import

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,4 +30,4 @@ end
 gem 'rubyforge', :group => :development
 gem 'minitest', '>= 5.0.0', '< 6.0.0', :group => :test
 #gem "sass-spec", :path => "../sass-spec"
-gem "sass-spec", :git => 'https://github.com/sass/sass-spec.git'
+gem "sass-spec", :git => 'https://github.com/sass/sass-spec.git', :branch => "import-supports"

--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -9,11 +9,18 @@
   and can now be configured to output to any IO object. This can help
   services and processes that wrap Sass compilation reliably extract
   warnings in a concurrent environment.
+
 * Setting the numeric precision by assigning to
   `Sass::Script::Value::Number.precision` is now thread safe. To set for
   all threads, be sure to set the precision on the main thread.
+
 * Sass cache files will now be world and group writable if your umask
   allows it.
+  [Issue #1623](https://github.com/sass/sass/issues/1623)
+
+* The `supports(...)` clause in `@import` statements now allows bare
+  declarations as per the CSS specification.
+  [Issue #1967](https://github.com/sass/sass/issues/1967)
 
 ## 3.4.22 (28 March 2016)
 

--- a/lib/sass/scss/parser.rb
+++ b/lib/sass/scss/parser.rb
@@ -560,7 +560,7 @@ module Sass
       def supports_clause
         return unless tok(/supports\(/i)
         ss
-        supports = supports_condition
+        supports = import_supports_condition
         ss
         tok!(/\)/)
         supports
@@ -568,6 +568,10 @@ module Sass
 
       def supports_condition
         supports_negation || supports_operator || supports_interpolation
+      end
+
+      def import_supports_condition
+        supports_condition || supports_declaration
       end
 
       def supports_negation
@@ -587,6 +591,14 @@ module Sass
             cond, expr!(:supports_condition_in_parens), op)
         end
         cond
+      end
+
+      def supports_declaration
+          return if tok?(/\(/)
+          name = sass_script(:parse)
+          tok!(/:/); ss
+          value = sass_script(:parse)
+          Sass::Supports::Declaration.new(name, value)
       end
 
       def supports_condition_in_parens

--- a/lib/sass/scss/parser.rb
+++ b/lib/sass/scss/parser.rb
@@ -594,7 +594,6 @@ module Sass
       end
 
       def supports_declaration
-          return if tok?(/\(/)
           name = sass_script(:parse)
           tok!(/:/); ss
           value = sass_script(:parse)
@@ -609,11 +608,9 @@ module Sass
           tok!(/\)/); ss
           cond
         else
-          name = sass_script(:parse)
-          tok!(/:/); ss
-          value = sass_script(:parse)
+          decl = supports_declaration
           tok!(/\)/); ss
-          Sass::Supports::Declaration.new(name, value)
+          decl
         end
       end
 


### PR DESCRIPTION
Specs are in https://github.com/sass/sass-spec/tree/import-supports/spec/sass_3_4_x/simple_supports_clause_in_import

This change fixes #1967. 
