### PR TITLE
Add multiline expressions, issue #216

### DIFF
--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -3391,6 +3391,10 @@ CSS
 SASS
   end
 
+  def test_multiline_operator
+    renders_correctly 'multiline-operator'
+  end
+
   private
 
   def assert_hash_has(hash, expected)

--- a/test/sass/results/multiline-operator.css
+++ b/test/sass/results/multiline-operator.css
@@ -1,0 +1,26 @@
+.shadow {
+  box-shadow: 5px 5px 10px black, inset 0 0 10px white; }
+
+.color-red {
+  color: red; }
+
+.color-green {
+  color: green; }
+
+.color-blue {
+  color: blue; }
+
+.color-c {
+  color: cyan; }
+
+.color-m {
+  color: magenta; }
+
+.color-y {
+  color: yellow; }
+
+.color-k {
+  color: black; }
+
+.comment {
+  box-shadow: inset 0 0 10px white; }

--- a/test/sass/results/multiline-operator.css
+++ b/test/sass/results/multiline-operator.css
@@ -24,3 +24,17 @@
 
 .comment {
   box-shadow: inset 0 0 10px white; }
+
+#sidebar div a {
+  color: red; }
+
+.nested {
+  color: red;
+  color: orange;
+  color: yellow;
+  color: green;
+  color: blue; }
+
+@media all and (min-device-width: 100px) and (max-device-width: 300px) {
+  #sidebar {
+    width: 100%; } }

--- a/test/sass/templates/multiline-operator.sass
+++ b/test/sass/templates/multiline-operator.sass
@@ -1,0 +1,28 @@
+.shadow
+  box-shadow: \
+    5px 5px 10px black,
+    inset 0 0 10px white
+
+$rgb-colors: \
+  red
+  green
+  blue
+
+@each $color in $rgb-colors
+  .color-#{"" + $color}
+    color: $color
+
+$cmyk-colors: ( \
+  c: cyan,
+  m: magenta,
+  y: yellow,
+  k: black )
+
+@each $key, $color in $cmyk-colors
+  .color-#{$key}
+    color: $color
+
+.comment
+  box-shadow: \
+    // 5px 5px 10px black,
+    inset 0 0 10px white

--- a/test/sass/templates/multiline-operator.sass
+++ b/test/sass/templates/multiline-operator.sass
@@ -1,11 +1,11 @@
 .shadow
   box-shadow: \
-    5px 5px 10px black,
+    5px 5px 10px black, \
     inset 0 0 10px white
 
 $rgb-colors: \
-  red
-  green
+  red \
+  green \
   blue
 
 @each $color in $rgb-colors
@@ -13,9 +13,9 @@ $rgb-colors: \
     color: $color
 
 $cmyk-colors: ( \
-  c: cyan,
-  m: magenta,
-  y: yellow,
+  c: cyan, \
+  m: magenta, \
+  y: yellow, \
   k: black )
 
 @each $key, $color in $cmyk-colors
@@ -28,23 +28,23 @@ $cmyk-colors: ( \
     inset 0 0 10px white
 
 #sidebar \
-  div
+  div \
   a
-    color: red
+  color: red
 
 .nested
   @each \
     $color in \
-      red
-      orange
-      yellow
-      green
+      red \
+      orange \
+      yellow \
+      green \
       blue
-        color: $color
+    color: $color
 
 @media all \
-  and (min-device-width: 100px)
+  and (min-device-width: 100px) \
   and (max-device-width: 300px)
-    #sidebar
-      width: 100%
+  #sidebar
+    width: 100%
 

--- a/test/sass/templates/multiline-operator.sass
+++ b/test/sass/templates/multiline-operator.sass
@@ -26,3 +26,25 @@ $cmyk-colors: ( \
   box-shadow: \
     // 5px 5px 10px black,
     inset 0 0 10px white
+
+#sidebar \
+  div
+  a
+    color: red
+
+.nested
+  @each \
+    $color in \
+      red
+      orange
+      yellow
+      green
+      blue
+        color: $color
+
+@media all \
+  and (min-device-width: 100px)
+  and (max-device-width: 300px)
+    #sidebar
+      width: 100%
+


### PR DESCRIPTION
Enables splitting a long definition into several lines:

``` sass
.shadow
  box-shadow: \
    5px 5px 10px black,
    inset 0 0 10px white

```

Symbol `\` is replaced with a concatenation of lines in a nested block.
This can be usefull for long css properties, variable maps or variable
lists. `\` has to be at the end of a line to work like this.

``` sass
$rgb-colors: \
  red
  green
  blue
```

Transformation is done before running a parser, during building of a
lines array. It works in a similar fashion to processing block comments.

This pull request is related to issue #216
