### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,10 @@ install:
   - bundle update sass-spec
 rvm:
   - 2.0.0
-  - 2.1.7
-  - 2.2.3
-  - 2.3.0
-  - jruby-9.0.0.0
-  - rbx-2.2.7
+  - 2.1.10
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
 gemfile: Gemfile
 env:
   - MATHN=true RUBOCOP=false
@@ -32,14 +31,10 @@ branches:
 notifications:
   irc: {channels: "irc.freenode.org#sass"}
 matrix:
-  allow_failures:
-    - rvm: rbx-2.2.7
-    - rvm: jruby-9.0.0.0
   include:
-    - rvm: 2.2.3
+    - rvm: 2.2.7
       env: MATHN=true RUBOCOP=true
-    - rvm: 2.1.7
+    - rvm: 2.1.10
       env: MATHN=true RUBOCOP=true
     - rvm: 2.0.0
       env: MATHN=true RUBOCOP=true
-


### PR DESCRIPTION
I updated rubies to latest version.
I added `ruby-head` as `allow_failures` in `.travis.yml`.

I think this is useful.
Because we can prepare before next version Ruby 2.5 release.

We can see this kind of logic in `rails`, `rspec` and `cucumber` and etc.
https://github.com/rails/rails/blob/master/.travis.yml
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml

Is it possible to merge?
Thanks.