### PR TITLE
Fix unallowed block error.

### DIFF
--- a/lib/sass/tree/visitors/perform.rb
+++ b/lib/sass/tree/visitors/perform.rb
@@ -350,7 +350,7 @@ WARNING
       mixin = @environment.mixin(node.name)
       raise Sass::SyntaxError.new("Undefined mixin '#{node.name}'.") unless mixin
 
-      if node.children.any? && !mixin.has_content
+      if node.has_children && !mixin.has_content
         raise Sass::SyntaxError.new(%(Mixin "#{node.name}" does not accept a content block.))
       end
 

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -368,6 +368,12 @@ SASS
     end
   end
 
+  def test_empty_block_in_no_content_mixin
+    assert_raise_message Sass::SyntaxError, 'Mixin "foo" does not accept a content block.' do
+      render "@mixin foo() {}\n @include foo() {}", :syntax => :scss
+    end
+  end
+
   def test_selector_tracing
     actual_css = render(<<-SCSS, :syntax => :scss, :trace_selectors => true)
       @mixin mixed {
@@ -894,7 +900,7 @@ foo {
 CSS
 foo
   bar : baz
-  bizz	: bap
+  bizz : bap
 SASS
   end
 


### PR DESCRIPTION
Displays error message 'Mixin "foo" does not accept a content block.'
for this example:

``` scss
@mixin foo() {}
@include foo() {}
```

Before, example was rendered without error and only failed if block
inside `@include` had some statements.

This is fix to:
https://github.com/sass/sass/issues/2106
Tests: sass/sass-spec#897
