### PR TITLE
Improve the output of --version

### DIFF
--- a/lib/sass/exec/sass_scss.rb
+++ b/lib/sass/exec/sass_scss.rb
@@ -92,7 +92,7 @@ END
       end
 
       opts.on("-v", "--version", "Print the Sass version.") do
-        puts("Sass #{Sass.version[:string]}")
+        puts("Ruby Sass #{Sass.version[:string]}")
         exit
       end
     end

--- a/lib/sass/version.rb
+++ b/lib/sass/version.rb
@@ -76,7 +76,6 @@ module Sass
         end
       end
 
-      @@version[:string] << " (#{name})"
       @@version
     end
 


### PR DESCRIPTION
This explicitly says that this is Ruby Sass, and no longer prints the
version name (which isn't being updated any more).