### PR TITLE
Spec the @for at-rule

### DIFF
--- a/spec/at-rules/for.md
+++ b/spec/at-rules/for.md
@@ -1,0 +1,61 @@
+# `@for`
+
+## Table of Contents
+
+* [Syntax](#syntax)
+* [Semantics](#semantics)
+
+## Syntax
+
+<x><pre>
+**ForRule**            ::= '@for' [PlainVariable][] FromDeclaration
+&#32;                      (ToDeclaration | ThroughDeclaration) ForBlock
+**FromDeclaration**    ::= 'from' Expression
+**ToDeclaration**      ::= 'to' Expression
+**ThroughDeclaration** ::= 'through' Expression
+**ForBlock**           ::= '{' Statements '}'
+</pre></x>
+
+[PlainVariable]: ../variables.md#syntax
+
+## Semantics
+
+To execute a `@for` rule `rule`:
+
+* Let `from` be the result of evaluating the expression in `FromDeclaration`.
+
+* If `rule` has a `ToDeclaration`:
+
+  * Let `to` be the result of evaluating the expression in `ToDeclaration`.
+
+  * Let `exclusive` be `true`.
+  
+* Otherwise:
+
+  * Let `to` be the result of evaluating the expression in `ThroughDeclaration`.
+
+  * Let `exclusive` be `false`.
+  
+* If `from` and `to` aren't numbers, throw an error.
+
+* If `from` and `to` aren't integers, throw an error.
+
+* If `from` is greater than `to`, set `direction` to `-1`. Otherwise, set
+  `direction` to `1`.
+
+* If `exclusive` is `false`, set `to` to `to + direction`.
+
+* Let `i` be `from`.
+
+* While `i` is not equal to `to`:
+
+  * Let `scope` be a new [scope].
+
+  * Add a variable with `rule`'s `VariableName` as its name and `i` as its value
+    to `scope`.
+  
+  * Execute the `ForBlock`'s statements in `scope`.
+  
+  * Set `i` to `i + direction`.
+
+  [scope]: ../variables.md#scope

--- a/spec/at-rules/mixin.md
+++ b/spec/at-rules/mixin.md
@@ -52,7 +52,7 @@ To execute a `@mixin` rule `rule`:
 
 <x><pre>
 **IncludeRule**      ::= '@include' [NamespacedIdentifier][] ArgumentInvocation?
-                         ContentBlock?
+&#32;                    ContentBlock?
 **ContentBlock**     ::= UsingDeclaration? '{' Statements '}'
 **UsingDeclaration** ::= 'using' ArgumentDeclaration
 </pre></x>

--- a/spec/variables.md
+++ b/spec/variables.md
@@ -9,21 +9,22 @@
 * [Semantics](#semantics)
   * [Executing a Variable Declaration](#executing-a-variable-declaration)
   * [Evaluating a Variable](#evaluating-a-variable)
-  
+
 ## Syntax
 
 <x><pre>
-**Variable**            ::= '$' Identifier | NamespacedVariable
+**Variable**            ::= PlainVariable | NamespacedVariable
+**PlainVariable**       ::= '$' Identifier
 **NamespacedVariable**  ::= Identifier '.$' [PublicIdentifier][]
 **VariableDeclaration** ::= Variable ':' Expression ('!global' | '!default')*
 </pre></x>
 
 [PublicIdentifier]: modules.md#syntax
 
-No whitespace is allowed after the `$` or before or after the `.$` in
-`Variable`. Each of `!global` and `!default` is allowed at most once in
-`VariableDeclaration`. As with all statements, a `VariableDeclaration` must be
-separated from other statements with a semicolon.
+No whitespace is allowed after the `$` in `PlainVariable` or before or after
+the `.$` in `NamespacedVariable`. Each of `!global` and `!default` is allowed
+at most once in `VariableDeclaration`. As with all statements, a
+`VariableDeclaration` must be separated from other statements with a semicolon.
 
 ## Definitions
 


### PR DESCRIPTION
As a basis for the fast-track proposal in #2931, this writes specs for the `@for` at-rule.

I intentionally skipped any mention of the unit conversion for `from` and `to`, because dart-sass, libsass and ruby-sass have 3 different behaviors for it (which is precisely what #2931 is meant to solve).
Implementing strictly the spec as written here would probably produce the libsass behavior (relying on the fact that adding a unitless number to a number with unit is allowed in Sass and produces a number with that unit). Specifying the ruby-sass behavior is a matter of adding a step ``Convert `to` to `from`'s unit`` before asserting that both values are integers (but currently, dart-sass does the conversion the other way, which is why I prefer keeping this line as part of the proposal instead). Spec'ing the existing dart-sass behavior would make the spec more complex for something that would have to be reverted by the proposal anyway (converting numbers to strip the unit for the loop variable).