### PR TITLE
Remove duplicate private

### DIFF
--- a/lib/sass/selector/sequence.rb
+++ b/lib/sass/selector/sequence.rb
@@ -624,8 +624,6 @@ module Sass
         other.members.reject {|m| m == "\n"}.eql?(members.reject {|m| m == "\n"})
       end
 
-      private
-
       def path_has_two_subjects?(path)
         subject = false
         path.each do |sseq_or_op|


### PR DESCRIPTION
`Sass::Selector::Sequence` called `private` twice. The second call was
removed.
