### PR TITLE
Switch YARD markdown provider to Redcarpet

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,6 +1,6 @@
 --readme          README.md
 --markup          markdown
---markup-provider maruku
+--markup-provider redcarpet
 --default-return  ""
 --title           "Sass Documentation"
 --query           'object.type != :classvariable'

--- a/sass.gemspec
+++ b/sass.gemspec
@@ -19,8 +19,8 @@ SASS_GEMSPEC = Gem::Specification.new do |spec|
     END
 
   spec.required_ruby_version = '>= 1.8.7'
-  spec.add_development_dependency 'yard', '>= 0.5.3'
-  spec.add_development_dependency 'maruku', '>= 0.5.9'
+  spec.add_development_dependency 'yard', '>= 0.9.8'
+  spec.add_development_dependency 'redcarpet', '~> 2.3.0'
   spec.add_development_dependency 'minitest', '>= 5'
 
   readmes = Dir['*'].reject{ |x| x =~ /(^|[^.a-z])[a-z]+/ || x == "TODO" }


### PR DESCRIPTION
Hi there! I'm the current maintainer of [Maruku](https://github.com/bhollis/maruku), a Ruby Markdown parser that's being used by Sass though YARD to generate its documentation. A few years ago I declared [Maruku obsolete](https://benhollis.net/blog/2013/10/20/maruku-is-obsolete/) since there are now better options available.

Sass is one of the top consumers of Maruku, so I'd like to remove that dependency to help Maruku sail off into the sunset. Here I've changed Sass' development dependency to a newer YARD and to use Redcarpet for Markdown generation. I would have chosen Kramdown, which does not have any native dependency, but it doesn't support GitHub-style Markdown without extra configuration that YARD doesn't provide to it.