### PR TITLE
Reconfigurable Modules via "@forward ... with"

### DIFF
--- a/proposal/forward-with.md
+++ b/proposal/forward-with.md
@@ -39,7 +39,7 @@ of the root module, without removing that option for end-users.
 > This section is non-normative.
 
 Sass will add a `with` clause to `@forward`. The `@forward ... with` syntax is
-similar to `@use ... with`, but also allows additional `!default` flags,
+based on the `@use ... with` syntax, but allows the addition of `!default` flags
 similar to a [variable declaration][]. Unlike `@use ... with`, unconfigured
 origin variables, and variables configured with a `!default` flag will remain configurable by any file importing the combined module. For example:
 

--- a/proposal/forward-with.md
+++ b/proposal/forward-with.md
@@ -61,8 +61,10 @@ $saturation: 50% !default;
 // entrypoint.scss
 @use "middleware" with (
   $hue: 120 // override both the origin & middleware !default values
-  // middleware.$saturation will be 70%
 );
+
+// middleware.$hue == 120
+// middleware.$saturation == 70%
 ```
 
 Keyword arguments in the configuration must reference variable names as

--- a/proposal/forward-with.md
+++ b/proposal/forward-with.md
@@ -133,6 +133,7 @@ The new `WithClause` extends `@forward` to the follow grammar:
 The `@forward ... with` semantics builds on the existing proposal for
 [Executing Files][], and should be understood as modifying and expanding upon
 the existing execution process rather than being a comprehensive replacement.
+The `AsClause` logic remains unchanged, but is included here for context.
 
 [Executing Files]: ../accepted/module-system.md#executing-files
 
@@ -141,34 +142,35 @@ Given a source file `file`, a configuration `config`, and an import context
 
 * When a `@forward` rule `rule` is encountered:
 
-  * For each variable `variable` in `config`:
+  * If `rule` has an `AsClause` with identifier `prefix`:
 
     * Let `rule-config` be an empty configuration.
 
-    * If `rule` has an `AsClause` with identifier `prefix`:
+    * For each variable `variable` in `config`:
 
-      * If `variable`'s name begins with `prefix`, let `name` be the portion of
-        `variable`'s name after `prefix`.
+      * If `variable`'s name begins with `prefix`:
 
-    * Otherwise, let `name` be `variable`'s name.
+        * Let `suffix` be the portion of `variable`'s name after `prefix`.
 
-    * Add a variable to `rule-config` with the name `name` and with the
-      same value as `variable`.
+        * Add a variable to `rule-config` with the name `suffix` and with the
+          same value as `variable`.
 
   * Otherwise, let `rule-config` be `config`.
 
   * If `rule` has a `WithClause`:
 
-    * For each `KeywordArgument` `argument` in this clause:
-
-      * Let `value` be the result of evaluating `argument`'s expression.
+    * For each `ForwardWithArgument` `argument` in this clause:
 
       * If a variable exists in `rule-config` with the same name as `argument`'s
         identifier:
 
-        * If `argument` does has a `!default` flag, do nothing.
+        * If `argument` has a `!default` flag, do nothing.
 
         * Otherwise, throw an error.
 
-      * Otherwise, add a variable to `rule-config` with the same name as
-        `argument`'s identifier, and with `value` as its value.
+      * Otherwise:
+
+        * Let `value` be the result of evaluating `argument`'s expression.
+
+        * Add a variable to `rule-config` with the same name as `argument`'s
+          identifier, and with `value` as its value.

--- a/proposal/forward-with.md
+++ b/proposal/forward-with.md
@@ -41,7 +41,8 @@ of the root module, without removing that option for end-users.
 Sass will add a `with` clause to `@forward`. The `@forward ... with` syntax is
 based on the `@use ... with` syntax, but allows the addition of `!default` flags
 similar to a [variable declaration][]. Unlike `@use ... with`, unconfigured
-origin variables, and variables configured with a `!default` flag will remain configurable by any file importing the combined module. For example:
+origin variables, and variables configured with a `!default` flag, will remain
+configurable by any file importing the combined module. For example:
 
 [variable declaration]: https://github.com/sass/sass/blob/master/spec/variables.md#syntax
 

--- a/proposal/forward-with.md
+++ b/proposal/forward-with.md
@@ -154,10 +154,6 @@ Given a source file `file`, a configuration `config`, and an import context
 
     * For each `KeywordArgument` `argument` in this clause:
 
-      * If the public API of the module at `rule`'s URL does not contain a
-        variable with the same name as `argument`'s identifier and a `!default`
-        flag, throw an error.
-
       * Let `value` be the result of evaluating `argument`'s expression.
 
       * Add a variable to `rule-config` with the same name as `argument`'s
@@ -165,6 +161,10 @@ Given a source file `file`, a configuration `config`, and an import context
 
   * Let `module` be the result of [loading][] the module with `rule`'s URL
     and `rule-config`.
+
+  * If `rule` has a `WithClause` that contains any variables that aren't part of
+    `module`'s public API or that weren't declared with a `!default` flag in
+    `module`, throw an error.
 
   * Associate `rule` with `module` in `uses`.
 
@@ -189,10 +189,6 @@ Given a source file `file`, a configuration `config`, and an import context
 
     * For each `ForwardWithArgument` `argument` in this clause:
 
-      * If the public API of the module at `rule`'s URL does not contain a
-        variable with the same name as `argument`'s identifier and a `!default`
-        flag, throw an error.
-
       * If a variable exists in `rule-config` with the same name as `argument`'s
         identifier, do nothing.
 
@@ -205,6 +201,10 @@ Given a source file `file`, a configuration `config`, and an import context
 
   * Let `forwarded` be the result of [loading][] the module with `rule`'s URL
     and `rule-config`.
+
+  * If `rule` has a `WithClause` that contains any variables that aren't part of
+    `forwarded`'s public API or that weren't declared with a `!default` flag in
+    `forwarded`, throw an error.
 
   * [Forward `forwarded`][forwarding] with `file` through `module`.
 

--- a/proposal/forward-with.md
+++ b/proposal/forward-with.md
@@ -141,7 +141,7 @@ Given a source file `file`, a configuration `config`, and an import context
 
 * Let `module` be an empty module with the same URL as `file`.
 
-* Let `uses` be an empty map from `@use` rules to [modules](#module).
+* Let `uses` be an empty map from `@use` rules to [modules][].
 
 * When a `@use` rule `rule` is encountered:
 
@@ -214,5 +214,6 @@ Given a source file `file`, a configuration `config`, and an import context
 
 > From this point on, the logic remains unchanged.
 
+[modules]: ../accepted/module-system.md#module
 [loading]: ../accepted/module-system.md#loading-modules
 [forwarding]: ../accepted/module-system.md#forwarding-modules

--- a/proposal/forward-with.md
+++ b/proposal/forward-with.md
@@ -152,15 +152,15 @@ Given a source file `file`, a configuration `config`, and an import context
 
   * If `rule` has a `WithClause`:
 
-    * Let `target` be the module at `rule`'s URL.
-
     * For each `KeywordArgument` `argument` in this clause:
 
-      * If `target`'s public API does not include a variable with `argument`'s
-        name and a `!default` flag, throw an error.
+      * If the public API of the module at `rule`'s URL does not contain a
+        variable with the same name as `argument`'s identifier and a `!default`
+        flag, throw an error.
 
         > We now check for configuration errors inside each individual
-        > `withClause`, rather than waiting until the target module is execurted.
+        > `withClause`, rather than waiting for execution of the used or
+        > forwarded module. This simplifies thge logic of error-checking.
 
       * Let `value` be the result of evaluating `argument`'s expression.
 
@@ -191,12 +191,11 @@ Given a source file `file`, a configuration `config`, and an import context
 
   * If `rule` has a `WithClause`:
 
-    * Let `target` be the module at `rule`'s URL.
-
     * For each `ForwardWithArgument` `argument` in this clause:
 
-      * If `target`'s public API does not include a variable with the same name
-        as `argument`'s identifier, and a `!default` flag, throw an error.
+      * If the public API of the module at `rule`'s URL does not contain a
+        variable with the same name as `argument`'s identifier and a `!default`
+        flag, throw an error.
 
       * If a variable exists in `rule-config` with the same name as `argument`'s
         identifier, do nothing.

--- a/proposal/forward-with.md
+++ b/proposal/forward-with.md
@@ -1,0 +1,168 @@
+# Reconfigurable Modules via "@forward ... with": Draft 1
+
+*([Issues](https://github.com/sass/sass/issues/2744))*
+
+## Table of Contents
+
+- [Reconfigurable Modules via "@forward ... with": Draft 1](#reconfigurable-modules-via-%22forward--with%22-draft-1)
+  - [Table of Contents](#table-of-contents)
+  - [Background](#background)
+  - [Summary](#summary)
+  - [Syntax](#syntax)
+  - [Semantics](#semantics)
+
+## Background
+
+> This section is non-normative.
+
+In the existing module system each module can only be cofigured once,
+the first time it is used. That works well for direct use of modules,
+but doesn't allow for "middleware" modules to forward pre-configured,
+and re-configurable modules. It is often useful for complex libraries to
+provide a "core" module with unopinionated defaults, and then specialized
+wrapper modules with more opinionated configurations and additional helpers.
+That wrapper package needs to:
+
+1. Set some or all origin-package configurations
+2. Allow the user to *also* set some or all origin-package configurations,
+   along with new middleware configurations
+3. Use the configured origin-package to provide additional members
+   based on the fully-configured origin module
+
+Part 3 should be possible in the existing system by writing the `@forward`
+rules before the `@use` rules, but parts 1 and 2 are not currently possible
+in combination.
+
+This proposal provides a syntax for middleware modules to add configuration
+of the root module, without removing that option for end-users.
+
+## Summary
+
+> This section is non-normative.
+
+Sass will add a `with` clause to `@forward`. The `@forward ... with` syntax is
+similar to `@use ... with`, but also allows additional `!default` flags,
+similar to a [variable declaration][]. Unlike `@use ... with`, unconfigured
+origin variables, and variables configured with a `!default` flag will remain configurable by any file importing the combined module. For example:
+
+[variable declaration]: https://github.com/sass/sass/blob/master/spec/variables.md#syntax
+
+```scss
+// _origin.scss
+$hue: 0 !default;
+$saturation: 50% !default;
+
+// _middleware.scss
+@forward "origin" with (
+  $hue: 330 !default, // Can be overridden by importing users.
+  $saturation: 70% // Cannot be overridden by importing users.
+);
+
+// entrypoint.scss
+@use "middleware" with (
+  $hue: 120 // override both the origin & middleware !default values
+  // middleware.$saturation will be 70%
+);
+```
+
+Keyword arguments in the configuration must reference variable names as
+defined in the forwarded module, regardless of any concurent `as` clause:
+
+```scss
+// _origin.scss
+$hue: 0 !default;
+$color-hex: #ccc !default;
+
+// _middleware.scss
+@forward "origin" as color-* with (
+  $hue: 330, // the color-* prefix is not referenced in configuration
+  $color-hex: #966
+);
+
+// entrypoint.scss
+@use "middleware" as m;
+// m.$color-hue == 330
+// m.$color-hex == #966
+```
+
+A `@forward` rule configuration is applied to the source module even if the
+forwarding module acts as an entrypoint:
+
+```scss
+// _origin.scss
+$hue: 0 !default;
+
+// entrypoint.scss
+@forward "origin" with (
+  $hue: 330 !default
+);
+
+@use "origin"; // origin.$hue == 330
+```
+
+Multiple configurations can be chained in a single cascading "thread" that
+contains zero or more `@forward` rules, and zero or one terminal `@use` rule.
+Variables remain open to configuration in the chain as long as every mention
+includes the `!default` flag:
+
+```scss
+// _origin.scss
+$hue: 0 !default;
+
+// _middle1.scss
+@forward "origin" with (
+  $hue: 330 !default
+);
+
+// _middle2.scss
+@forward "middle1" with (
+  $hue: 120 !default
+);
+
+// entrypoint.scss
+@use "middle2" with (
+  $hue: 30
+);
+
+// middle2.$hue == 30
+```
+
+Multiple threads configuring a single module will cause an error, no matter
+what combinations of `@forward` and `@use` are involved:
+
+```scss
+// _origin.scss
+$hue: 0 !default;
+
+// _middle1.scss
+@forward "origin" with (
+  $hue: 330 !default
+);
+
+// _middle2.scss
+@use "origin" with (
+  $hue: 120
+);
+
+// entrypoint.scss
+@forward "middle1";
+@use "middle2"; // ERROR
+```
+
+## Syntax
+
+The new `WithClause` extends `@forward` to the follow grammar:
+
+<x><pre>
+**ForwardRule**     ::= '@forward' QuotedString AsClause? (ShowClause | HideClause)?  WithClause?
+**AsClause**        ::= 'as' Identifier '*'
+**ShowClause**      ::= 'show' MemberName (',' MemberName)*
+**HideClause**      ::= 'hide' MemberName (',' MemberName)*
+**MemberName**      ::= '$'? Identifier
+**WithClause**      ::= 'with' '('
+&#32;                     KeywordArgument (',' KeywordArgument)\* ','?
+&#32;                   ')'
+**KeywordArgument** ::= '$' Identifier ':' Expression ('!default')
+</pre></x>
+
+## Semantics

--- a/proposal/forward-with.md
+++ b/proposal/forward-with.md
@@ -158,10 +158,6 @@ Given a source file `file`, a configuration `config`, and an import context
         variable with the same name as `argument`'s identifier and a `!default`
         flag, throw an error.
 
-        > We now check for configuration errors inside each individual
-        > `withClause`, rather than waiting for execution of the used or
-        > forwarded module. This simplifies thge logic of error-checking.
-
       * Let `value` be the result of evaluating `argument`'s expression.
 
       * Add a variable to `rule-config` with the same name as `argument`'s

--- a/proposal/forward-with.md
+++ b/proposal/forward-with.md
@@ -125,7 +125,7 @@ The new `WithClause` extends `@forward` to the follow grammar:
 **WithClause**      ::= 'with' '('
 &#32;                     KeywordArgument (',' KeywordArgument)\* ','?
 &#32;                   ')'
-**KeywordArgument** ::= '$' Identifier ':' Expression ('!default')
+**ForwardWithArgument** ::= '$' Identifier ':' Expression '!default'?
 </pre></x>
 
 ## Semantics


### PR DESCRIPTION
This is a (draft) proposal for adding a `with` clause to the `@forward` rule, so that module configurations can be chained together, as per #2744:

```scss
// _origin.scss
$hue: 0 !default;
$saturation: 50% !default;

// _middleware.scss
@forward "origin" with (
  $hue: 330 !default, // Can be overridden by importing users.
  $saturation: 70% // Cannot be overridden by importing users.
);

// entrypoint.scss
@use "middleware" with (
  $hue: 120 // override both the origin & middleware !default values
);

// middleware.$hue == 120
// middleware.$saturation == 70%
```