### PR TITLE
Use relative links whenever possible

### DIFF
--- a/accepted/content-args.md
+++ b/accepted/content-args.md
@@ -70,7 +70,7 @@ decided that it was both semantically ambiguous and confusing because the
 [module system proposal][] uses to declare an argument *invocation* rather than
 an argument *declaration*.
 
-[module system proposal]: https://github.com/sass/sass/blob/master/accepted/module-system.md
+[module system proposal]: module-system.md
 
 ## Syntax
 

--- a/accepted/css-imports.md
+++ b/accepted/css-imports.md
@@ -9,7 +9,7 @@ until the [module system][] was in place and support CSS imports only with
 compatibility with the existing LibSass implementation. See
 [Background](#background) for more details.
 
-[module system]: https://github.com/sass/sass/blob/master/accepted/module-system.md
+[module system]: module-system.md
 
 ## Table of Contents
 

--- a/accepted/forward-with.md
+++ b/accepted/forward-with.md
@@ -45,7 +45,7 @@ similar to a [variable declaration][]. Unlike `@use ... with`, unconfigured
 origin variables, and variables configured with a `!default` flag, will remain
 configurable by any file importing the combined module. For example:
 
-[variable declaration]: https://github.com/sass/sass/blob/master/spec/variables.md#syntax
+[variable declaration]: ../spec/variables.md#syntax
 
 ```scss
 // _origin.scss

--- a/accepted/media-ranges.md
+++ b/accepted/media-ranges.md
@@ -85,7 +85,7 @@ The `<mf-comparison>`, `<mf-lt>`, and `<mf-gt>` productions are defined in
 > according to the level 4 specification, since no browsers support it yet. See
 > [sass/sass#2538][] for details.
 
-[sass/sass#2538]: https://GitHub.com/sass/sass/issues/2538
+[sass/sass#2538]: https://github.com/sass/sass/issues/2538
 
 ### CSS
 

--- a/spec/at-rules/media.md
+++ b/spec/at-rules/media.md
@@ -48,7 +48,7 @@ function calls and map literals) and square brackets.
 > according to the level 4 specification, since no browsers support it yet. See
 > [sass/sass#2538][] for details.
 
-[sass/sass#2538]: https://GitHub.com/sass/sass/issues/2538
+[sass/sass#2538]: https://github.com/sass/sass/issues/2538
 
 ### CSS
 


### PR DESCRIPTION
This reduces the number of github.com links and so the risk of hitting the rate limit while running tests (which slows things down).

I also normalized some links to use a lowercase `github.com` domain name