### PR TITLE
Backport the quietDeps and verbose flags to the old JS API

### DIFF
--- a/spec/js-api.d.ts
+++ b/spec/js-api.d.ts
@@ -51,6 +51,25 @@ export interface _Options<sync = 'sync' | 'async'> {
   sourceMapRoot?: string;
   importer?: Importer<sync> | Importer<sync>[];
   functions?: {[key: string]: CustomFunction<sync>};
+
+  /**
+   * If true, the compiler must not print deprecation warnings for stylesheets
+   * that are transitively loaded through an import path or importer.
+   *
+   * @default false
+   */
+  quietDeps?: boolean;
+
+  /**
+   * If `true`, the compiler must print every single deprecation warning it
+   * encounters.
+   *
+   * If `false`, the compiler may choose not to print repeated deprecation
+   * warnings.
+   *
+   * @default false
+   */
+  verbose?: boolean;
 }
 
 export type Options<sync = 'sync' | 'async'> = _Options<sync> &


### PR DESCRIPTION
This is a fast-track proposal. This API is non-controversial and
heavily requested. Although I previously believed it to be infeasible
to implement in the old JS API, I've since found a way to make it
work.

Closes #3065