### PR TITLE
Add Travis Badge for next branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sass [![Gem Version](https://badge.fury.io/rb/sass.svg)](http://badge.fury.io/rb/sass) [![Inline docs](http://inch-ci.org/github/sass/sass.svg)](http://inch-ci.org/github/sass/sass)
+# Sass [![Travis Build Status](https://travis-ci.org/sass/sass.svg?branch=next)](https://travis-ci.org/sass/sass) [![Gem Version](https://badge.fury.io/rb/sass.svg)](http://badge.fury.io/rb/sass) [![Inline docs](http://inch-ci.org/github/sass/sass.svg)](http://inch-ci.org/github/sass/sass)
 
 **Sass makes CSS fun again**. Sass is an extension of CSS,
 adding nested rules, variables, mixins, selector inheritance, and more.


### PR DESCRIPTION
Added Travis Badge to README.
https://github.com/junaruga/sass/blob/feature/next-travis-badge/README.md

Seeing Travis page and status easily must be useful to maintain `sass`.

You can see modified README here.
https://github.com/junaruga/sass/blob/feature/next-travis-badge/README.md

The badge image URL includes branch name.
`https://travis-ci.org/sass/sass.svg?branch=next`.
So, please take care of merging this commit to `stable`, `master` branches.


I referred below sites.
https://github.com/rspec/rspec-core/
https://github.com/sparklemotion/nokogiri
