### PR TITLE
Update links to sass/language

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ The process for adding a new feature works as follows:
    elapsed and the Sass team is satisfied that all feedback is addressed, the
    feature moves to step 4.
 
-   [versioning policy]: https://github.com/sass/language#versioning-policy
+   [versioning policy]: README.md#versioning-policy
 
 4. The proposal is marked as accepted and moved into [the `accepted/`
    directory][]. *This doesn't mean that the proposal is immutable*, but it does
@@ -55,7 +55,7 @@ The process for adding a new feature works as follows:
    alongside an implementation helps ensure that the specs are accurate and
    sensible, and that the implementation is correct.
    
-   [the `accepted/` directory]: https://github.com/sass/language/tree/master/accepted
+   [the `accepted/` directory]: accepted
    [specs]: https://github.com/sass/sass-spec
    [Dart Sass]: https://github.com/sass/dart-sass
 
@@ -125,7 +125,7 @@ accepted.
   See [Plain CSS `min()` and `max()`][min-max background] for a good example of
   a Background section.
 
-  [min-max background]: https://github.com/sass/language/blob/master/accepted/min-max.md#background
+  [min-max background]: https://github.com/sass/sass/blob/master/accepted/min-max.md#background
 
 * **Summary**
 
@@ -136,7 +136,7 @@ accepted.
   
   See [Escapes in Identifiers][] for a good example of a Summary section.
 
-  [Escapes in Identifiers]: https://github.com/sass/language/blob/master/accepted/identifier-escapes.md#summary
+  [Escapes in Identifiers]: accepted/identifier-escapes.md#summary
 
   * **Design Decisions**
   
@@ -147,7 +147,7 @@ accepted.
     See [Plain CSS `min()` and `max()`][min-max design] for a good example
     of a Design Decisions section.
     
-    [min-max design]: https://github.com/sass/language/blob/master/accepted/min-max.md#design-decisions
+    [min-max design]: accepted/min-max.md#design-decisions
 
 * **Syntax**
 
@@ -174,7 +174,7 @@ accepted.
 
   See [Range-Context Media Features][] for an good example of a Syntax section.
 
-  [Range-Context Media Features]: https://github.com/sass/language/blob/master/accepted/media-ranges.md
+  [Range-Context Media Features]: accepted/media-ranges.md
 
 * **Semantics**
 
@@ -185,7 +185,7 @@ accepted.
 
   See [CSS Imports][css-imports semantics] for a good example of a Semantics section.
 
-  [css-imports semantics]: https://github.com/sass/language/blob/master/accepted/css-imports.md#semantics
+  [css-imports semantics]: accepted/css-imports.md#semantics
 
 * **Deprecation Process**
 

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ This repository isn't an implementation of Sass. Those live in
 * [`accepted/`][], which contains proposals that have been accepted and are
   either implemented or in the process of being implemented.
 
-[`spec/`]: https://github.com/sass/language/tree/master/spec
-[`proposal/`]: https://github.com/sass/language/tree/master/proposal
-[`accepted/`]: https://github.com/sass/language/tree/master/accepted
+[`spec/`]: https://github.com/sass/sass/tree/master/spec
+[`proposal/`]: https://github.com/sass/sass/tree/master/proposal
+[`accepted/`]: https://github.com/sass/sass/tree/master/accepted
 
 Note that this doesn't contain a full specification of Sass. Instead, feature
 specifications are written as needed when a new feature is being designed or

--- a/accepted/module-system.changes.md
+++ b/accepted/module-system.changes.md
@@ -95,9 +95,7 @@
 ## Draft 3
 
 * Limit extensions to affecting only modules transitively used by the module in
-  which the `@extend` appears ([#6][]).
-
-  [#6]: https://github.com/sass/language/issues/6
+  which the `@extend` appears.
 
 * Replace module mixins with a built-in `load-css()` mixin that dynamically
   includes the CSS for a module with a given URL.
@@ -105,27 +103,15 @@
 * Add support for configuring modules using a new `with` clause.
 
 * Update the `module-variables()` and `module-functions()` functions to return
-  maps from names to values, rather than just lists of names ([#12][]).
-  
-  [#12]: https://github.com/sass/language/issues/12
+  maps from names to values, rather than just lists of names.
 
-* Remove the `module-mixins()` function until Sass supports first-class mixins
-  ([#12][]).
+* Remove the `module-mixins()` function until Sass supports first-class mixins.
 
-* Add support for `_file.import.scss` as a file that only `@import`s will see
-  ([#11][]).
+* Add support for `_file.import.scss` as a file that only `@import`s will see.
 
-  [#11]: https://github.com/sass/language/issues/11
+* Change the syntax for a `@use` rule without a namespace to `@use "..." as *`.
 
-* Change the syntax for a `@use` rule without a namespace to `@use "..." as *`
-  ([#10][]).
-
-  [#10]: https://github.com/sass/language/issues/10
-
-* Initialize modules' variables with the values as declared in those modules
-  ([#13][]).
-
-  [#13]: https://github.com/sass/language/issues/13
+* Initialize modules' variables with the values as declared in those modules.
 
 * Allow comments to be emitted before dependencies' CSS.
 
@@ -140,9 +126,7 @@
 
 * Forbid whitespace in various member-reference productions.
 
-* Explicitly indicate that extensions are dynamically scoped ([#7][]).
-
-  [#7]: https://github.com/sass/language/issues/7
+* Explicitly indicate that extensions are dynamically scoped.
 
 * Explicitly indicate which parts of a module are immutable.
 

--- a/accepted/module-system.md
+++ b/accepted/module-system.md
@@ -8,7 +8,7 @@ hosted on GitHub to encourage community collaboration and contributions. Any
 suggestions or issues can be brought up and discussed on [the issue
 tracker][issues].
 
-[issues]: https://github.com/sass/language/issues?q=is%3Aissue+is%3Aopen+label%3A%22proposal%3A+module+system%22
+[issues]: https://github.com/sass/sass/issues?q=is%3Aissue+is%3Aopen+label%3A%22proposal%3A+module+system%22
 
 Although this document describes some imperative processes when describing the
 semantics of the module system, these aren't meant to prescribe a specific


### PR DESCRIPTION
The repository has been renamed to sass/sass. In most cases, we can just
make these links relative so they'll work regardless of the repo name.

The tests for this are expected to fail, since the proposal/ folder
won't exist on the master branch until this lands.