### PR TITLE
Updating broken doc links

### DIFF
--- a/lib/sass.rb
+++ b/lib/sass.rb
@@ -47,7 +47,7 @@ module Sass
   #
   # @param contents [String] The contents of the Sass file.
   # @param options [{Symbol => Object}] An options hash;
-  #   see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}
+  #   see {file:SASS_REFERENCE.md#Options the Sass options documentation}
   # @raise [Sass::SyntaxError] if there's an error in the document
   # @raise [Encoding::UndefinedConversionError] if the source encoding
   #   cannot be converted to UTF-8
@@ -69,7 +69,7 @@ module Sass
   #
   #   @param filename [String] The path to the Sass, SCSS, or CSS file on disk.
   #   @param options [{Symbol => Object}] An options hash;
-  #     see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}
+  #     see {file:SASS_REFERENCE.md#Options the Sass options documentation}
   #   @return [String] The compiled CSS.
   #
   # @overload compile_file(filename, css_filename, options = {})
@@ -77,7 +77,7 @@ module Sass
   #
   #   @param filename [String] The path to the Sass, SCSS, or CSS file on disk.
   #   @param options [{Symbol => Object}] An options hash;
-  #     see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}
+  #     see {file:SASS_REFERENCE.md#Options the Sass options documentation}
   #   @param css_filename [String] The location to which to write the compiled CSS.
   def self.compile_file(filename, *args)
     options = args.last.is_a?(Hash) ? args.pop : {}

--- a/lib/sass/css.rb
+++ b/lib/sass/css.rb
@@ -18,7 +18,7 @@ module Sass
     #   that can be converted to Unicode.
     #   If the stylesheet contains an `@charset` declaration,
     #   that overrides the Ruby encoding
-    #   (see {file:SASS_REFERENCE.md#encodings the encoding documentation})
+    #   (see {file:SASS_REFERENCE.md#Encodings the encoding documentation})
     # @option options :old [Boolean] (false)
     #     Whether or not to output old property syntax
     #     (`:color blue` as opposed to `color: blue`).

--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -168,7 +168,7 @@ module Sass
     # default values and resolving aliases.
     #
     # @param options [{Symbol => Object}] The options hash;
-    #   see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}
+    #   see {file:SASS_REFERENCE.md#Options the Sass options documentation}
     # @return [{Symbol => Object}] The normalized options hash.
     # @private
     def self.normalize_options(options)
@@ -222,7 +222,7 @@ module Sass
     #
     # @param filename [String] The path to the Sass or SCSS file
     # @param options [{Symbol => Object}] The options hash;
-    #   See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+    #   See {file:SASS_REFERENCE.md#Options the Sass options documentation}.
     # @return [Sass::Engine] The Engine for the given Sass or SCSS file.
     # @raise [Sass::SyntaxError] if there's an error in the document.
     def self.for_file(filename, options)
@@ -240,7 +240,7 @@ module Sass
     end
 
     # The options for the Sass engine.
-    # See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+    # See {file:SASS_REFERENCE.md#Options the Sass options documentation}.
     #
     # @return [{Symbol => Object}]
     attr_reader :options
@@ -257,9 +257,9 @@ module Sass
     #   that can be converted to Unicode.
     #   If the template contains an `@charset` declaration,
     #   that overrides the Ruby encoding
-    #   (see {file:SASS_REFERENCE.md#encodings the encoding documentation})
+    #   (see {file:SASS_REFERENCE.md#Encodings the encoding documentation})
     # @param options [{Symbol => Object}] An options hash.
-    #   See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+    #   See {file:SASS_REFERENCE.md#Options the Sass options documentation}.
     # @see {Sass::Engine.for_file}
     # @see {Sass::Plugin}
     def initialize(template, options = {})

--- a/lib/sass/environment.rb
+++ b/lib/sass/environment.rb
@@ -81,7 +81,7 @@ module Sass
     inherited_hash_reader :function
 
     # @param options [{Symbol => Object}] The options hash. See
-    #   {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+    #   {file:SASS_REFERENCE.md#Options the Sass options documentation}.
     # @param parent [Environment] See \{#parent}
     def initialize(parent = nil, options = nil)
       @parent = parent

--- a/lib/sass/plugin.rb
+++ b/lib/sass/plugin.rb
@@ -12,7 +12,7 @@ module Sass
   # when it's used as a plugin for various frameworks.
   # All Rack-enabled frameworks are supported out of the box.
   # The plugin is
-  # {file:SASS_REFERENCE.md#rails_merb_plugin automatically activated for Rails and Merb}.
+  # {file:SASS_REFERENCE.md#Rack_Rails_Merb_Plugin automatically activated for Rails and Merb}.
   # Other frameworks must enable it explicitly; see {Sass::Plugin::Rack}.
   #
   # This module has a large set of callbacks available

--- a/lib/sass/plugin/compiler.rb
+++ b/lib/sass/plugin/compiler.rb
@@ -31,7 +31,7 @@ module Sass::Plugin
     # Creates a new compiler.
     #
     # @param opts [{Symbol => Object}]
-    #   See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+    #   See {file:SASS_REFERENCE.md#Options the Sass options documentation}.
     def initialize(opts = {})
       @watched_files = Set.new
       options.merge!(opts)

--- a/lib/sass/plugin/configuration.rb
+++ b/lib/sass/plugin/configuration.rb
@@ -27,7 +27,7 @@ module Sass
       end
 
       # An options hash.
-      # See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+      # See {file:SASS_REFERENCE.md#Options the Sass options documentation}.
       #
       # @return [{Symbol => Object}]
       def options

--- a/lib/sass/plugin/rack.rb
+++ b/lib/sass/plugin/rack.rb
@@ -14,14 +14,14 @@ module Sass
     #       :never_update => environment != :production,
     #       :full_exception => environment != :production)
     #
-    # {file:SASS_REFERENCE.md#options See the Reference for more options}.
+    # {file:SASS_REFERENCE.md#Options See the Reference for more options}.
     #
     # ## Use
     #
     # Put your Sass files in `public/stylesheets/sass`.
     # Your CSS will be generated in `public/stylesheets`,
     # and regenerated every request if necessary.
-    # The locations and frequency {file:SASS_REFERENCE.md#options can be customized}.
+    # The locations and frequency {file:SASS_REFERENCE.md#Options can be customized}.
     # That's all there is to it!
     class Rack
       # The delay, in seconds, between update checks.

--- a/lib/sass/plugin/staleness_checker.rb
+++ b/lib/sass/plugin/staleness_checker.rb
@@ -39,7 +39,7 @@ module Sass
       # for checking the staleness of several stylesheets at once.
       #
       # @param options [{Symbol => Object}]
-      #   See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+      #   See {file:SASS_REFERENCE.md#Options the Sass options documentation}.
       def initialize(options)
         # URIs that are being actively checked for staleness. Protects against
         # import loops.

--- a/lib/sass/script.rb
+++ b/lib/sass/script.rb
@@ -21,7 +21,7 @@ module Sass
     # @param offset [Integer] The number of characters in on `line` that the SassScript started.
     #   Used for error reporting
     # @param options [{Symbol => Object}] An options hash;
-    #   see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}
+    #   see {file:SASS_REFERENCE.md#Options the Sass options documentation}
     # @return [Script::Tree::Node] The root node of the parse tree
     def self.parse(value, line, offset, options = {})
       Parser.parse(value, line, offset, options)

--- a/lib/sass/script/lexer.rb
+++ b/lib/sass/script/lexer.rb
@@ -147,7 +147,7 @@ module Sass
       # @param offset [Integer] The 1-based character (not byte) offset in the line in the source.
       #   Used for error reporting and sourcemap building
       # @param options [{Symbol => Object}] An options hash;
-      #   see {file:SASS_REFERENCE.md#sass_options the Sass options documentation}
+      #   see {file:SASS_REFERENCE.md#Options the Sass options documentation}
       def initialize(str, line, offset, options)
         @scanner = str.is_a?(StringScanner) ? str : Sass::Util::MultibyteStringScanner.new(str)
         @line = line

--- a/lib/sass/script/parser.rb
+++ b/lib/sass/script/parser.rb
@@ -26,7 +26,7 @@ module Sass
       # @param offset [Integer] The character (not byte) offset where the script starts in the line.
       #   Used for error reporting and sourcemap building
       # @param options [{Symbol => Object}] An options hash; see
-      #   {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+      #   {file:SASS_REFERENCE.md#Options the Sass options documentation}.
       #   This supports an additional `:allow_extra_text` option that controls
       #   whether the parser throws an error when extra text is encountered
       #   after the parsed construct.

--- a/lib/sass/script/tree/node.rb
+++ b/lib/sass/script/tree/node.rb
@@ -33,7 +33,7 @@ module Sass::Script::Tree
 
     # Sets the options hash for this node,
     # as well as for all child nodes.
-    # See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+    # See {file:SASS_REFERENCE.md#Options the Sass options documentation}.
     #
     # @param options [{Symbol => Object}] The options
     def options=(options)

--- a/lib/sass/script/value/base.rb
+++ b/lib/sass/script/value/base.rb
@@ -27,7 +27,7 @@ module Sass::Script::Value
 
     # Sets the options hash for this node,
     # as well as for all child nodes.
-    # See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+    # See {file:SASS_REFERENCE.md#Options the Sass options documentation}.
     #
     # @param options [{Symbol => Object}] The options
     attr_writer :options

--- a/lib/sass/tree/node.rb
+++ b/lib/sass/tree/node.rb
@@ -83,7 +83,7 @@ module Sass
       attr_writer :filename
 
       # The options hash for the node.
-      # See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+      # See {file:SASS_REFERENCE.md#Options the Sass options documentation}.
       #
       # @return [{Symbol => Object}]
       attr_reader :options
@@ -151,7 +151,7 @@ module Sass
       # @return [Boolean]
       def invisible?; false; end
 
-      # The output style. See {file:SASS_REFERENCE.md#sass_options the Sass options documentation}.
+      # The output style. See {file:SASS_REFERENCE.md#Options the Sass options documentation}.
       #
       # @return [Symbol]
       def style

--- a/sass.gemspec
+++ b/sass.gemspec
@@ -19,7 +19,7 @@ SASS_GEMSPEC = Gem::Specification.new do |spec|
     END
 
   spec.required_ruby_version = '>= 1.8.7'
-  spec.add_development_dependency 'yard', '>= 0.9.8'
+  spec.add_development_dependency 'yard', '~> 0.8.7.6'
   spec.add_development_dependency 'redcarpet', '~> 2.3.0'
   spec.add_development_dependency 'minitest', '>= 5'
 


### PR DESCRIPTION
Updates several broken doc links as discussed on #2295

Downgraded dependency on yardoc to 0.8.7.6 to make output match current docs on sass-lang.org

There are still some broken links related to the switch from maruku to redcarpet.  Starting around line 156 of [SASS_REFERENCE.md](https://github.com/sass/sass/blob/stable/doc-src/SASS_REFERENCE.md) there is some markdown that maruku was turning into HTML dl/dt/dd that both redcarpet and github's markdown dialect don't support.  I left that alone since there wasn't an obvious path forward, but can follow up on that later if given guidance.

I did the work on stable branch - if future work should start on master instead, let me know.