### PR TITLE
Suppress warning from minitest.

### DIFF
--- a/test/sass/engine_test.rb
+++ b/test/sass/engine_test.rb
@@ -3394,7 +3394,13 @@ SASS
   private
 
   def assert_hash_has(hash, expected)
-    expected.each {|k, v| assert_equal(v, hash[k])}
+    expected.each do |k, v|
+      if v.nil?
+        assert_nil(hash[k])
+      else
+        assert_equal(v, hash[k])
+      end
+    end
   end
 
   def assert_renders_encoded(css, sass)

--- a/test/sass/source_map_test.rb
+++ b/test/sass/source_map_test.rb
@@ -984,7 +984,11 @@ CSS
   def assert_ranges_equal(expected, actual, lines, prefix)
     assert_positions_equal(expected.start_pos, actual.start_pos, lines, prefix + " start position")
     assert_positions_equal(expected.end_pos, actual.end_pos, lines, prefix + " end position")
-    assert_equal(expected.file, actual.file)
+    if expected.file.nil?
+      assert_nil(actual.file)
+    else
+      assert_equal(expected.file, actual.file)
+    end
   end
 
   def assert_sourcemaps_equal(source, css, expected, actual)

--- a/test/sass/util/multibyte_string_scanner_test.rb
+++ b/test/sass/util/multibyte_string_scanner_test.rb
@@ -140,8 +140,16 @@ unless Sass::Util.ruby1_8?
     def assert_scanner_state(pos, byte_pos, matched_size, byte_matched_size)
       assert_equal pos, @scanner.pos, 'pos'
       assert_equal byte_pos, @scanner.byte_pos, 'byte_pos'
-      assert_equal matched_size, @scanner.matched_size, 'matched_size'
-      assert_equal byte_matched_size, @scanner.byte_matched_size, 'byte_matched_size'
+      if matched_size.nil?
+        assert_nil @scanner.matched_size, 'matched_size'
+      else
+        assert_equal matched_size, @scanner.matched_size, 'matched_size'
+      end
+      if byte_matched_size.nil?
+        assert_nil @scanner.byte_matched_size, 'byte_matched_size'
+      else
+        assert_equal byte_matched_size, @scanner.byte_matched_size, 'byte_matched_size'
+      end
     end
   end
 end


### PR DESCRIPTION
I fixed to suppress the warning "DEPRECATED: Use assert_nil if expecting nil" by minitest.

As a information, other kind of warnings are from other gem packages.

* [DEPRECATION] `last_comment` is deprecated.  Please use `last_description` instead.
  => From rubocop 0.33.0 (latest version is 0.49.0)
* ... celluloid-0.16.0/lib/celluloid/logging/incident_logger.rb:96: warning: parentheses after method name    
* ... celluloid-0.16.0/lib/celluloid.rb:513: warning: global variable `$CELLULOID_TEST' not initialized
* ... celluloid-0.16.0/lib/celluloid.rb:138: warning: instance variable @shutdown_registered not initialized
  => From celluloid 0.16.0 (latest version is 0.17.3)
* "fatal: Not a git repository (or any of the parent directories): .git"
  => From ?
Those can be suppressed when we update those gems to latest version in the future.
