### PR TITLE
Improve parent resolution

### DIFF
--- a/lib/sass/selector/simple_sequence.rb
+++ b/lib/sass/selector/simple_sequence.rb
@@ -132,8 +132,15 @@ module Sass
             end
           end
 
+          resolution = parent_sub + resolved_members[1..-1]
+          resolution.sort_by! {|e| e.is_a?(Pseudo) ? 1 : 0}
+          resolution.uniq!
+          if resolution.any? {|e| [Element, Class, Id].include? e.class}
+            resolution.delete_if {|e| e.is_a? Universal}
+          end
+
           Sequence.new(members[0...-1] +
-            [SimpleSequence.new(parent_sub + resolved_members[1..-1], subject?)] +
+            [SimpleSequence.new(resolution, subject?)] +
             [newline].compact)
           end)
       end


### PR DESCRIPTION
Places pseudo class selectors at the end, removes duplicate selectors
and removes universal selector if possible during resolution of parent
selector (&)
## Pseudo at the end

``` sass
div:before { &[id] { color: red; }}
```

Before:

``` css
div:before[id] {
  color: red; }
```

After:

``` css
div[id]:before {
  color: red; }
```
## Remove duplicates

``` sass
.foo { &.foo { color: red; }}
```

Before:

``` css
.foo.foo {
  color: red; }
```

After:

``` css
.foo {
  color: red; }
```
## Remove universal

``` sass
* { &.foo { color: red; }}
```

Before:

``` css
*.foo {
  color: red; }
```

After:

``` css
.foo {
  color: red; }
```

Related to: https://github.com/sass/sass/issues/490
Tests: https://github.com/sass/sass-spec/pull/931
