### PR TITLE
Don't unify :host and :host-context with other selectors

### DIFF
--- a/spec/at-rules/extend.md
+++ b/spec/at-rules/extend.md
@@ -360,6 +360,20 @@ This procedure takes a simple selector `simple` and a compound selector
   > Note that pseudo-element selectors like `:before` are still considered
   > pseudo-elements even if they use the legacy single-colon syntax.
 
+* If either `simple` or `compound` is a `:host` or `:host-context` selector, and
+  the other selector contains any selector other than a `:host` or a
+  pseudo-selector with a selector argument, return null.
+
+  > The `:host` and `:host-context` selectors select elements outside the
+  > current shadow DOM context, while most other selectors exclusively refer to
+  > elements *within* the current shadow DOM context. Thus the intersection
+  > between `:host` and, say, `div` is always empty.
+  >
+  > We carve out an exception for selector pseudos because it's possible they
+  > contain their own `:host` or `:host-context` selectors, and we don't want to
+  > add the complexity of determining for sure whether they do or not. For
+  > example, `:host(.foo):not(:host-context(.bar))` is valid.
+
 * Return a copy of `compound` with `simple` added:
 
   * If `simple` is a pseudo-element, add it to the end.

--- a/spec/at-rules/extend.md
+++ b/spec/at-rules/extend.md
@@ -349,17 +349,6 @@ This procedure takes a simple selector `simple` and a compound selector
 > by both `simple` and `compound`. In other words, it's the set intersection
 > operation. The null return value indicates the empty set.
 
-* If either `simple` or `compound` is a universal selector, return the other.
-
-* If `compound` contains a selector that's identical to `simple`, return
-  `compound`.
-
-* If `simple` is a type, ID, or [pseudo-element] selector and `compound`
-  contains a type, ID, or pseudo-element selector respectively, return null.
-
-  > Note that pseudo-element selectors like `:before` are still considered
-  > pseudo-elements even if they use the legacy single-colon syntax.
-
 * If either `simple` or `compound` is a `:host` or `:host-context` selector, and
   the other selector contains any selector other than a `:host` or a
   pseudo-selector with a selector argument, return null.
@@ -373,6 +362,17 @@ This procedure takes a simple selector `simple` and a compound selector
   > contain their own `:host` or `:host-context` selectors, and we don't want to
   > add the complexity of determining for sure whether they do or not. For
   > example, `:host(.foo):not(:host-context(.bar))` is valid.
+
+* If either `simple` or `compound` is a universal selector, return the other.
+
+* If `compound` contains a selector that's identical to `simple`, return
+  `compound`.
+
+* If `simple` is a type, ID, or [pseudo-element] selector and `compound`
+  contains a type, ID, or pseudo-element selector respectively, return null.
+
+  > Note that pseudo-element selectors like `:before` are still considered
+  > pseudo-elements even if they use the legacy single-colon syntax.
 
 * Return a copy of `compound` with `simple` added:
 


### PR DESCRIPTION
This is a fast-track proposal.

See sass/sass#3134