### PR TITLE
[Supports General] Mark InterpolatedAnyValue productions as optional

### DIFF
--- a/accepted/supports-general.changes.md
+++ b/accepted/supports-general.changes.md
@@ -1,0 +1,9 @@
+## Draft 2
+
+* Mark the `InterpolatedAnyValue` productions as optional. According to Tab
+  Atkins, this matches the intended (although not the written) syntax of the
+  CSS spec.
+
+## Draft 1
+
+* Initial draft.

--- a/accepted/supports-general.changes.md
+++ b/accepted/supports-general.changes.md
@@ -4,6 +4,9 @@
   Atkins, this matches the intended (although not the written) syntax of the
   CSS spec.
 
+* Add `Interpolation` as an option for `SupportsInParens`, for
+  backwards-compatibility with existing Sass behavior.
+
 ## Draft 1
 
 * Initial draft.

--- a/accepted/supports-general.md
+++ b/accepted/supports-general.md
@@ -1,6 +1,6 @@
-# `@supports` `<general-enclosed>`: Draft 1.0
+# `@supports` `<general-enclosed>`: Draft 2.0
 
-*([Issue](https://github.com/sass/sass/issues/2780))*
+*([Issue](https://github.com/sass/sass/issues/2780), [Changelog](supports-general.changes.md))*
 
 This proposal defines how Sass parses supports queries that use the
 [`<general-enclosed>`][] production.
@@ -139,8 +139,8 @@ ambiguous with a declaration and thus with raw SassScript.
 **SupportsInParens**    ::= '(' (SupportsCondition | SupportsDeclaration | SupportsAnything) ')'
 &#32;                     | SupportsFunction
 **SupportsDeclaration** ::= Expression¹ ':' Expression
-**SupportsAnything**    ::= [InterpolatedIdentifier][]² [InterpolatedAnyValue][]³
-**SupportsFunction**    ::= [InterpolatedIdentifier][]⁴ '(' [InterpolatedAnyValue][] ')'
+**SupportsAnything**    ::= [InterpolatedIdentifier][]² [InterpolatedAnyValue][]³?
+**SupportsFunction**    ::= [InterpolatedIdentifier][]⁴ '(' [InterpolatedAnyValue][]? ')'
 </pre></x>
 
 [InterpolatedIdentifier]: ../spec/syntax.md#interpolatedidentifier

--- a/accepted/supports-general.md
+++ b/accepted/supports-general.md
@@ -137,7 +137,7 @@ ambiguous with a declaration and thus with raw SassScript.
 &#32;                     | SupportsInParens ('and' SupportsInParens)*
 &#32;                     | SupportsInParens ('or' SupportsInParens)*
 **SupportsInParens**    ::= '(' (SupportsCondition | SupportsDeclaration | SupportsAnything) ')'
-&#32;                     | SupportsFunction
+&#32;                     | SupportsFunction | Interpolation
 **SupportsDeclaration** ::= Expression¹ ':' Expression
 **SupportsAnything**    ::= [InterpolatedIdentifier][]² [InterpolatedAnyValue][]³?
 **SupportsFunction**    ::= [InterpolatedIdentifier][]⁴ '(' [InterpolatedAnyValue][]? ')'


### PR DESCRIPTION
According to @tabatkins, this matches the intended CSS syntax. The
syntax as written in the current drafts is mistaken in disallowing
empty values here.