### PR TITLE
Fix custom property interpolation

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -3,6 +3,11 @@
 * Table of contents
 {:toc}
 
+## 3.5.2 (Unreleased)
+
+* Properly parse CSS variables that begin with interpolation (for example,
+  `--#{$foo}: ...`).
+
 ## 3.5.1 (13 July 2017)
 
 * Avoid conflicts with the `listen` gem.

--- a/lib/sass/scss/rx.rb
+++ b/lib/sass/scss/rx.rb
@@ -121,7 +121,7 @@ module Sass
       OPTIONAL = /!#{W}optional/i
       IDENT_START = /-|#{NMSTART}/
 
-      IDENT_HYPHEN_INTERP = /-(?=#\{)/
+      IDENT_HYPHEN_INTERP = /-+(?=#\{)/
       STRING1_NOINTERP = /\"((?:[^\n\r\f\\"#]|#(?!\{)|#{ESCAPE})*)\"/
       STRING2_NOINTERP = /\'((?:[^\n\r\f\\'#]|#(?!\{)|#{ESCAPE})*)\'/
       STRING_NOINTERP = /#{STRING1_NOINTERP}|#{STRING2_NOINTERP}/


### PR DESCRIPTION
Interpolation that included the full property name (such as --#{foo})
was crashing the parser.

Closes #2383
See sass/sass-spec#1169