### PR TITLE
DeepCopy bugfix

### DIFF
--- a/lib/sass/tree/visitors/deep_copy.rb
+++ b/lib/sass/tree/visitors/deep_copy.rb
@@ -55,7 +55,7 @@ class Sass::Tree::Visitors::DeepCopy < Sass::Tree::Visitors::Base
 
   def visit_mixin(node)
     node.args = node.args.map {|a| a.deep_copy}
-    node.keywords = Hash[node.keywords.map {|k, v| [k, v.deep_copy]}]
+    node.keywords = Sass::Util::NormalizedMap.new(Hash[node.keywords.map {|k, v| [k, v.deep_copy]}])
     yield
   end
 


### PR DESCRIPTION
Fixes a bug in Tree::Visitors::DeepCopy, which converted node.keywords to Hash but it should remain a Sass::Util::NormalizedMap.

This bug show up when trying to render a deep-copied tree to scss, where it gives an error "undefined method `as_stored` for Hash".

Sorry that I didn't supply a test - I couldn't figure out where to add it, as there seem to be no tests for DeepCopy so far at all. Any pointers appreciated.