### PR TITLE
Add nested-map support in sass:map module

### DIFF
--- a/proposal/nested-map-functions.md
+++ b/proposal/nested-map-functions.md
@@ -308,6 +308,8 @@ merge($map1, $args...)
 
 * If either `$map1` or `map2` is not a map, throw an error.
 
+* If `$args` has fewer than two elements, throw an error.
+
 * Let `keys` be a slice of all elements in `$args` except the last.
 
 * Let `sub` be the result of calling `get()` with `$map1` as the first
@@ -323,7 +325,8 @@ merge($map1, $args...)
   * Let `sub-merged` be `map2`.
 
 * Return the result of calling `set()` with `$map1` as the first argument,
-  followed by the contents of `keys` as separate arguments, followed by `sub`.
+  followed by the contents of `keys` as separate arguments, followed by
+  `sub-merged`.
 
 ### `deep-merge()`
 

--- a/proposal/nested-map-functions.md
+++ b/proposal/nested-map-functions.md
@@ -328,29 +328,25 @@ merge($map1, $args...)
 ### `deep-merge()`
 
 ```
-deep-merge($map1, $map2, $maps...)
+deep-merge($map1, $map2)
 ```
 
-* Let `maps` be a list containing `$map1`, `$map2`, and the elements of `$maps`.
+* If `$map1` and `$map2` are not maps, throw an error.
 
-* If any elements in `maps` are not maps, throw an error.
+* Let `merged` be a copy of `$map1`.
 
-* Let `merged` be an empty map.
+* For each `new-key`/`new-value` pair in `$map2`:
 
-* For each `map` in `maps`:
+  * If `merged` has a key `old-key` that's `==` to `new-key`:
 
-  * For each `new-key`/`new-value` pair in `map`:
+    * Let `old-value` be the value associated with `old-key` in `merged`.
 
-    * If `merged` has a key `old-key` that's `==` to `new-key`:
+    * Remove `old-key`/`old-value` from `merged`.
 
-      * Let `old-value` be the value associated with `old-key` in `merged`.
+    * If both `old-value` and `new-value` are maps, set `new-value` to the
+      result of calling `deep-merge()` with `old-value` and `new-value`.
 
-      * Remove `old-key`/`old-value` from `merged`.
-
-      * If both `old-value` and `new-value` are maps, set `new-value` to the
-        result of calling `deep-merge()` with `old-value` and `new-value`.
-
-    * Associate `new-key` with `new-value` in `merged`.
+  * Associate `new-key` with `new-value` in `merged`.
 
 * Return `merged`.
 

--- a/proposal/nested-map-functions.md
+++ b/proposal/nested-map-functions.md
@@ -201,11 +201,13 @@ has-key($map, $keys...)
 
 * If there is more than one element in `$keys`:
 
-  * Let `map` be the value assigned to `key` in `$map`
+  * Let `value` be the value assigned to `key` in `$map`
+
+  * If `value` is not a map, return boolean `false`.
 
   * Let `keys` be all but the first element in `$keys`
 
-  * Call `has-key()` with `map` and expanded `keys` as arguments
+  * Call `has-key()` with `value` and expanded `keys` as arguments
 
 * Otherwise, return boolean `true`
 
@@ -273,8 +275,7 @@ merge($map1, $args...)
 
   * Let `set-args` be the result of appending `sub-merged` to the list `keys`
 
-  * Return the result of calling `set()` with `$map1` and expanded `set-args`
-    as arguments.
+  * Call `set()` with `$map1` and expanded `set-args` as arguments.
 
 * Otherwise:
 

--- a/proposal/nested-map-functions.md
+++ b/proposal/nested-map-functions.md
@@ -1,0 +1,204 @@
+# Nested Map Functions: Draft 1.0
+
+*[(Issue)](https://github.com/sass/sass/issues/1739)*
+
+This proposal updates the built-in `sass:map` module to better support merging,
+setting, and getting items from nested maps.
+
+## Table of Contents
+
+* [Background](#background)
+* [Summary](#summary)
+* [Syntax](#syntax)
+  * [`get()`](#get)
+  * [`has-key()`](#has-key)
+  * [`set()`](#set)
+  * [`merge()`](#merge)
+
+## Background
+
+> This section is non-normative.
+
+The current map inspection and manipulation functions don't provide any built-in
+support for managing nested maps. Projects often build thir own tooling, but
+the results are inconsistent, and often slow.
+
+## Summary
+
+> This section is non-normative.
+
+This proposal updates the `sass:map` module to better support inspection and
+manipulation of nested maps.
+
+The `has-key()` and `get()` functions both accept multiple `$keys...`:
+
+```scss
+@use 'sass:map';
+
+$nav: (
+  'bg': 'gray',
+  'color': (
+    'hover': (
+      'search': yellow,
+      'home': red,
+      'filter': blue,
+    ),
+  ),
+);
+
+$has-search: map.has-key($nav, 'color', 'hover', 'search'); // true
+$search-hover: map.get($nav, 'color', 'hover', 'search'); // yellow
+```
+
+The `merge()` function now accepts multiple `$keys...` between the two maps
+being merged. The keys form a path to the nested location in `$map1` where
+`$map2` should be merged. For example, we update the hover colors in our `$nav`
+map above:
+
+```scss
+@use 'sass:map';
+
+$new-hover: (
+  'search': green,
+  'logo': orange,
+);
+
+$nav: map.merge($nav, 'color', 'hover', $new-hover);
+
+// $nav: (
+//   'bg': 'gray',
+//   'color': (
+//     'hover': (
+//       'search': green,
+//       'home': red,
+//       'filter': blue,
+//       'logo': orange,
+//     ),
+//   ),
+// );
+```
+
+This proposal also adds a `set()` function to `sass:map`, with a similar syntax,
+returning a map with any nested key set to a specific value. To achieve the
+same output as our merge example, we can set each key individually:
+
+```scss
+@use 'sass:map';
+
+$nav: map.set($nav, 'color', 'hover', 'search', green);
+$nav: map.set($nav, 'color', 'hover', 'logo', orange);
+```
+
+## Syntax
+
+### `get()`
+
+```
+get($map, $keys...)
+```
+
+* Let `key` be the first (or only) element in `$keys`
+
+* If `$map` does not have a key with the same name as `key`, throw an error.
+
+* Let `value` be the value assigned to `key` in `$map`
+
+* If there is more than one element in `$keys`:
+
+  * Let `keys` be all elements in `$keys` after the first element
+
+  * Call `get()` with `value` and expanded `keys` as arguments
+
+* Otherwise, return `value`
+
+### `has-key()`
+
+```
+has-key($map, $keys...)
+```
+
+* Let `key` be the first (or only) element in `$keys`
+
+* If `$map` does not have a key with the same name as `key`, return boolean
+  `false`.
+
+* If there is more than one element in `$keys`:
+
+  * Let `map` be the value assigned to `key` in `$map`
+
+  * Let `keys` be all but the first element in `$keys`
+
+  * Call `has-key()` with `map` and expanded `keys` as arguments
+
+* Otherwise, return boolean `true`
+
+### `set()`
+
+```
+set($map1, $keys..., $value)
+```
+
+* If `$map1` is not a map, throw an error.
+
+* If fewer than three arguments are provided, throw an error.
+
+* Let `map` be an empty map .
+
+* If there is more than one argument in arglist `$keys`:
+
+  * Let `set-key` be the first element in `$keys`.
+
+  * Let `keys` be a slice of all `$keys` elements except the first.
+
+  * If `$map1` has a key `current-key` with the same name as `set-key`:
+
+    * Let `current` be the value of `current-key`.
+
+  * Otherwise:
+
+    * Let `current` be an empty map.
+
+  * Let `set-value` be the result of calling `set()` with `current` and expanded
+      `keys` as arguments.
+
+    > This will error if `current` is not a map, but we stil have nested `keys`
+
+* Otherwise:
+
+  * Let `set-key` be the only element in `$keys`
+
+  * Let `set-value` be the value of `$value`
+
+* Add a key with name `set-key` and value `set-value` to `map`
+
+* For each `key`, `value` pair in `$map1`
+
+  * If a key with name `key` already exists in `map`, do nothing.
+
+  * Otherwise, add a key to `map` with name `key` and value `value`.
+
+* Return the value `map`
+
+### `merge()`
+
+```
+merge($map1, $keys..., $map2)
+```
+
+* If only one argument is provided, throw an error.
+
+* If either the first (`$map1`) or last (`$map2`) argument is not a map, throw
+  an error.
+
+* Let `map` be an empty map.
+
+* For each `key`, `new` pair in `$map2`:
+
+  * If `$map1` has a key with the same name as `key`
+
+  * Let `keys` be the result of appending `key` to the argument list `$keys`.
+
+  * Update `map` to be the result of calling `set()` with `map`,
+    expanded `keys`, and `value` as arguments.
+
+* Return the value of `map`


### PR DESCRIPTION
Formal proposal based on discussion in #1739

## Questions raised:

- Is it confusing that the list of `$keys...` in `map.remove()` is used to indicated _multiple keys_ rather than _nested keys_?
- Is there a reason we don't want a function that deep-merges two complex maps with nested values?