### PR TITLE
Fix parent selector replaced with a multiline rule

### DIFF
--- a/lib/sass/selector/sequence.rb
+++ b/lib/sass/selector/sequence.rb
@@ -66,10 +66,14 @@ module Sass
           next [sseq_or_op] unless sseq_or_op.is_a?(SimpleSequence)
           sseq_or_op.resolve_parent_refs(super_cseq).members
         end).map do |path|
-          Sequence.new(path.map do |seq_or_op|
+          path_members = path.map do |seq_or_op|
             next seq_or_op unless seq_or_op.is_a?(Sequence)
             seq_or_op.members
-          end.flatten)
+          end
+          if path_members.length == 2 && path_members[1][0] == "\n"
+            path_members[0].unshift path_members[1].shift
+          end
+          Sequence.new(path_members.flatten)
         end)
       end
 


### PR DESCRIPTION
Fixes newline placement when the parent selector is used with a
multiline rule.

``` scss
.foo,
.bar {
  .baz & {
    color: red;
  }
}
```

Before

``` css
.baz .foo, .baz
.bar {
  color: red; }
```

After

``` css
.baz .foo,
.baz .bar {
  color: red; }
```

Closes: https://github.com/sass/sass/issues/1976
Tests: https://github.com/sass/sass-spec/pull/933
