### PR TITLE
Don't modify $stderr in a thread-unsafe way

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -3,6 +3,10 @@
 * Table of contents
 {:toc}
 
+## 3.5.4 (Unreleased)
+
+* Avoid thread-unsafely modifying `$stderr`.
+
 ## 3.5.3 (26 October 2017)
 
 * Generate correct source maps for map literals.

--- a/lib/sass/engine.rb
+++ b/lib/sass/engine.rb
@@ -375,7 +375,7 @@ Error generating source map: couldn't determine public URL for "#{filename}".
   Without a public URL, there's nothing for the source map to link to.
   An importer was not set for this file.
 ERR
-      elsif Sass::Util.silence_warnings do
+      elsif Sass::Util.silence_sass_warnings do
               sourcemap_dir = nil if @options[:sourcemap] == :file
               importer.public_url(filename, sourcemap_dir).nil?
             end

--- a/lib/sass/logger/base.rb
+++ b/lib/sass/logger/base.rb
@@ -22,6 +22,17 @@ class Sass::Logger::Base
     !disabled && self.class.log_level?(level, log_level)
   end
 
+  # Captures all logger messages emitted during a block and returns them as a
+  # string.
+  def capture
+    old_io = io
+    self.io = StringIO.new
+    yield
+    io.to_s
+  ensure
+    self.io = old_io
+  end
+
   def log(level, message)
     _log(level, message) if logging_level?(level)
   end

--- a/lib/sass/tree/rule_node.rb
+++ b/lib/sass/tree/rule_node.rb
@@ -139,13 +139,11 @@ module Sass::Tree
       # We don't use real filename/line info because we don't have it yet.
       # When we get it, we'll set it on the parsed rules if possible.
       parser = nil
-      warnings = Sass::Util.silence_warnings do
+      warnings = Sass.logger.capture do
         parser = Sass::SCSS::StaticParser.new(@rule.join.strip, nil, nil, 1)
         # rubocop:disable RescueModifier
         @parsed_rules = parser.parse_selector rescue nil
         # rubocop:enable RescueModifier
-
-        $stderr.string
       end
 
       # If parsing produces a warning, throw away the result so we can parse

--- a/lib/sass/util.rb
+++ b/lib/sass/util.rb
@@ -451,16 +451,6 @@ module Sass
       Sass::Util.sass_warn full_message
     end
 
-    # Silence all output to STDERR within a block.
-    #
-    # @yield A block in which no output will be printed to STDERR
-    def silence_warnings
-      the_real_stderr, $stderr = $stderr, StringIO.new
-      yield
-    ensure
-      $stderr = the_real_stderr
-    end
-
     # Silences all Sass warnings within a block.
     #
     # @yield A block in which no Sass warnings will be printed

--- a/test/sass/script_test.rb
+++ b/test/sass/script_test.rb
@@ -994,7 +994,7 @@ SCSS
 
   def test_ids
     assert_equal "#foo", resolve("#foo")
-    assert_equal "#abcd", resolve("#abcd")
+    silence_warnings {assert_equal "#abcd", resolve("#abcd")}
     assert_equal "#abc-def", resolve("#abc-def")
     assert_equal "#abc_def", resolve("#abc_def")
     assert_equal "#uvw-xyz", resolve("#uvw-xyz")

--- a/test/sass/util_test.rb
+++ b/test/sass/util_test.rb
@@ -139,16 +139,6 @@ class UtilTest < MiniTest::Test
     assert(!subsequence?([1, 2, 3], [3, 2, 1]))
   end
 
-  def test_silence_warnings
-    old_stderr, $stderr = $stderr, StringIO.new
-    warn "Out"
-    assert_equal("Out\n", $stderr.string)
-    silence_warnings {warn "In"}
-    assert_equal("Out\n", $stderr.string)
-  ensure
-    $stderr = old_stderr
-  end
-
   def test_sass_warn
     assert_warning("Foo!") {sass_warn "Foo!"}
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -74,7 +74,7 @@ class MiniTest::Test
   end
 
   def silence_warnings(&block)
-    Sass::Util.silence_warnings(&block)
+    Sass::Util.silence_sass_warnings(&block)
   end
 
   def assert_raise_message(klass, message)


### PR DESCRIPTION
Rather than mucking with $stderr to capture warnings within a block,
this modifies the thread-local Logger object.

Closes #2414
Closes #2417