### PR TITLE
Node-API proposal: make `charset` optional

### DIFF
--- a/spec/js-api.d.ts
+++ b/spec/js-api.d.ts
@@ -53,6 +53,18 @@ export interface _Options<sync = 'sync' | 'async'> {
   functions?: {[key: string]: CustomFunction<sync>};
 
   /**
+   * If `true`, the compiler may prepend `@charset "UTF-8";` or U+FEFF
+   * (byte-order marker) if it outputs non-ASCII CSS.
+   *
+   * If `false`, the compiler never emits these byte sequences. This is ideal
+   * when concatenating or embedding in HTML `<style>` tags. (The output will
+   * still be UTF-8.)
+   *
+   * @default true
+   */
+  charset?: boolean;
+
+  /**
    * If true, the compiler must not print deprecation warnings for stylesheets
    * that are transitively loaded through an import path or importer.
    *


### PR DESCRIPTION
This is a fast-track proposal: it's just a teensy option and the feature already exists in the Dart API (for the below rationale).

Currently, Sass prepends `@charset` or a byte-order marker to CSS that contains non-ASCII characters. This is perfect when outputting a file. But when outputting text to be embedded in a `<style>` tag -- or _concatenating_ outputs -- these byte sequences are invalid:

`@charset` is invalid in the middle of a document, as per [CSS3-syntax](https://www.w3.org/TR/css-syntax-3/#charset-rule):

> However, there is no actual at-rule named @charset. When a stylesheet is actually parsed, any occurrences of an @charset rule must be treated as an unrecognized rule, and thus dropped as invalid when the stylesheet is grammar-checked.

`U+FEFF` is invalid in the middle of a text document, as per [UTF-8 BOM FAQ](https://www.unicode.org/faq/utf_bom.html#BOM):

> A: In the absence of a protocol supporting its use as a BOM and when not at the beginning of a text stream, U+FEFF should normally not occur. For backwards compatibility it should be treated as ZERO WIDTH NON-BREAKING SPACE (ZWNBSP), and is then part of the content of the file or string. The use of U+2060 WORD JOINER is strongly preferred over ZWNBSP for expressing word joining semantics since it cannot be confused with a BOM. When designing a markup language or data protocol, the use of U+FEFF can be restricted to that of Byte Order Mark. In that case, any U+FEFF occurring in the middle of a file can be treated as an unsupported character. [AF]

These are both wishy-washy, hand-wavy statements of "invalid", unlikely to actually break a web browser. But Sass is the language of perfectionists, right? `@charset` in the middle of a document is not perfect.

Ref of best practices: https://www.w3.org/International/questions/qa-css-charset

Current workaround for a humble Webpack user is to add `postcss` or some custom regex-y hack to one's pipeline to remove the `@charset`. It would be nicer if we could direct Sass not to add the `@charset` in the first place.

dart-sass implementation PR: https://github.com/sass/dart-sass/pull/1446