### PR TITLE
Add a fromImport flag to JS API importers' `this` context

### DIFF
--- a/spec/js-api.md
+++ b/spec/js-api.md
@@ -22,26 +22,32 @@ only written when they're necessary as background for new API proposals.
 ### `this` Context
 
 When running an importer callback, JavaScript's `this` must refer to an object
-with an `options` field. This field's value must be an object with the following
-fields:
+with the following fields:
 
-* `file`: The `file` option passed to the `render()` call.
-* `data`: The `data` option passed to the `render()` call.
-* `includePaths`: A string that contains the current working directory followed
-  by strings passed in the `includePaths` option, separated by `";"` on Windows
-  and `":"` elsewhere.
-* `precision`: The number 10.
-* `style`: An integer. The specific semantics of this are left up to the
-  implementation. (The reference implementation always returns 1.)
-* `indentType`: The number 1 if the `indentType` option was `tab`. The number 0
-  otherwise.
-* `indentWidth`: An integer indicating the number of spaces or tabs emitted by
-  the compiler for each level of indentation.
-* `linefeed`: A string indicating the linefeed character or character sequence
-  emitted by the compiler at the end of each line.
-* `result`: An object with a `stats` field, whose value is an object with the
-  following fields:
-  * `start`: The number of milliseconds since the Unix epoch (1 January 1970
-    00:00:00 UT) at the point at which the user called `render()`.
-  * `entry`: The `file` option passed to the `render()` call, or the string
-    `"data"` if no file was passed.
+* An `options` field that's an object with the following fields:
+  * `file`: The `file` option passed to the `render()` call.
+  * `data`: The `data` option passed to the `render()` call.
+  * `includePaths`: A string that contains the current working directory
+    followed by strings passed in the `includePaths` option, separated by `";"`
+    on Windows and `":"` elsewhere.
+  * `precision`: The number 10.
+  * `style`: An integer. The specific semantics of this are left up to the
+    implementation. (The reference implementation always returns 1.)
+  * `indentType`: The number 1 if the `indentType` option was `tab`. The number
+    0 otherwise.
+  * `indentWidth`: An integer indicating the number of spaces or tabs emitted by
+    the compiler for each level of indentation.
+  * `linefeed`: A string indicating the linefeed character or character sequence
+    emitted by the compiler at the end of each line.
+  * `result`: An object with a `stats` field, whose value is an object with the
+    following fields:
+    * `start`: The number of milliseconds since the Unix epoch (1 January 1970
+      00:00:00 UT) at the point at which the user called `render()`.
+    * `entry`: The `file` option passed to the `render()` call, or the string
+      `"data"` if no file was passed.
+
+* A `fromImport` field that's `true` if the import came from an `@import`
+  statement and `false` otherwise.
+
+  > This allows importers to look for `.import.scss` stylesheets if and only if
+  > an `@import` is being resolved.


### PR DESCRIPTION
This is a fast-track proposal.

See webpack-contrib/sass-loader#905