### PR TITLE
Allow for frozen string literals.

### DIFF
--- a/lib/sass/deprecation.rb
+++ b/lib/sass/deprecation.rb
@@ -45,7 +45,7 @@ module Sass
         message = column_or_message
       end
 
-      location = "line #{line}"
+      location = "line #{line}".dup
       location << ", column #{column}" if column
       location << " of #{filename}" if filename
 

--- a/lib/sass/media.rb
+++ b/lib/sass/media.rb
@@ -147,7 +147,7 @@ module Sass::Media
     #
     # @return [String]
     def to_css
-      css = ''
+      css = ''.dup
       css << resolved_modifier
       css << ' ' unless resolved_modifier.empty?
       css << resolved_type

--- a/lib/sass/script/lexer.rb
+++ b/lib/sass/script/lexer.rb
@@ -405,7 +405,7 @@ MESSAGE
       end
 
       def special_fun_body(parens, prefix = nil)
-        str = prefix || ''
+        str = prefix || ''.dup
         while (scanned = scan(/.*?([()]|\#\{)/m))
           str << scanned
           if scanned[-1] == ?(

--- a/lib/sass/script/parser.rb
+++ b/lib/sass/script/parser.rb
@@ -817,8 +817,8 @@ RUBY
       # @param node [Sass::Script::Tree::Node]
       def interpolation_deprecation(interpolation)
         return if @options[:_convert]
-        location = "on line #{interpolation.line}"
-        location << " of #{interpolation.filename}" if interpolation.filename
+        location  = "on line #{interpolation.line}"
+        location += " of #{interpolation.filename}" if interpolation.filename
         Sass::Util.sass_warn <<WARNING
 DEPRECATION WARNING #{location}:
 \#{} interpolation near operators will be simplified in a future version of Sass.

--- a/lib/sass/script/tree/interpolation.rb
+++ b/lib/sass/script/tree/interpolation.rb
@@ -70,7 +70,7 @@ module Sass::Script::Tree
     def to_sass(opts = {})
       return to_quoted_equivalent.to_sass if deprecation == :immediate
 
-      res = ""
+      res = "".dup
       res << @before.to_sass(opts) if @before
       res << ' ' if @before && @whitespace_before
       res << '#{' unless @originally_text
@@ -163,7 +163,7 @@ module Sass::Script::Tree
     # @return [Sass::Script::Value::String]
     #   The SassScript string that is the value of the interpolation
     def _perform(environment)
-      res = ""
+      res = "".dup
       res << @before.perform(environment).to_s if @before
       res << " " if @before && @whitespace_before
 

--- a/lib/sass/script/tree/string_interpolation.rb
+++ b/lib/sass/script/tree/string_interpolation.rb
@@ -52,7 +52,7 @@ module Sass::Script::Tree
       quote = type == :string ? opts[:quote] || quote_for(self) || '"' : :none
       opts = opts.merge(:quote => quote)
 
-      res = ""
+      res = "".dup
       res << quote if quote != :none
       res << _to_sass(before, opts)
       res << '#{' << @mid.to_sass(opts.merge(:quote => nil)) << '}'
@@ -87,7 +87,7 @@ module Sass::Script::Tree
     # @return [Sass::Script::Value::String]
     #   The SassScript string that is the value of the interpolation
     def _perform(environment)
-      res = ""
+      res = "".dup
       before = @before.perform(environment)
       res << before.value
       mid = @mid.perform(environment)

--- a/lib/sass/scss/parser.rb
+++ b/lib/sass/scss/parser.rb
@@ -1104,7 +1104,7 @@ module Sass
         pos = @scanner.pos
         line = @line
         offset = @offset
-        @strs.push ""
+        @strs.push "".dup
         throw_error {yield} && @strs.last
       rescue Sass::SyntaxError
         @scanner.pos = pos
@@ -1276,7 +1276,7 @@ module Sass
         was = was[0...15] + "..." if was.size > 18
 
         raise Sass::SyntaxError.new(
-          "Invalid CSS after \"#{after}\": expected #{expected}, was \"#{was}\"",
+          "Invalid CSS after \"#{after}\": expected #{expected}, was \"#{was}\"".dup,
           :line => line)
       end
 

--- a/lib/sass/scss/rx.rb
+++ b/lib/sass/scss/rx.rb
@@ -14,7 +14,7 @@ module Sass
       def self.escape_ident(str)
         return "" if str.empty?
         return "\\#{str}" if str == '-' || str == '_'
-        out = ""
+        out = "".dup
         value = str.dup
         out << value.slice!(0...1) if value =~ /^[-_]/
         if value[0...1] =~ NMSTART

--- a/lib/sass/scss/static_parser.rb
+++ b/lib/sass/scss/static_parser.rb
@@ -86,7 +86,7 @@ module Sass
         sel = selector
         return unless sel
         selectors = [sel]
-        ws = ''
+        ws = ''.dup
         while tok(/,/)
           ws << str {ss}
           next unless (sel = selector)
@@ -94,7 +94,7 @@ module Sass
           if ws.include?("\n")
             selectors[-1] = Selector::Sequence.new(["\n"] + selectors.last.members)
           end
-          ws = ''
+          ws = ''.dup
         end
         Selector::CommaSequence.new(selectors)
       end
@@ -140,7 +140,7 @@ MESSAGE
 
       def reference_combinator
         return unless tok(%r{/})
-        res = '/'
+        res = '/'.dup
         ns, name = expr!(:qualified_name)
         res << ns << '|' if ns
         res << name << tok!(%r{/})

--- a/lib/sass/selector.rb
+++ b/lib/sass/selector.rb
@@ -310,7 +310,7 @@ module Sass
 
       # @see Selector#to_s
       def to_s(opts = {})
-        res = "["
+        res = "[".dup
         res << @namespace << "|" if @namespace
         res << @name
         res << @operator << @value if @value

--- a/lib/sass/source/map.rb
+++ b/lib/sass/source/map.rb
@@ -98,7 +98,7 @@ module Sass::Source
       css_uri ||= Sass::Util.file_uri_from_path(
         Sass::Util.relative_path_from(css_path, sourcemap_path.dirname))
 
-      result = "{\n"
+      result = "{\n".dup
       write_json_field(result, "version", 3, true)
 
       source_uri_to_id = {}
@@ -156,7 +156,7 @@ module Sass::Source
           end
 
           # `segment` is a data chunk for a single position mapping.
-          segment = ""
+          segment = "".dup
 
           # Field 1: zero-based starting offset.
           segment << Sass::Util.encode_vlq(target_pos.offset - previous_target_offset)

--- a/lib/sass/tree/css_import_node.rb
+++ b/lib/sass/tree/css_import_node.rb
@@ -58,7 +58,7 @@ module Sass::Tree
     def resolved_value
       @resolved_value ||=
         begin
-          str = "@import #{resolved_uri}"
+          str = "@import #{resolved_uri}".dup
           str << " supports(#{supports_condition.to_css})" if supports_condition
           str << " #{resolved_query.to_css}" if resolved_query
           str

--- a/lib/sass/tree/visitors/convert.rb
+++ b/lib/sass/tree/visitors/convert.rb
@@ -92,8 +92,7 @@ class Sass::Tree::Visitors::Convert < Sass::Tree::Visitors::Base
   end
 
   def visit_directive(node)
-    res = "#{tab_str}#{interp_to_src(node.value)}"
-    res.gsub!(/^@import \#\{(.*)\}([^}]*)$/, '@import \1\2')
+    res = "#{tab_str}#{interp_to_src(node.value)}".gsub(/^@import \#\{(.*)\}([^}]*)$/, '@import \1\2')
     return res + "#{semi}\n" unless node.has_children
     res + yield
   end
@@ -135,7 +134,7 @@ class Sass::Tree::Visitors::Convert < Sass::Tree::Visitors::Base
         "else"
       end
     @is_else = false
-    str = "#{tab_str}@#{name}"
+    str = "#{tab_str}@#{name}".dup
     str << " #{node.expr.to_sass(@options)}" if node.expr
     str << yield
     @is_else = true
@@ -160,9 +159,9 @@ class Sass::Tree::Visitors::Convert < Sass::Tree::Visitors::Base
 
   def visit_cssimport(node)
     if node.uri.is_a?(Sass::Script::Tree::Node)
-      str = "#{tab_str}@import #{node.uri.to_sass(@options)}"
+      str = "#{tab_str}@import #{node.uri.to_sass(@options)}".dup
     else
-      str = "#{tab_str}@import #{node.uri}"
+      str = "#{tab_str}@import #{node.uri}".dup
     end
     str << " supports(#{node.supports_condition.to_src(@options)})" if node.supports_condition
     str << " #{interp_to_src(node.query)}" unless node.query.empty?
@@ -174,7 +173,7 @@ class Sass::Tree::Visitors::Convert < Sass::Tree::Visitors::Base
       if node.args.empty? && node.splat.nil?
         ""
       else
-        str = '('
+        str = '('.dup
         str << node.args.map do |v, d|
           if d
             "#{v.to_sass(@options)}: #{d.to_sass(@options)}"

--- a/lib/sass/tree/visitors/perform.rb
+++ b/lib/sass/tree/visitors/perform.rb
@@ -494,7 +494,7 @@ WARNING
     res = node.expr.perform(@environment)
     res = res.value if res.is_a?(Sass::Script::Value::String)
     @environment.stack.with_directive(node.filename, node.line, "@warn") do
-      msg = "WARNING: #{res}\n         "
+      msg = "WARNING: #{res}\n         ".dup
       msg << @environment.stack.to_s.gsub("\n", "\n         ") << "\n"
       Sass::Util.sass_warn msg
     end
@@ -561,7 +561,7 @@ WARNING
   end
 
   def handle_import_loop!(node)
-    msg = "An @import loop has been found:"
+    msg = "An @import loop has been found:".dup
     files = @environment.stack.frames.select {|f| f.is_import?}.map {|f| f.filename}.compact
     if node.filename == node.imported_file.options[:filename]
       raise Sass::SyntaxError.new("#{msg} #{node.filename} imports itself")

--- a/lib/sass/tree/visitors/to_css.rb
+++ b/lib/sass/tree/visitors/to_css.rb
@@ -131,7 +131,7 @@ class Sass::Tree::Visitors::ToCss < Sass::Tree::Visitors::Base
     if node.style == :compressed && trailing_semicolon?
       erase! 1
     end
-    return "" if @result.empty?
+    return "".dup if @result.empty?
 
     output "\n"
 
@@ -421,7 +421,7 @@ class Sass::Tree::Visitors::ToCss < Sass::Tree::Visitors::Base
   def debug_info_rule(debug_info, options)
     node = Sass::Tree::DirectiveNode.resolved("@media -sass-debug-info")
     debug_info.map {|k, v| [k.to_s, v.to_s]}.to_a.each do |k, v|
-      rule = Sass::Tree::RuleNode.new([""])
+      rule = Sass::Tree::RuleNode.new(["".dup])
       rule.resolved_rules = Sass::Selector::CommaSequence.new(
         [Sass::Selector::Sequence.new(
           [Sass::Selector::SimpleSequence.new(
@@ -429,7 +429,7 @@ class Sass::Tree::Visitors::ToCss < Sass::Tree::Visitors::Base
             false)
           ])
         ])
-      prop = Sass::Tree::PropNode.new([""], [""], :new)
+      prop = Sass::Tree::PropNode.new(["".dup], ["".dup], :new)
       prop.resolved_name = "font-family"
       prop.resolved_value = Sass::SCSS::RX.escape_ident(v.to_s)
       rule << prop

--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -898,7 +898,7 @@ module Sass
     def json_escape_string(s)
       return s if s !~ /["\\\b\f\n\r\t]/
 
-      result = ""
+      result = "".dup
       s.split("").each do |c|
         case c
         when '"', "\\"
@@ -963,7 +963,7 @@ module Sass
         value <<= 1
       end
 
-      result = ''
+      result = ''.dup
       begin
         digit = value & VLQ_BASE_MASK
         value >>= VLQ_BASE_SHIFT

--- a/test/sass/css2sass_test.rb
+++ b/test/sass/css2sass_test.rb
@@ -498,7 +498,7 @@ CSS
   # Encodings
 
   def test_encoding_error
-    css2sass("foo\nbar\nb\xFEaz".force_encoding("utf-8"))
+    css2sass("foo\nbar\nb\xFEaz".dup.force_encoding("utf-8"))
     assert(false, "Expected exception")
   rescue Sass::SyntaxError => e
     assert_equal(3, e.sass_line)
@@ -507,7 +507,7 @@ CSS
 
   def test_ascii_incompatible_encoding_error
     template = "foo\nbar\nb_z".encode("utf-16le")
-    template[9] = "\xFE".force_encoding("utf-16le")
+    template[9] = "\xFE".dup.force_encoding("utf-16le")
     css2sass(template)
     assert(false, "Expected exception")
   rescue Sass::SyntaxError => e

--- a/test/sass/encoding_test.rb
+++ b/test/sass/encoding_test.rb
@@ -7,7 +7,7 @@ class EncodingTest < MiniTest::Test
   include Sass::Util::Test
 
   def test_encoding_error
-    render("foo\nbar\nb\xFEaz".force_encoding("utf-8"))
+    render("foo\nbar\nb\xFEaz".dup.force_encoding("utf-8"))
     assert(false, "Expected exception")
   rescue Sass::SyntaxError => e
     assert_equal(3, e.sass_line)
@@ -16,7 +16,7 @@ class EncodingTest < MiniTest::Test
 
   def test_ascii_incompatible_encoding_error
     template = "foo\nbar\nb_z".encode("utf-16le")
-    template[9] = "\xFE".force_encoding("utf-16le")
+    template[9] = "\xFE".dup.force_encoding("utf-16le")
     render(template)
     assert(false, "Expected exception")
   rescue Sass::SyntaxError => e
@@ -94,7 +94,7 @@ SASS
   end
 
   def test_utf_8_with_bom
-    assert_renders_encoded(<<CSS, <<SASS.force_encoding("BINARY"))
+    assert_renders_encoded(<<CSS, <<SASS.dup.force_encoding("BINARY"))
 @charset "UTF-8";
 fóó {
   a: b; }
@@ -118,7 +118,7 @@ SASS
   def test_charset_with_special_case_encoding
     # For some reason, a file with an ASCII-compatible UTF-16 charset
     # declaration is specced to be parsed as UTF-8.
-    assert_renders_encoded(<<CSS, <<SASS.force_encoding("BINARY"))
+    assert_renders_encoded(<<CSS, <<SASS.dup.force_encoding("BINARY"))
 @charset "UTF-8";
 fóó {
   a: b; }

--- a/test/sass/source_map_test.rb
+++ b/test/sass/source_map_test.rb
@@ -4,7 +4,7 @@ require File.dirname(__FILE__) + '/test_helper'
 
 class SourcemapTest < MiniTest::Test
   def test_to_json_requires_args
-    _, sourcemap = render_with_sourcemap('')
+    _, sourcemap = render_with_sourcemap(''.dup)
     assert_raises(ArgumentError) {sourcemap.to_json({})}
     assert_raises(ArgumentError) {sourcemap.to_json({:css_path => 'foo'})}
     assert_raises(ArgumentError) {sourcemap.to_json({:sourcemap_path => 'foo'})}
@@ -180,7 +180,7 @@ JSON
   end
 
   def test_different_charset_than_encoding_scss
-    assert_parses_with_sourcemap(<<SCSS.force_encoding("IBM866"), <<CSS, <<JSON)
+    assert_parses_with_sourcemap(<<SCSS.dup.force_encoding("IBM866"), <<CSS, <<JSON)
 @charset "IBM866";
 f\x86\x86 {
   \x86: b;
@@ -203,7 +203,7 @@ JSON
   end
 
   def test_different_charset_than_encoding_sass
-    assert_parses_with_sourcemap(<<SASS.force_encoding("IBM866"), <<CSS, <<JSON, :syntax => :sass)
+    assert_parses_with_sourcemap(<<SASS.dup.force_encoding("IBM866"), <<CSS, <<JSON, :syntax => :sass)
 @charset "IBM866"
 f\x86\x86
   \x86: b
@@ -955,8 +955,8 @@ CSS
     options[:syntax] ||= :scss
     input_filename = filename_for_test(options[:syntax])
     mapping = build_mapping_from_annotations(source, css, input_filename)
-    source.gsub!(ANNOTATION_REGEX, "")
-    css.gsub!(ANNOTATION_REGEX, "")
+    source = source.gsub(ANNOTATION_REGEX, "")
+    css = css.gsub(ANNOTATION_REGEX, "")
     rendered, sourcemap = render_with_sourcemap(source, options)
     assert_equal css.rstrip, rendered.rstrip
     assert_sourcemaps_equal source, css, mapping, sourcemap

--- a/test/sass/util_test.rb
+++ b/test/sass/util_test.rb
@@ -98,11 +98,11 @@ class UtilTest < MiniTest::Test
 
   def test_strip_string_array
     assert_equal(["foo ", " bar ", " baz"],
-      strip_string_array([" foo ", " bar ", " baz "]))
+      strip_string_array([" foo ".dup, " bar ".dup, " baz ".dup]))
     assert_equal([:foo, " bar ", " baz"],
-      strip_string_array([:foo, " bar ", " baz "]))
+      strip_string_array([:foo, " bar ".dup, " baz ".dup]))
     assert_equal(["foo ", " bar ", :baz],
-      strip_string_array([" foo ", " bar ", :baz]))
+      strip_string_array([" foo ".dup, " bar ".dup, :baz]))
   end
 
   def test_paths


### PR DESCRIPTION
These changes get the tests passing when `RUBYOPT="--enable-frozen-string-literal" is set for MRI 2.4.

* There are no behaviour changes here - just modifications of string literal usage.
* I've opted for `dup` over `String.new` - in other patches I've been submitting around this, some maintainers have expressed a strong preference for the former. I'm happy to switch my changes here to `String.new` though if you'd prefer that!
* You're using an old version of rubocop, which is not frozen-string-literal friendly. Even with the latest versions, they're reliant on parser (which isn't, but there's a pending PR), which in turn is reliant on racc (which isn't, and there are some incomplete/forgotten PRs). This means enabling the RUBYOPT flag for MRI 2.4+ isn't going to be an option, unfortunately.
* You're also using an old version of Yard - it should be frozen-string-literal friendly as of 0.9.6.
* I haven't added the pragma comments at the top of all files - though I can do that if you'd like (as a separate PR).