### PR TITLE
Changes most references of Fixnum class to Integer, to account for deprecation of Fixnum and Bignum classes in Ruby 2.4.0

### DIFF
--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -94,13 +94,13 @@ module Sass
     # `text`: `String`
     # : The text in the line, without any whitespace at the beginning or end.
     #
-    # `tabs`: `Fixnum`
+    # `tabs`: `Integer`
     # : The level of indentation of the line.
     #
-    # `index`: `Fixnum`
+    # `index`: `Integer`
     # : The line number in the original document.
     #
-    # `offset`: `Fixnum`
+    # `offset`: `Integer`
     # : The number of bytes in on the line that the text begins.
     #   This ends up being the number of bytes of leading whitespace.
     #

--- a/lib/sass/error.rb
+++ b/lib/sass/error.rb
@@ -69,14 +69,14 @@ module Sass
     # The name of the mixin in which the error occurred.
     # This could be `nil` if the error occurred outside a mixin.
     #
-    # @return [Fixnum]
+    # @return [String]
     def sass_mixin
       sass_backtrace.first[:mixin]
     end
 
     # The line of the Sass template on which the error occurred.
     #
-    # @return [Fixnum]
+    # @return [Integer]
     def sass_line
       sass_backtrace.first[:line]
     end
@@ -153,7 +153,7 @@ module Sass
       # Returns an error report for an exception in CSS format.
       #
       # @param e [Exception]
-      # @param line_offset [Fixnum] The number of the first line of the Sass template.
+      # @param line_offset [Integer] The number of the first line of the Sass template.
       # @return [String] The error report
       # @raise [Exception] `e`, if the
       #   {file:SASS_REFERENCE.md#full_exception-option `:full_exception`} option

--- a/lib/sass/plugin/staleness_checker.rb
+++ b/lib/sass/plugin/staleness_checker.rb
@@ -72,7 +72,7 @@ module Sass
       # Returns whether a Sass or SCSS stylesheet has been modified since a given time.
       #
       # @param template_file [String] The location of the Sass or SCSS template.
-      # @param mtime [Fixnum] The modification time to check against.
+      # @param mtime [Time] The modification time to check against.
       # @param importer [Sass::Importers::Base] The importer used to locate the stylesheet.
       #   Defaults to the filesystem importer.
       # @return [Boolean] Whether the stylesheet has been modified.
@@ -103,7 +103,7 @@ module Sass
       # so it's better to use when checking multiple stylesheets at once.
       #
       # @param template_file [String] The location of the Sass or SCSS template.
-      # @param mtime [Fixnum] The modification time to check against.
+      # @param mtime [Time] The modification time to check against.
       # @param importer [Sass::Importers::Base] The importer used to locate the stylesheet.
       #   Defaults to the filesystem importer.
       # @return [Boolean] Whether the stylesheet has been modified.

--- a/lib/sass/script.rb
+++ b/lib/sass/script.rb
@@ -16,9 +16,9 @@ module Sass
     # Parses a string of SassScript
     #
     # @param value [String] The SassScript
-    # @param line [Fixnum] The number of the line on which the SassScript appeared.
+    # @param line [Integer] The number of the line on which the SassScript appeared.
     #   Used for error reporting
-    # @param offset [Fixnum] The number of characters in on `line` that the SassScript started.
+    # @param offset [Integer] The number of characters in on `line` that the SassScript started.
     #   Used for error reporting
     # @param options [{Symbol => Object}] An options hash;
     #   see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}

--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -431,8 +431,8 @@ module Sass::Script
     # If no signatures match, the first signature is returned for error messaging.
     #
     # @param method_name [Symbol] The name of the Ruby function to be called.
-    # @param arg_arity [Fixnum] The number of unnamed arguments the function was passed.
-    # @param kwarg_arity [Fixnum] The number of keyword arguments the function was passed.
+    # @param arg_arity [Integer] The number of unnamed arguments the function was passed.
+    # @param kwarg_arity [Integer] The number of keyword arguments the function was passed.
     #
     # @return [{Symbol => Object}, nil]
     #   The signature options for the matching signature,

--- a/lib/sass/script/lexer.rb
+++ b/lib/sass/script/lexer.rb
@@ -19,13 +19,13 @@ module Sass
       # `source_range`: \[`Sass::Source::Range`\]
       # : The range in the source file in which the token appeared.
       #
-      # `pos`: \[`Fixnum`\]
+      # `pos`: \[`Integer`\]
       # : The scanner position at which the SassScript token appeared.
       Token = Struct.new(:type, :value, :source_range, :pos)
 
       # The line number of the lexer's current position.
       #
-      # @return [Fixnum]
+      # @return [Integer]
       def line
         return @line unless @tok
         @tok.source_range.start_pos.line
@@ -34,7 +34,7 @@ module Sass
       # The number of bytes into the current line
       # of the lexer's current position (1-based).
       #
-      # @return [Fixnum]
+      # @return [Integer]
       def offset
         return @offset unless @tok
         @tok.source_range.start_pos.offset
@@ -142,9 +142,9 @@ module Sass
       }
 
       # @param str [String, StringScanner] The source text to lex
-      # @param line [Fixnum] The 1-based line on which the SassScript appears.
+      # @param line [Integer] The 1-based line on which the SassScript appears.
       #   Used for error reporting and sourcemap building
-      # @param offset [Fixnum] The 1-based character (not byte) offset in the line in the source.
+      # @param offset [Integer] The 1-based character (not byte) offset in the line in the source.
       #   Used for error reporting and sourcemap building
       # @param options [{Symbol => Object}] An options hash;
       #   see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}

--- a/lib/sass/script/parser.rb
+++ b/lib/sass/script/parser.rb
@@ -8,22 +8,22 @@ module Sass
     class Parser
       # The line number of the parser's current position.
       #
-      # @return [Fixnum]
+      # @return [Integer]
       def line
         @lexer.line
       end
 
       # The column number of the parser's current position.
       #
-      # @return [Fixnum]
+      # @return [Integer]
       def offset
         @lexer.offset
       end
 
       # @param str [String, StringScanner] The source text to parse
-      # @param line [Fixnum] The line on which the SassScript appears.
+      # @param line [Integer] The line on which the SassScript appears.
       #   Used for error reporting and sourcemap building
-      # @param offset [Fixnum] The character (not byte) offset where the script starts in the line.
+      # @param offset [Integer] The character (not byte) offset where the script starts in the line.
       #   Used for error reporting and sourcemap building
       # @param options [{Symbol => Object}] An options hash; see
       #   {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.

--- a/lib/sass/script/tree/node.rb
+++ b/lib/sass/script/tree/node.rb
@@ -10,7 +10,7 @@ module Sass::Script::Tree
 
     # The line of the document on which this node appeared.
     #
-    # @return [Fixnum]
+    # @return [Integer]
     attr_accessor :line
 
     # The source range in the document on which this node appeared.

--- a/lib/sass/script/value/base.rb
+++ b/lib/sass/script/value/base.rb
@@ -149,7 +149,7 @@ MSG
     # Returns the hash code of this value. Two objects' hash codes should be
     # equal if the objects are equal.
     #
-    # @return [Fixnum] The hash code.
+    # @return [Integer for Ruby 2.4.0+, Fixnum for earlier Ruby versions] The hash code.
     def hash
       value.hash
     end
@@ -176,7 +176,7 @@ MSG
       eq(other).to_bool
     end
 
-    # @return [Fixnum] The integer value of this value
+    # @return [Integer] The integer value of this value
     # @raise [Sass::SyntaxError] if this value isn't an integer
     def to_i
       raise Sass::SyntaxError.new("#{inspect} is not an integer.")

--- a/lib/sass/script/value/color.rb
+++ b/lib/sass/script/value/color.rb
@@ -17,8 +17,8 @@ module Sass::Script::Value
     # @private
     #
     # Convert a ruby integer to a rgba components
-    # @param color [Fixnum]
-    # @return [Array<Fixnum>] Array of 4 numbers representing r,g,b and alpha
+    # @param color [Integer]
+    # @return [Array<Integer>] Array of 4 numbers representing r,g,b and alpha
     def self.int_to_rgba(color)
       rgba = (0..3).map {|n| color >> (n << 3) & 0xff}.reverse
       rgba[-1] = rgba[-1] / 255.0
@@ -293,7 +293,7 @@ module Sass::Script::Value
 
     # The red component of the color.
     #
-    # @return [Fixnum]
+    # @return [Integer]
     def red
       hsl_to_rgb!
       @attrs[:red]
@@ -301,7 +301,7 @@ module Sass::Script::Value
 
     # The green component of the color.
     #
-    # @return [Fixnum]
+    # @return [Integer]
     def green
       hsl_to_rgb!
       @attrs[:green]
@@ -309,7 +309,7 @@ module Sass::Script::Value
 
     # The blue component of the color.
     #
-    # @return [Fixnum]
+    # @return [Integer]
     def blue
       hsl_to_rgb!
       @attrs[:blue]
@@ -342,7 +342,7 @@ module Sass::Script::Value
     # The alpha channel (opacity) of the color.
     # This is 1 unless otherwise defined.
     #
-    # @return [Fixnum]
+    # @return [Integer]
     def alpha
       @attrs[:alpha].to_f
     end
@@ -357,7 +357,7 @@ module Sass::Script::Value
 
     # Returns the red, green, and blue components of the color.
     #
-    # @return [Array<Fixnum>] A frozen three-element array of the red, green, and blue
+    # @return [Array<Integer>] A frozen three-element array of the red, green, and blue
     #   values (respectively) of the color
     def rgb
       [red, green, blue].freeze
@@ -365,7 +365,7 @@ module Sass::Script::Value
 
     # Returns the red, green, blue, and alpha components of the color.
     #
-    # @return [Array<Fixnum>] A frozen four-element array of the red, green,
+    # @return [Array<Integer>] A frozen four-element array of the red, green,
     #   blue, and alpha values (respectively) of the color
     def rgba
       [red, green, blue, alpha].freeze
@@ -373,7 +373,7 @@ module Sass::Script::Value
 
     # Returns the hue, saturation, and lightness components of the color.
     #
-    # @return [Array<Fixnum>] A frozen three-element array of the
+    # @return [Array<Integer>] A frozen three-element array of the
     #   hue, saturation, and lightness values (respectively) of the color
     def hsl
       [hue, saturation, lightness].freeze
@@ -381,7 +381,7 @@ module Sass::Script::Value
 
     # Returns the hue, saturation, lightness, and alpha components of the color.
     #
-    # @return [Array<Fixnum>] A frozen four-element array of the hue,
+    # @return [Array<Integer>] A frozen four-element array of the hue,
     #   saturation, lightness, and alpha values (respectively) of the color
     def hsla
       [hue, saturation, lightness, alpha].freeze

--- a/lib/sass/script/value/number.rb
+++ b/lib/sass/script/value/number.rb
@@ -306,7 +306,7 @@ module Sass::Script::Value
     end
     alias_method :to_sass, :inspect
 
-    # @return [Fixnum] The integer value of the number
+    # @return [Integer] The integer value of the number
     # @raise [Sass::SyntaxError] if the number isn't an integer
     def to_i
       super unless int?

--- a/lib/sass/scss/parser.rb
+++ b/lib/sass/scss/parser.rb
@@ -16,9 +16,9 @@ module Sass
       #   warnings and source maps.
       # @param importer [Sass::Importers::Base] The importer used to import the
       #   file being parsed. Used for source maps.
-      # @param line [Fixnum] The 1-based line on which the source string appeared,
+      # @param line [Integer] The 1-based line on which the source string appeared,
       #   if it's part of another document.
-      # @param offset [Fixnum] The 1-based character (not byte) offset in the line on
+      # @param offset [Integer] The 1-based character (not byte) offset in the line on
       #   which the source string starts. Used for error reporting and sourcemap
       #   building.
       def initialize(str, filename, importer, line = 1, offset = 1)

--- a/lib/sass/scss/rx.rb
+++ b/lib/sass/scss/rx.rb
@@ -40,7 +40,7 @@ module Sass
       # escaping all significant characters.
       #
       # @param str [String] The text of the regexp
-      # @param flags [Fixnum] Flags for the created regular expression
+      # @param flags [Integer] Flags for the created regular expression
       # @return [Regexp]
       # @private
       def self.quote(str, flags = 0)

--- a/lib/sass/selector/abstract_sequence.rb
+++ b/lib/sass/selector/abstract_sequence.rb
@@ -8,7 +8,7 @@ module Sass
     class AbstractSequence
       # The line of the Sass template on which this selector was declared.
       #
-      # @return [Fixnum]
+      # @return [Integer]
       attr_reader :line
 
       # The name of the file in which this selector was declared.
@@ -19,8 +19,8 @@ module Sass
       # Sets the line of the Sass template on which this selector was declared.
       # This also sets the line for all child selectors.
       #
-      # @param line [Fixnum]
-      # @return [Fixnum]
+      # @param line [Integer]
+      # @return [Integer]
       def line=(line)
         members.each {|m| m.line = line}
         @line = line
@@ -42,7 +42,7 @@ module Sass
       # Subclasses should define `#_hash` rather than overriding this method,
       # which automatically handles memoizing the result.
       #
-      # @return [Fixnum]
+      # @return [Integer]
       def hash
         @_hash ||= _hash
       end
@@ -83,7 +83,7 @@ module Sass
       # The base is given by {Sass::Selector::SPECIFICITY_BASE}. This can be a
       # number or a range representing possible specificities.
       #
-      # @return [Fixnum, Range]
+      # @return [Integer, Range]
       def specificity
         _specificity(members)
       end

--- a/lib/sass/selector/sequence.rb
+++ b/lib/sass/selector/sequence.rb
@@ -6,8 +6,8 @@ module Sass
       # Sets the line of the Sass template on which this selector was declared.
       # This also sets the line for all child selectors.
       #
-      # @param line [Fixnum]
-      # @return [Fixnum]
+      # @param line [Integer]
+      # @return [Integer]
       def line=(line)
         members.each {|m| m.line = line if m.is_a?(SimpleSequence)}
         @line = line

--- a/lib/sass/selector/simple.rb
+++ b/lib/sass/selector/simple.rb
@@ -5,7 +5,7 @@ module Sass
     class Simple
       # The line of the Sass template on which this selector was declared.
       #
-      # @return [Fixnum]
+      # @return [Integer]
       attr_accessor :line
 
       # The name of the file in which this selector was declared,
@@ -36,7 +36,7 @@ module Sass
       # so if that contains information irrelevant to the identity of the selector,
       # this should be overridden.
       #
-      # @return [Fixnum]
+      # @return [Integer]
       def hash
         @_hash ||= equality_key.hash
       end

--- a/lib/sass/shared.rb
+++ b/lib/sass/shared.rb
@@ -31,7 +31,7 @@ module Sass
     #   A `Fixnum` in 1.8, a `String` in 1.9
     # @param finish [Character] The character closing the balanced pair.
     #   A `Fixnum` in 1.8, a `String` in 1.9
-    # @param count [Fixnum] The number of opening characters matched
+    # @param count [Integer] The number of opening characters matched
     #   before calling this method
     # @return [(String, String)] The string matched within the balanced pair
     #   and the rest of the string.

--- a/lib/sass/source/map.rb
+++ b/lib/sass/source/map.rb
@@ -37,7 +37,7 @@ module Sass::Source
 
     # Shifts all output source ranges forward one or more lines.
     #
-    # @param delta [Fixnum] The number of lines to shift the ranges forward.
+    # @param delta [Integer] The number of lines to shift the ranges forward.
     def shift_output_lines(delta)
       return if delta == 0
       @data.each do |m|
@@ -49,7 +49,7 @@ module Sass::Source
     # Shifts any output source ranges that lie on the first line forward one or
     # more characters on that line.
     #
-    # @param delta [Fixnum] The number of characters to shift the ranges
+    # @param delta [Integer] The number of characters to shift the ranges
     #   forward.
     def shift_output_offsets(delta)
       return if delta == 0

--- a/lib/sass/source/position.rb
+++ b/lib/sass/source/position.rb
@@ -2,17 +2,17 @@ module Sass::Source
   class Position
     # The one-based line of the document associated with the position.
     #
-    # @return [Fixnum]
+    # @return [Integer]
     attr_accessor :line
 
     # The one-based offset in the line of the document associated with the
     # position.
     #
-    # @return [Fixnum]
+    # @return [Integer]
     attr_accessor :offset
 
-    # @param line [Fixnum] The source line
-    # @param offset [Fixnum] The source offset
+    # @param line [Integer] The source line
+    # @param offset [Integer] The source offset
     def initialize(line, offset)
       @line = line
       @offset = offset

--- a/lib/sass/tree/comment_node.rb
+++ b/lib/sass/tree/comment_node.rb
@@ -59,7 +59,7 @@ module Sass::Tree
 
     # Returns the number of lines in the comment.
     #
-    # @return [Fixnum]
+    # @return [Integer]
     def lines
       @value.inject(0) do |s, e|
         next s + e.count("\n") if e.is_a?(String)

--- a/lib/sass/tree/node.rb
+++ b/lib/sass/tree/node.rb
@@ -69,7 +69,7 @@ module Sass
 
       # The line of the document on which this node appeared.
       #
-      # @return [Fixnum]
+      # @return [Integer]
       attr_accessor :line
 
       # The source range in the document on which this node appeared.

--- a/lib/sass/tree/prop_node.rb
+++ b/lib/sass/tree/prop_node.rb
@@ -39,7 +39,7 @@ module Sass::Tree
     # * This is a child property of another property
     # * The parent property has a value, and thus will be rendered
     #
-    # @return [Fixnum]
+    # @return [Integer]
     attr_accessor :tabs
 
     # The source range in which the property name appears.

--- a/lib/sass/tree/rule_node.rb
+++ b/lib/sass/tree/rule_node.rb
@@ -40,7 +40,7 @@ module Sass::Tree
     # * This is a child rule of another rule
     # * The parent rule has properties, and thus will be rendered
     #
-    # @return [Fixnum]
+    # @return [Integer]
     attr_accessor :tabs
 
     # The entire selector source range for this rule.

--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -418,7 +418,7 @@ module Sass
     # Returns information about the caller of the previous method.
     #
     # @param entry [String] An entry in the `#caller` list, or a similarly formatted string
-    # @return [[String, Fixnum, (String, nil)]]
+    # @return [[String, Integer, (String, nil)]]
     #   An array containing the filename, line, and method name of the caller.
     #   The method name may be nil
     def caller_info(entry = nil)
@@ -636,7 +636,7 @@ module Sass
 
     # Returns an array of ints representing the JRuby version number.
     #
-    # @return [Array<Fixnum>]
+    # @return [Array<Integer>]
     def jruby_version
       @jruby_version ||= ::JRUBY_VERSION.split(".").map {|s| s.to_i}
     end
@@ -941,7 +941,7 @@ module Sass
     # A version of `Enumerable#enum_cons` that works in Ruby 1.8 and 1.9.
     #
     # @param enum [Enumerable] The enumerable to get the enumerator for
-    # @param n [Fixnum] The size of each cons
+    # @param n [Integer] The size of each cons
     # @return [Enumerator] The consed enumerator
     def enum_cons(enum, n)
       ruby1_8? ? enum.enum_cons(n) : enum.each_cons(n)
@@ -950,7 +950,7 @@ module Sass
     # A version of `Enumerable#enum_slice` that works in Ruby 1.8 and 1.9.
     #
     # @param enum [Enumerable] The enumerable to get the enumerator for
-    # @param n [Fixnum] The size of each slice
+    # @param n [Integer] The size of each slice
     # @return [Enumerator] The consed enumerator
     def enum_slice(enum, n)
       ruby1_8? ? enum.enum_slice(n) : enum.each_slice(n)
@@ -977,7 +977,7 @@ module Sass
     # Returns the ASCII code of the given character.
     #
     # @param c [String] All characters but the first are ignored.
-    # @return [Fixnum] The ASCII code of `c`.
+    # @return [Integer] The ASCII code of `c`.
     def ord(c)
       ruby1_8? ? c[0] : c.ord
     end
@@ -1102,11 +1102,11 @@ module Sass
 
     # Converts the argument into a valid JSON value.
     #
-    # @param v [Fixnum, String, Array, Boolean, nil]
+    # @param v [Integer, String, Array, Boolean, nil]
     # @return [String]
     def json_value_of(v)
       case v
-      when Fixnum
+      when Integer
         v.to_s
       when String
         "\"" + json_escape_string(v) + "\""
@@ -1139,7 +1139,7 @@ module Sass
 
     # Encodes `value` as VLQ (http://en.wikipedia.org/wiki/VLQ).
     #
-    # @param value [Fixnum]
+    # @param value [Integer]
     # @return [String] The encoded value
     def encode_vlq(value)
       if value < 0

--- a/lib/sass/version.rb
+++ b/lib/sass/version.rb
@@ -8,7 +8,7 @@ module Sass
   # if it was installed from Git.
   module Version
     # Returns a hash representing the version of Sass.
-    # The `:major`, `:minor`, and `:teeny` keys have their respective numbers as Fixnums.
+    # The `:major`, `:minor`, and `:teeny` keys have their respective numbers as Integers.
     # The `:name` key has the name of the version.
     # The `:string` key contains a human-readable string representation of the version.
     # The `:number` key is the major, minor, and teeny keys separated by periods.
@@ -41,7 +41,7 @@ module Sass
     #       :prerelease_number => 1
     #     }
     #
-    # @return [{Symbol => String/Fixnum}] The version hash
+    # @return [{Symbol => String/Integer}] The version hash
     # @comment
     #   rubocop:disable ClassVars
     def version

--- a/yard/callbacks.rb
+++ b/yard/callbacks.rb
@@ -4,7 +4,7 @@ class CallbacksHandler < YARD::Handlers::Ruby::Legacy::Base
   def process
     callback_name = tokval(statement.tokens[2])
     attr_index = statement.comments.each_with_index {|c, i| break i if c[0] == ?@}
-    if attr_index.is_a?(Fixnum)
+    if attr_index.is_a?(Integer)
       docstring = statement.comments[0...attr_index]
       attrs = statement.comments[attr_index..-1]
     else


### PR DESCRIPTION
Closes #2218