### PR TITLE
Don't crash on custom properties without semicolons

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -3,6 +3,10 @@
 * Table of contents
 {:toc}
 
+## 3.5.6 (Unreleased)
+
+* Don't crash on custom properties that aren't followed by semicolons.
+
 ## 3.5.5 (4 January 2018)
 
 * Emit a warning when `&&` is used, since it's probably not what the user means.

--- a/lib/sass/tree/visitors/to_css.rb
+++ b/lib/sass/tree/visitors/to_css.rb
@@ -392,7 +392,8 @@ class Sass::Tree::Visitors::ToCss < Sass::Tree::Visitors::Base
   # @param node [Sass::Script::Tree::PropNode] A custom property node.
   # @return [String]
   def format_custom_property_value(node)
-    if node.style == :compact || node.style == :compressed || !node.resolved_value.include?("\n")
+    value = node.resolved_value.gsub(/\n[ \t\r\f\n]*/, ' ')
+    if node.style == :compact || node.style == :compressed || !value.include?("\n")
       # Folding not involving newlines was done in the parser. We can safely
       # fold newlines here because tokens like strings can't contain literal
       # newlines, so we know any adjacent whitespace is tokenized as whitespace.
@@ -401,7 +402,7 @@ class Sass::Tree::Visitors::ToCss < Sass::Tree::Visitors::Base
 
     # Find the smallest amount of indentation in the custom property and use
     # that as the base indentation level.
-    lines = node.resolved_value.split("\n")
+    lines = value.split("\n")
     indented_lines = lines[1..-1]
     min_indentation = indented_lines.
       map {|line| line[/^[ \t]*/]}.

--- a/lib/sass/tree/visitors/to_css.rb
+++ b/lib/sass/tree/visitors/to_css.rb
@@ -392,7 +392,7 @@ class Sass::Tree::Visitors::ToCss < Sass::Tree::Visitors::Base
   # @param node [Sass::Script::Tree::PropNode] A custom property node.
   # @return [String]
   def format_custom_property_value(node)
-    value = node.resolved_value.gsub(/\n[ \t\r\f\n]*/, ' ')
+    value = node.resolved_value.sub(/\n[ \t\r\f\n]*\Z/, ' ')
     if node.style == :compact || node.style == :compressed || !value.include?("\n")
       # Folding not involving newlines was done in the parser. We can safely
       # fold newlines here because tokens like strings can't contain literal


### PR DESCRIPTION
See sass/sass-spec#1203