### PR TITLE
Fix docs for `index` case in URL resolution

### DIFF
--- a/spec/modules.md
+++ b/spec/modules.md
@@ -325,8 +325,7 @@ either another URL that's guaranteed to point to a file on disk or null.
 
 * If `resolved` is not null, return it. Otherwise:
 
-* Let `index` be [`dirname(url)`](#dirname) + `"index/"` +
-  [`basename(url)`](#basename).
+* Let `index` be `url` + `"/index"`
 
 * Return the result of [resolving `index` for extensions][resolving for
   extensions].


### PR DESCRIPTION
The description here does not match the implementation in https://github.com/sass/dart-sass/blob/7e371666f4f4554bb4e78de3087fec8177074b29/lib/src/importer/utils.dart#L62
For demonstration, see https://gist.github.com/Rafer45/3f0bce5ce2519192282564056144fc38