### PR TITLE
Better define how numbers work in Sass

### DIFF
--- a/proposal/numbers.md
+++ b/proposal/numbers.md
@@ -56,8 +56,27 @@ if `a == b`, then `b == a` and if `a == b` and `b == c`, then `a == c`.
 Numbers in Sass are *not* necessarily reflexively equal. `NaN == NaN`,
 `Infinity == Infinity`, and `-Infinity == -Infinity` will always be false.
 
-In the case that two numbers use more than 10 decimal places of precision,
-both numbers are truncated to 10 decimal places and compared.
+In the case that two numbers differ only in their 11th or later digits after
+the decimal point, both numbers are truncated to 10 decimal places and compared.
+
+For example,
+
+```
+These two numbers differ *before* the 10th decimal place, so they should be considered
+unequal
+1.0000000010 == 1.0000000020
+  ---------^      ---------^
+
+These two numbers differ *at* the 10th decimal place, so they should be considered
+unequal
+1.0000000001 == 1.0000000002
+  ---------^      ---------^
+
+These two numbers differ only *beyond* the 10th decimal place, so they should be considered
+equal
+1.00000000001 == 1.00000000002
+  ---------^       ---------^
+```
 
 ### Ordering
 

--- a/proposal/numbers.md
+++ b/proposal/numbers.md
@@ -56,8 +56,7 @@ if `a == b`, then `b == a` and if `a == b` and `b == c`, then `a == c`.
 Numbers in Sass are *not* necessarily reflexively equal. `NaN == NaN`,
 `Infinity == Infinity`, and `-Infinity == -Infinity` will always be false.
 
-In the case that two numbers differ only in their 11th or later digits after
-the decimal point, both numbers are rounded to 10 decimal places and compared.
+Two numbers are considered equal if they do no differ when rounded to 10 decimal places.
 
 > For example,
 > 

--- a/proposal/numbers.md
+++ b/proposal/numbers.md
@@ -57,7 +57,7 @@ Numbers in Sass are *not* necessarily reflexively equal. `NaN == NaN`,
 `Infinity == Infinity`, and `-Infinity == -Infinity` will always be false.
 
 In the case that two numbers differ only in their 11th or later digits after
-the decimal point, both numbers are truncated to 10 decimal places and compared.
+the decimal point, both numbers are rounded to 10 decimal places and compared.
 
 For example,
 
@@ -83,7 +83,7 @@ equal
 Numbers in Sass do not have total ordering. Any comparison to `NaN` will return false.
 Otherwise, ordering follows what would be expected when comparing two numbers.
 
-Numbers with more than 10 decimal places are truncated to 10 places before comparison.
+Numbers with more than 10 decimal places are rounded to 10 places before comparison.
 
 ### Hashing
 

--- a/proposal/numbers.md
+++ b/proposal/numbers.md
@@ -9,11 +9,13 @@ This proposal formally defines all numbers in Sass to be double-precision or 64-
 - [Floating Point Numbers: Draft 1.0](#floating-point-numbers-draft-10)
   - [Table of Contents](#table-of-contents)
   - [Background](#background)
-  - [Division by Zero](#division-by-zero)
-  - [Equality](#equality)
-  - [Ordering](#ordering)
-  - [Hashing](#hashing)
-  - [Formatting](#formatting)
+  - [Summary]()
+  - [Semantics](#semantics)
+    - [Division by Zero](#division-by-zero)
+    - [Equality](#equality)
+    - [Ordering](#ordering)
+    - [Hashing](#hashing)
+    - [Formatting](#formatting)
 
 ## Background
 
@@ -29,7 +31,16 @@ and [crashes](https://github.com/sass/dart-sass/issues/1059) for `dart-sass`.
 
 This document serves to unify these edge cases and resolve existing issues within implementations.
 
-## Division by Zero
+## Semantics
+
+This proposal formally defines all numbers in Sass to be double-precision or 64-bit floating point numbers.
+
+More specifically, numbers are represented as [IEEE 754-2008 "binary64" floating point numbers](https://web.archive.org/web/20190820164556/http://www.dsc.ufcg.edu.br/~cnum/modulos/Modulo2/IEEE754_2008.pdf).
+
+The semantics enumerated here serve to more succintly describe their behavior and
+to highlight Sass-specific behavior.
+
+### Division by Zero
 
 Any positive number divided by zero will return `Infinity`
 
@@ -37,7 +48,7 @@ Zero divided by zero will return `NaN`
 
 Any negative number divided by zero will return `-Infinity`
 
-## Equality
+### Equality
 
 Numbers in Sass are symmetrically and transitively equal. That is,
 if `a == b`, then `b == a` and if `a == b` and `b == c`, then `a == c`.
@@ -48,14 +59,14 @@ Numbers in Sass are *not* necessarily reflexively equal. `NaN == NaN`,
 In the case that two numbers use more than 10 decimal places of precision,
 both numbers are truncated to 10 decimal places and compared.
 
-## Ordering
+### Ordering
 
 Numbers in Sass do not have total ordering. Any comparison to `NaN` will return false.
 Otherwise, ordering follows what would be expected when comparing two numbers.
 
 Numbers with more than 10 decimal places are truncated to 10 places before comparison.
 
-## Hashing
+### Hashing
 
 The non-reflexive nature of number equality in Sass makes it difficult to
 use floating point numbers as keys inside maps. This property means
@@ -68,7 +79,7 @@ In order to support numbers as map keys, a Sass implementation must
  - deny `NaN`, `Infinity`, and `-Infinity` as keys
  - truncate all numbers to 10 decimal places before insertion
 
-## Formatting
+### Formatting
 
 In order to emit a number:
  - Round the number to 10 decimal places

--- a/proposal/numbers.md
+++ b/proposal/numbers.md
@@ -23,7 +23,7 @@ Numbers in Sass today are ill-defined. Between implementations there
 is very little agreement around edge cases, and there are few spec tests
 exercising these cases.
 
-The behavior of `dart-sass` and `libsass`, the two officially "blessed" implementations
+The behavior of `dart-sass` and `libsass`, the two major implementations
 at the time of writing, differ greatly with regard to numeric equality, rounding, and overflows.
 
 Additionally, this lack of definition has caused both [regressions](https://github.com/sass/dart-sass/issues/807)
@@ -104,31 +104,27 @@ In order to emit a number:
  - Round the number to 10 decimal places
  - Remove trailing zeros
  - If the number is negative and non-zero, emit a negative sign, `-`
- - If in compressed mode:
-   - If the whole number is zero, do nothing
-   - Otherwise, emit the whole number
- - Otherwise, if in expanded mode:
-   - Emit the whole number
+ - Emit the whole number
  - If the decimal portion is non-zero, emit the decimal portion
 
 `NaN`, `Infinity`, and `-Infinity` are emitted as written.
 
-| As written in Sass | As emitted in expanded mode | As emitted in compressed mode |
-| ------------------ | --------------------------- | ----------------------------- |
-| 0                  | 0                           | 0                             |
-| 0.0                | 0                           | 0                             |
-| -0                 | 0                           | 0                             |
-| -0.0               | 0                           | 0                             |
-| 1                  | 1                           | 1                             |
-| 1.0                | 1                           | 1                             |
-| -1                 | -1                          | -1                            |
-| -1.0               | -1                          | -1                            |
-| 0.1                | 0.1                         | .1                            |
-| -0.1               | -0.1                        | -.1                           |
-| .1                 | 0.1                         | .1                            |
-| -.1                | -0.1                        | -.1                           |
-| 1.1                | 1.1                         | 1.1                           |
-| -1.1               | -1.1                        | -1.1                          |
-| NaN                | NaN                         | NaN                           |
-| Infinity           | Infinity                    | Infinity                      |
-| -Infinity          | -Infinity                   | -Infinity                     |
+| As written in Sass | As emitted in expanded mode |
+| ------------------ | --------------------------- |
+| 0                  | 0                           |
+| 0.0                | 0                           |
+| -0                 | 0                           |
+| -0.0               | 0                           |
+| 1                  | 1                           |
+| 1.0                | 1                           |
+| -1                 | -1                          |
+| -1.0               | -1                          |
+| 0.1                | 0.1                         |
+| -0.1               | -0.1                        |
+| .1                 | 0.1                         |
+| -.1                | -0.1                        |
+| 1.1                | 1.1                         |
+| -1.1               | -1.1                        |
+| NaN                | NaN                         |
+| Infinity           | Infinity                    |
+| -Infinity          | -Infinity                   |

--- a/proposal/numbers.md
+++ b/proposal/numbers.md
@@ -1,0 +1,104 @@
+# Floating Point Numbers: Draft 1.0
+
+*[(Issue)](https://github.com/sass/sass/issues/2892)*
+
+This proposal formally defines all numbers in Sass to be double-precision or 64-bit floating point numbers.
+
+## Table of Contents
+
+- [Floating Point Numbers: Draft 1.0](#floating-point-numbers-draft-10)
+  - [Table of Contents](#table-of-contents)
+  - [Background](#background)
+  - [Division by Zero](#division-by-zero)
+  - [Equality](#equality)
+  - [Ordering](#ordering)
+  - [Hashing](#hashing)
+  - [Formatting](#formatting)
+
+## Background
+
+Numbers in Sass today are ill-defined. Between implementations there
+is very little agreement around edge cases, and there are few spec tests
+exercising these cases.
+
+The behavior of `dart-sass` and `libsass`, the two officially "blessed" implementations
+at the time of writing, differ greatly with regard to numeric equality, rounding, and overflows.
+
+Additionally, this lack of definition has caused both [regressions](https://github.com/sass/dart-sass/issues/807)
+and [crashes](https://github.com/sass/dart-sass/issues/1059) for `dart-sass`.
+
+This document serves to unify these edge cases and resolve existing issues within implementations.
+
+## Division by Zero
+
+Any positive number divided by zero will return `Infinity`
+
+Zero divided by zero will return `NaN`
+
+Any negative number divided by zero will return `-Infinity`
+
+## Equality
+
+Numbers in Sass are symmetrically and transitively equal. That is,
+if `a == b`, then `b == a` and if `a == b` and `b == c`, then `a == c`.
+
+Numbers in Sass are *not* necessarily reflexively equal. `NaN == NaN`,
+`Infinity == Infinity`, and `-Infinity == -Infinity` will always be false.
+
+In the case that two real numbers use more than 10 decimal places of precision,
+both numbers are truncated to 10 decimal places and compared.
+
+## Ordering
+
+Numbers in Sass do not have total ordering. Any comparison to `NaN` will return false.
+Otherwise, ordering follows what would be expected when comparing two real numbers.
+
+Real numbers with more than 10 decimal places are truncated to 10 places before comparison.
+
+## Hashing
+
+The non-reflexive nature of number equality in Sass makes it difficult to
+use floating point numbers as keys inside maps. This property means
+that `hash(a)` does not necessarily equal `hash(a)`.
+
+Despite this, it is desirable for users to be able to use numbers as map keys,
+and dropping support for numbers as map keys would break backwards compatibility.
+
+In order to support numbers as map keys, a Sass implementation must
+ - deny `NaN`, `Infinity`, and `-Infinity` as keys
+ - truncate all numbers to 10 decimal places before insertion
+
+## Formatting
+
+In order to emit a real number:
+ - Round the number to 10 decimal places
+ - Remove trailing zeros
+ - If the number is negative and non-zero, emit a negative sign, `-`
+ - If in compressed mode:
+   - If the whole number is zero, do nothing
+   - Otherwise, emit the whole number
+ - Otherwise, if in expanded mode:
+   - Emit the whole number
+ - If the decimal portion is non-zero, emit the decimal portion
+
+`NaN`, `Infinity`, and `-Infinity` are emitted as written.
+
+| As written in Sass | As emitted in expanded mode | As emitted in compressed mode |
+| ------------------ | --------------------------- | ----------------------------- |
+| 0                  | 0                           | 0                             |
+| 0.0                | 0                           | 0                             |
+| -0                 | 0                           | 0                             |
+| -0.0               | 0                           | 0                             |
+| 1                  | 1                           | 1                             |
+| 1.0                | 1                           | 1                             |
+| -1                 | -1                          | -1                            |
+| -1.0               | -1                          | -1                            |
+| 0.1                | 0.1                         | .1                            |
+| -0.1               | -0.1                        | -.1                           |
+| .1                 | 0.1                         | .1                            |
+| -.1                | -0.1                        | -.1                           |
+| 1.1                | 1.1                         | 1.1                           |
+| -1.1               | -1.1                        | -1.1                          |
+| NaN                | NaN                         | NaN                           |
+| Infinity           | Infinity                    | Infinity                      |
+| -Infinity          | -Infinity                   | -Infinity                     |

--- a/proposal/numbers.md
+++ b/proposal/numbers.md
@@ -75,9 +75,9 @@ that `hash(a)` doesn't necessarily equal `hash(b)` even if `a == b`.
 Despite this, it is desirable for users to be able to use numbers as map keys,
 and dropping support for numbers as map keys would break backwards compatibility.
 
-In order to support numbers as map keys, a Sass implementation must
- - deny `NaN`, `Infinity`, and `-Infinity` as keys
- - truncate all numbers to 10 decimal places before insertion
+In order to support numbers as map keys, a Sass implementation must raise an error when
+trying to construct a map with, insert into (`map-insert`), retrieve (`map-get`) or remove (`map-remove`)
+from a map any of `NaN`, `Infinity`, or `-Infinity`.
 
 ### Formatting
 

--- a/proposal/numbers.md
+++ b/proposal/numbers.md
@@ -70,7 +70,7 @@ Numbers with more than 10 decimal places are truncated to 10 places before compa
 
 The non-reflexive nature of number equality in Sass makes it difficult to
 use floating point numbers as keys inside maps. This property means
-that `hash(a)` does not necessarily equal `hash(a)`.
+that `hash(a)` doesn't necessarily equal `hash(b)` even if `a == b`.
 
 Despite this, it is desirable for users to be able to use numbers as map keys,
 and dropping support for numbers as map keys would break backwards compatibility.

--- a/proposal/numbers.md
+++ b/proposal/numbers.md
@@ -45,15 +45,15 @@ if `a == b`, then `b == a` and if `a == b` and `b == c`, then `a == c`.
 Numbers in Sass are *not* necessarily reflexively equal. `NaN == NaN`,
 `Infinity == Infinity`, and `-Infinity == -Infinity` will always be false.
 
-In the case that two real numbers use more than 10 decimal places of precision,
+In the case that two numbers use more than 10 decimal places of precision,
 both numbers are truncated to 10 decimal places and compared.
 
 ## Ordering
 
 Numbers in Sass do not have total ordering. Any comparison to `NaN` will return false.
-Otherwise, ordering follows what would be expected when comparing two real numbers.
+Otherwise, ordering follows what would be expected when comparing two numbers.
 
-Real numbers with more than 10 decimal places are truncated to 10 places before comparison.
+Numbers with more than 10 decimal places are truncated to 10 places before comparison.
 
 ## Hashing
 
@@ -70,7 +70,7 @@ In order to support numbers as map keys, a Sass implementation must
 
 ## Formatting
 
-In order to emit a real number:
+In order to emit a number:
  - Round the number to 10 decimal places
  - Remove trailing zeros
  - If the number is negative and non-zero, emit a negative sign, `-`

--- a/proposal/numbers.md
+++ b/proposal/numbers.md
@@ -59,24 +59,22 @@ Numbers in Sass are *not* necessarily reflexively equal. `NaN == NaN`,
 In the case that two numbers differ only in their 11th or later digits after
 the decimal point, both numbers are rounded to 10 decimal places and compared.
 
-For example,
-
-```
-These two numbers differ *before* the 10th decimal place, so they should be considered
-unequal
-1.0000000010 == 1.0000000020
-  ---------^      ---------^
-
-These two numbers differ *at* the 10th decimal place, so they should be considered
-unequal
-1.0000000001 == 1.0000000002
-  ---------^      ---------^
-
-These two numbers differ only *beyond* the 10th decimal place, so they should be considered
-equal
-1.00000000001 == 1.00000000002
-  ---------^       ---------^
-```
+> For example,
+> 
+> These two numbers differ *before* the 10th decimal place, so they should be considered
+> unequal
+> 1.0000000010 == 1.0000000020
+>   ---------^      ---------^
+> 
+> These two numbers differ *at* the 10th decimal place, so they should be considered
+> unequal
+> 1.0000000001 == 1.0000000002
+>   ---------^      ---------^
+> 
+> These two numbers differ only *beyond* the 10th decimal place, so they should be considered
+> equal
+> 1.00000000001 == 1.00000000002
+>   ---------^       ---------^
 
 ### Ordering
 


### PR DESCRIPTION
Resolves #2892

This serves to better define the edge cases regarding numbers in Sass and formally moves all numbers to be represented as 64-bit floating point real numbers. 

This is largely a description of how numbers currently work in `dart-sass`; however, this document suggests denying `NaN`, `Infinity`, and `-Infinity` as map keys. These values are currently de facto denied as map keys in `dart-sass` due to [a crash](https://github.com/sass/dart-sass/issues/1059), but `libsass` does allow them.

Interestingly, `libsass` will also treat `NaN` and `Infinity` as equal to themselves, causing `(1/0) == (2/0)` to be `true` and making it possible to use `NaN` to retrieve values from maps. Irrespective of this document, this behavior is considered a bug (or at the very least a deviation from `dart-sass`). This behavior is tracked in https://github.com/sass/libsass/issues/3126. 

Units are deliberately left out of this document, though could certainly be taken into consideration.

