### PR TITLE
Correct error in docs for `mix`.

### DIFF
--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -1305,7 +1305,7 @@ module Sass::Script
     #   @param $color1 [Sass::Script::Value::Color]
     #   @param $color2 [Sass::Script::Value::Color]
     #   @param $weight [Sass::Script::Value::Number] The relative weight of each
-    #     color. Closer to `0%` gives more weight to `$color1`, closer to `100%`
+    #     color. Closer to `100%` gives more weight to `$color1`, closer to `0%`
     #     gives more weight to `$color2`
     # @return [Sass::Script::Value::Color]
     # @raise [ArgumentError] if `$weight` is out of bounds or any parameter is


### PR DESCRIPTION
For better or worse the `$weight` argument is "how much of `$color1` to include
in the returned color" and not "how much to transition from `$color1` to
`$color2`". The rest of the docs get this right.

Here's a simple example that will show you that 100% favors `$color1`
and 0% favors `$color2`:

```scss
body {
  background-color: mix(white, black, 0%); // black
  color: mix(white, black, 100%); // white
}
```

Which outputs:

```scss
body {
  background-color: black;
  color: white;
}
```

See it in action here:

  http://www.sassmeister.com/gist/b805bc9bbc6e1f64c4a70899b0c9d9e8
