### PR TITLE
Update Travis to 2.2.8, 2.3.5, 2.4.2, add ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,10 @@ install:
 rvm:
   - 2.0.0
   - 2.1.10
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
+  - ruby-head
 gemfile: Gemfile
 branches:
   only:
@@ -28,5 +29,8 @@ branches:
     - stable
     - stable_3_2
     - next
+matrix:
+  allow_failures:
+    - rvm: ruby-head
 notifications:
   irc: {channels: "irc.freenode.org#sass"}


### PR DESCRIPTION
Somewhat in response to [Ruby Core Issue 14106](https://bugs.ruby-lang.org/issues/14106).

Updated versions are available and 'head' will be released soon.

May be an issue with Pathname...