### PR TITLE
[Supports General] Disambiguate SupportsCondition/SupportsAnything

### DIFF
--- a/accepted/supports-general.changes.md
+++ b/accepted/supports-general.changes.md
@@ -1,3 +1,9 @@
+## Draft 2.1
+
+* Forbid `"and"` or `"or"` tokens at the beginning of `InterpolatedAnyValue` in
+  `SupportsAnything`. This makes more explicit the fact that the
+  `SupportsCondition` parsing takes precedence.
+
 ## Draft 2
 
 * Mark the `InterpolatedAnyValue` productions as optional. According to Tab

--- a/accepted/supports-general.md
+++ b/accepted/supports-general.md
@@ -1,4 +1,4 @@
-# `@supports` `<general-enclosed>`: Draft 2.0
+# `@supports` `<general-enclosed>`: Draft 2.1
 
 *([Issue](https://github.com/sass/sass/issues/2780), [Changelog](supports-general.changes.md))*
 
@@ -151,7 +151,8 @@ ambiguous with a declaration and thus with raw SassScript.
 
 2: This `InterpolatedIdentifier` may not be the identifier `"not"`.
 
-3: This `InterpolatedAnyValue` may not contain a top-level `":"`.
+3: This `InterpolatedAnyValue` may not contain a top-level `":"`, and it may not
+begin with the identifier tokens `"and"` or `"or"`.
 
 4: This `InterpolatedIdentifier` may not be the identifier `"not"`. No
 whitespace is allowed between it and the following `"("`.


### PR DESCRIPTION
Within parentheses, a production like `#{$value} and ...` could be parsed as either branch, but *should* be parsed as a `SupportsCondition`.

See #2780