### PR TITLE
Enable parent at any position

### DIFF
--- a/lib/sass/scss/static_parser.rb
+++ b/lib/sass/scss/static_parser.rb
@@ -156,7 +156,7 @@ MESSAGE
 
         # The tok(/\*/) allows the "E*" hack
         while (v = id_selector || class_selector || placeholder_selector ||
-                   attrib || pseudo || (tok(/\*/) && Selector::Universal.new(nil)))
+                   attrib || pseudo || parent_selector || (tok(/\*/) && Selector::Universal.new(nil)))
           res << v
         end
 

--- a/lib/sass/selector/sequence.rb
+++ b/lib/sass/selector/sequence.rb
@@ -79,8 +79,8 @@ module Sass
       def contains_parent_ref?
         members.any? do |sseq_or_op|
           next false unless sseq_or_op.is_a?(SimpleSequence)
-          next true if sseq_or_op.members.first.is_a?(Parent)
           sseq_or_op.members.any? do |sel|
+            sel.is_a?(Parent) ||
             sel.is_a?(Pseudo) && sel.selector && sel.selector.contains_parent_ref?
           end
         end

--- a/lib/sass/selector/simple_sequence.rb
+++ b/lib/sass/selector/simple_sequence.rb
@@ -91,8 +91,10 @@ module Sass
           sel.with_selector(sel.selector.resolve_parent_refs(super_cseq, false))
         end.flatten
 
-        # Parent selector only appears as the first selector in the sequence
-        unless (parent = resolved_members.first).is_a?(Parent)
+        parent = resolved_members.find do |sym|
+          sym.is_a? Parent
+        end
+        unless parent
           return CommaSequence.new([Sequence.new([SimpleSequence.new(resolved_members, subject?)])])
         end
 
@@ -132,8 +134,9 @@ module Sass
             end
           end
 
+          replaced = resolved_members.map {|sel| sel.is_a?(Parent) ? parent_sub : sel}.flatten
           Sequence.new(members[0...-1] +
-            [SimpleSequence.new(parent_sub + resolved_members[1..-1], subject?)] +
+            [SimpleSequence.new(replaced, subject?)] +
             [newline].compact)
           end)
       end

--- a/test/sass/scss/scss_test.rb
+++ b/test/sass/scss/scss_test.rb
@@ -3522,36 +3522,33 @@ SCSS
   end
 
   def test_parent_in_mid_selector_error
-    assert_raise_message(Sass::SyntaxError, <<MESSAGE.rstrip) {render <<SCSS}
-Invalid CSS after ".foo": expected "{", was "&.bar"
-
-"&.bar" may only be used at the beginning of a compound selector.
-MESSAGE
-flim {
+    assert_equal <<CSS, render(<<SCSS)
+.foo.flim.bar {
+  a: b; }
+CSS
+.flim {
   .foo&.bar {a: b}
 }
 SCSS
   end
 
   def test_parent_after_selector_error
-    assert_raise_message(Sass::SyntaxError, <<MESSAGE.rstrip) {render <<SCSS}
-Invalid CSS after ".foo.bar": expected "{", was "&"
-
-"&" may only be used at the beginning of a compound selector.
-MESSAGE
-flim {
+    assert_equal <<CSS, render(<<SCSS)
+.foo.bar.flim {
+  a: b; }
+CSS
+.flim {
   .foo.bar& {a: b}
 }
 SCSS
   end
 
   def test_double_parent_selector_error
-    assert_raise_message(Sass::SyntaxError, <<MESSAGE.rstrip) {render <<SCSS}
-Invalid CSS after "&": expected "{", was "&"
-
-"&" may only be used at the beginning of a compound selector.
-MESSAGE
-flim {
+    assert_equal <<CSS, render(<<SCSS)
+.flim.flim {
+  a: b; }
+CSS
+.flim {
   && {a: b}
 }
 SCSS


### PR DESCRIPTION
Removes rule that the parent operator (`&`) has to be first symbol in a
sequence. Goal behind this change is to enable parent at suffix
position, like here:
```scss
.foo {
  bar& {
    color: red;
  }
}
```

This version is unsafe as it enables:
- double use of parent operator `bar&&`
- concatenation of selectors: `foo { bar& { a: b; } }` becomes `barfoo {
  a: b; }`

Closes: https://github.com/sass/sass/issues/1425
Tests: https://github.com/sass/sass-spec/pull/960