### PR TITLE
Remove extra lines after @include

### DIFF
--- a/lib/sass/tree/visitors/convert.rb
+++ b/lib/sass/tree/visitors/convert.rb
@@ -289,7 +289,9 @@ class Sass::Tree::Visitors::Convert < Sass::Tree::Visitors::Base
               child.line + 1 == nxt.line) ||
             (child.is_a?(Sass::Tree::VariableNode) && nxt.is_a?(Sass::Tree::VariableNode) &&
               child.line + 1 == nxt.line) ||
-            (child.is_a?(Sass::Tree::PropNode) && nxt.is_a?(Sass::Tree::PropNode))
+            (child.is_a?(Sass::Tree::PropNode) && nxt.is_a?(Sass::Tree::PropNode)) ||
+            (child.is_a?(Sass::Tree::MixinNode) && nxt.is_a?(Sass::Tree::MixinNode) &&
+              child.line + 1 == nxt.line)
           ""
         else
           "\n"

--- a/test/sass/conversion_test.rb
+++ b/test/sass/conversion_test.rb
@@ -1126,6 +1126,23 @@ foo {
 SCSS
   end
 
+  def test_consecutive_mixin_includes
+    assert_renders <<SASS, <<SCSS
+foo
+  +foo-bar
+  +foo-bar
+
+  a: blip
+SASS
+foo {
+  @include foo-bar;
+  @include foo-bar;
+
+  a: blip;
+}
+SCSS
+  end
+
   def test_mixin_include_with_hyphen_conversion_keyword_arg
     assert_renders <<SASS, <<SCSS
 foo


### PR DESCRIPTION
This closes #1843, which would prevent `sass-convert` from adding newlines in between consecutive `@include` statements.
