### PR TITLE
Change equality of lists

### DIFF
--- a/lib/sass/script/value/list.rb
+++ b/lib/sass/script/value/list.rb
@@ -40,7 +40,8 @@ module Sass::Script::Value
     def eq(other)
       Sass::Script::Value::Bool.new(
         other.is_a?(List) && value == other.value &&
-        separator == other.separator)
+        separator == other.separator &&
+        bracketed == other.bracketed)
     end
 
     def hash

--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -894,7 +894,7 @@ foo {
 CSS
 foo
   bar : baz
-  bizz	: bap
+  bizz  : bap
 SASS
   end
 
@@ -2454,6 +2454,19 @@ $var: 1
   b: $var
 SASS
   end
+
+def test_equality_of_lists
+  assert_equal(<<CSS, render(<<SASS))
+a {
+  f1: f; }
+CSS
+a
+  @if [1,2,3]==(1,2,3)
+    t1: t
+  @else
+    f1: f
+SASS
+end
 
   # Regression tests
 


### PR DESCRIPTION
This pull request changes value of [1,2,3] == (1,2,3) to false. Bracket
lists and parenthesized list with same content will not be equal.

Related to #2121
See sass/sass-spec#896