### PR TITLE
Skip mappings with nil importer in Source::Map#to_json

### DIFF
--- a/lib/sass/source/map.rb
+++ b/lib/sass/source/map.rb
@@ -118,12 +118,14 @@ module Sass::Source
       @data.each do |m|
         file, importer = m.input.file, m.input.importer
 
+        next unless importer
+
         if options[:type] == :inline
           source_uri = file
         else
           sourcemap_dir = sourcemap_path && sourcemap_path.dirname.to_s
           sourcemap_dir = nil if options[:type] == :file
-          source_uri = importer && importer.public_url(file, sourcemap_dir)
+          source_uri = importer.public_url(file, sourcemap_dir)
           next unless source_uri
         end
 


### PR DESCRIPTION
This was already happening in the case where `options[:type] != :inline`, but would cause an error in the case of :inline

I'm not sure exactly under what circumstances this condition was triggered, or if it's a valid state, but it occurred in my production Rails app, and an equivalent monkeypatch got everything working.
