### PR TITLE
Update sass-spec logic in .travis.yml for readability.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,14 @@ cache: bundler
 install:
   # If we're running for a pull request, check out the revision of sass-spec
   # referenced by that pull request.
-  - if-pr() { if [ ! -z "$TRAVIS_PULL_REQUEST" -a "$TRAVIS_PULL_REQUEST" != false ]; then "$@"; fi }
-  - if-pr mkdir sass-spec
-  - if-pr git -C sass-spec init
-  - if-pr git -C sass-spec pull --depth=1 git://github.com/sass/sass-spec `extra/sass-spec-ref.sh`
-  - if-pr bundle config local.sass-spec "`pwd`/sass-spec"
+  - |
+    if [ ! -z "$TRAVIS_PULL_REQUEST" -a "$TRAVIS_PULL_REQUEST" != false ]; then
+      mkdir sass-spec
+      git -C sass-spec init
+      git -C sass-spec pull --depth=1 git://github.com/sass/sass-spec \
+        $(extra/sass-spec-ref.sh)
+      bundle config local.sass-spec "$(pwd)/sass-spec"
+    fi
 
   - bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
   - bundle update sass-spec


### PR DESCRIPTION
Just small modification.
The reason of PR is because I believe that readable `.travis.yml` promotes pull-requests.

YAML block style "|" helps for the readability. :)
I also used "$(STATEMENT) instead of legacy `STATEMENT`".
Ref: https://github.com/koalaman/shellcheck/wiki/Sc2006