### PR TITLE
Change sourcemap JSON order to match spec

### DIFF
--- a/lib/sass/source/map.rb
+++ b/lib/sass/source/map.rb
@@ -101,6 +101,8 @@ module Sass::Source
       result = "{\n"
       write_json_field(result, "version", 3, true)
 
+      write_json_field(result, "file", css_uri)
+
       source_uri_to_id = {}
       id_to_source_uri = {}
       id_to_contents = {} if options[:type] == :inline
@@ -178,7 +180,6 @@ module Sass::Source
         end
       end
       line_data.push(segment_data_for_line.join(","))
-      write_json_field(result, "mappings", line_data.join(";"))
 
       source_names = []
       (0...next_source_id).each {|id| source_names.push(id_to_source_uri[id].to_s)}
@@ -190,7 +191,8 @@ module Sass::Source
       end
 
       write_json_field(result, "names", [])
-      write_json_field(result, "file", css_uri)
+
+      write_json_field(result, "mappings", line_data.join(";"))
 
       result << "\n}"
       result

--- a/test/sass/importer_test.rb
+++ b/test/sass/importer_test.rb
@@ -217,10 +217,10 @@ SCSS
     assert_equal <<JSON.strip, sourcemap.to_json(:css_uri => 'css_uri')
 {
 "version": 3,
-"mappings": "AAAA,QAAS;EACP,KAAK,EAAE,IAAI",
+"file": "css_uri",
 "sources": ["http://orange.example.com/style.scss"],
 "names": [],
-"file": "css_uri"
+"mappings": "AAAA,QAAS;EACP,KAAK,EAAE,IAAI"
 }
 JSON
   end
@@ -259,10 +259,10 @@ CSS
     assert_equal <<JSON.strip, map
 {
 "version": 3,
-"mappings": "AACA,OAAQ",
+"file": "css_uri",
 "sources": ["source_uri"],
 "names": [],
-"file": "css_uri"
+"mappings": "AACA,OAAQ"
 }
 JSON
   end
@@ -286,10 +286,10 @@ SCSS
     assert_equal <<JSON.strip, sourcemap.to_json(:css_uri => 'css_uri')
 {
 "version": 3,
-"mappings": "AAAA,IAAK;EAAC,CAAC,EAAE,CAAC",
+"file": "css_uri",
 "sources": ["#{uri}"],
 "names": [],
-"file": "css_uri"
+"mappings": "AAAA,IAAK;EAAC,CAAC,EAAE,CAAC"
 }
 JSON
   end
@@ -313,10 +313,10 @@ SCSS
     assert_equal <<JSON.strip, sourcemap.to_json(:css_uri => 'css_uri', :css_path => 'css_path')
 {
 "version": 3,
-"mappings": "AAAA,IAAK;EAAC,CAAC,EAAE,CAAC",
+"file": "css_uri",
 "sources": ["#{uri}"],
 "names": [],
-"file": "css_uri"
+"mappings": "AAAA,IAAK;EAAC,CAAC,EAAE,CAAC"
 }
 JSON
   end
@@ -343,10 +343,10 @@ SCSS
     assert_equal <<JSON.strip, sourcemap.to_json(:css_uri => css_uri, :sourcemap_path => sourcemap_path)
 {
 "version": 3,
-"mappings": "AAAA,IAAK;EAAC,CAAC,EAAE,CAAC",
+"file": "css_uri",
 "sources": ["../sass/style.scss"],
 "names": [],
-"file": "css_uri"
+"mappings": "AAAA,IAAK;EAAC,CAAC,EAAE,CAAC"
 }
 JSON
   end
@@ -371,10 +371,10 @@ SCSS
     assert_equal <<JSON.strip, sourcemap.to_json(:css_path => css_path, :sourcemap_path => sourcemap_path)
 {
 "version": 3,
-"mappings": "AAAA,IAAK;EAAC,CAAC,EAAE,CAAC",
+"file": "../static/style.css",
 "sources": ["../sass/style.scss"],
 "names": [],
-"file": "../static/style.css"
+"mappings": "AAAA,IAAK;EAAC,CAAC,EAAE,CAAC"
 }
 JSON
   end

--- a/test/sass/source_map_test.rb
+++ b/test/sass/source_map_test.rb
@@ -28,10 +28,10 @@ a {
 CSS
 {
 "version": 3,
-"mappings": "AAAA,CAAE;EACA,GAAG,EAAE,GAAG;EACV,kBAAkB;EAChB,SAAS,EAAE,IAAI",
+"file": "test.css",
 "sources": ["test_simple_mapping_scss_inline.scss"],
 "names": [],
-"file": "test.css"
+"mappings": "AAAA,CAAE;EACA,GAAG,EAAE,GAAG;EACV,kBAAkB;EAChB,SAAS,EAAE,IAAI"
 }
 JSON
   end
@@ -52,10 +52,10 @@ a {
 CSS
 {
 "version": 3,
-"mappings": "AAAA,CAAC;EACC,GAAG,EAAE,GAAG;;EAEP,SAAS,EAAC,IAAI",
+"file": "test.css",
 "sources": ["test_simple_mapping_sass_inline.sass"],
 "names": [],
-"file": "test.css"
+"mappings": "AAAA,CAAC;EACC,GAAG,EAAE,GAAG;;EAEP,SAAS,EAAC,IAAI"
 }
 JSON
   end
@@ -78,10 +78,10 @@ a {
 CSS
 {
 "version": 3,
-"mappings": "AAAA,CAAE;EACA,GAAG,EAAE,GAAG;EACV,kBAAkB;EAChB,SAAS,EAAE,IAAI",
+"file": "test.css",
 "sources": ["#{uri}"],
 "names": [],
-"file": "test.css"
+"mappings": "AAAA,CAAE;EACA,GAAG,EAAE,GAAG;EACV,kBAAkB;EAChB,SAAS,EAAE,IAAI"
 }
 JSON
   end
@@ -104,10 +104,10 @@ a {
 CSS
 {
 "version": 3,
-"mappings": "AAAA,CAAE;EACA,GAAG,EAAE,GAAG;EACV,kBAAkB;EAChB,SAAS,EAAE,IAAI",
+"file": "style.css",
 "sources": ["../scss/style.scss"],
 "names": [],
-"file": "style.css"
+"mappings": "AAAA,CAAE;EACA,GAAG,EAAE,GAAG;EACV,kBAAkB;EAChB,SAAS,EAAE,IAAI"
 }
 JSON
   end
@@ -129,10 +129,10 @@ a {
 CSS
 {
 "version": 3,
-"mappings": "AAAA,CAAC;EACC,GAAG,EAAE,GAAG;;EAEP,SAAS,EAAC,IAAI",
+"file": "style.css",
 "sources": ["../sass/style.sass"],
 "names": [],
-"file": "style.css"
+"mappings": "AAAA,CAAC;EACC,GAAG,EAAE,GAAG;;EAEP,SAAS,EAAC,IAAI"
 }
 JSON
   end
@@ -151,10 +151,10 @@ a {
 CSS
 {
 "version": 3,
-"mappings": ";AAAA,CAAE;EACA,GAAG,EAAE,GAAG",
+"file": "test.css",
 "sources": ["test_simple_charset_mapping_scss_inline.scss"],
 "names": [],
-"file": "test.css"
+"mappings": ";AAAA,CAAE;EACA,GAAG,EAAE,GAAG"
 }
 JSON
   end
@@ -172,10 +172,10 @@ a {
 CSS
 {
 "version": 3,
-"mappings": ";AAAA,CAAC;EACC,GAAG,EAAE,GAAG",
+"file": "test.css",
 "sources": ["test_simple_charset_mapping_sass_inline.sass"],
 "names": [],
-"file": "test.css"
+"mappings": ";AAAA,CAAC;EACC,GAAG,EAAE,GAAG"
 }
 JSON
   end
@@ -195,10 +195,10 @@ fЖЖ {
 CSS
 {
 "version": 3,
-"mappings": ";AACA,GAAI;EACF,CAAC,EAAE,CAAC",
+"file": "test.css",
 "sources": ["test_different_charset_than_encoding_scss_inline.scss"],
 "names": [],
-"file": "test.css"
+"mappings": ";AACA,GAAI;EACF,CAAC,EAAE,CAAC"
 }
 JSON
   end
@@ -217,10 +217,10 @@ fЖЖ {
 CSS
 {
 "version": 3,
-"mappings": ";AACA,GAAG;EACD,CAAC,EAAE,CAAC",
+"file": "test.css",
 "sources": ["test_different_charset_than_encoding_sass_inline.sass"],
 "names": [],
-"file": "test.css"
+"mappings": ";AACA,GAAG;EACD,CAAC,EAAE,CAAC"
 }
 JSON
   end
@@ -836,10 +836,10 @@ SCSS
     assert_equal json, <<JSON.rstrip
 {
 "version": 3,
-"mappings": "DADD,UAAU",
+"file": "output%20file.css",
 "sources": ["source%20file.scss"],
 "names": [],
-"file": "output%20file.css"
+"mappings": "DADD,UAAU"
 }
 JSON
   end


### PR DESCRIPTION
From [the spec](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit?pli=1#) the order should be:

* Line 1: The entire file is a single JSON object
* Line 2: File version (always the first entry in the object) and must be a positive integer.
* Line 3: An optional name of the generated code that this source map is associated with.
* Line 4: An optional source root, useful for relocating source files on a server or removing repeated values in the “sources” entry.  This value is prepended to the individual entries in the “source” field.
* Line 5: A list of original sources used by the “mappings” entry.
* Line 6: An optional list of source content, useful when the “source” can’t be hosted. The contents are listed in the same order as the sources in line 5. “null” may be used if some original sources should be retrieved by name.
* Line 7: A list of symbol names used by the “mappings” entry.
* Line 8: A string with the encoded mapping data.
