### PR TITLE
Change from .merge to .merge! in Rack documentation

### DIFF
--- a/lib/sass/plugin/rack.rb
+++ b/lib/sass/plugin/rack.rb
@@ -9,7 +9,7 @@ module Sass
     #
     # ## Customize
     #
-    #     Sass::Plugin.options.merge(
+    #     Sass::Plugin.options.merge!(
     #       :cache_location => './tmp/sass-cache',
     #       :never_update => environment != :production,
     #       :full_exception => environment != :production)


### PR DESCRIPTION
With just a `.merge`, changes to the hash don't stick.