### PR TITLE
Fix multiline parent selector

### DIFF
--- a/lib/sass/selector/sequence.rb
+++ b/lib/sass/selector/sequence.rb
@@ -51,11 +51,11 @@ module Sass
       # @raise [Sass::SyntaxError] If a parent selector is invalid
       def resolve_parent_refs(super_cseq, implicit_parent)
         members = @members.dup
-        nl = (members.first == "\n" && members.shift)
         contains_parent_ref = contains_parent_ref?
         return CommaSequence.new([self]) if !implicit_parent && !contains_parent_ref
 
         unless contains_parent_ref
+          nl = (members.first == "\n" && members.shift)
           old_members, members = members, []
           members << nl if nl
           members << SimpleSequence.new([Parent.new], false)


### PR DESCRIPTION
Fixes newline in parent rules that are muliline.

``` scss
a {
  &:focus,
  &:active {
    color: red;
  }
}
```

before

``` css
a:focus, a:active {
  color: red; }
```

after

``` css
a:focus,
a:active {
  color: red; }
```

Closes: #800
Tests: sass/sass-spec#1020
