### PR TITLE
Add a SourceSpan field to the new JS API Exception class

### DIFF
--- a/spec/js-api/exception.d.ts
+++ b/spec/js-api/exception.d.ts
@@ -1,9 +1,11 @@
+import {SourceSpan} from './logger';
+
 /** The error thrown by the compiler when a Sass compilation fails. */
 export interface Exception extends Error {
   /**
    * The compiler supplies this error message to the JS runtime. This should
-   * contain the description of the Sass exception as well as the Sass span and
-   * stack (if available).
+   * contain the description of the Sass exception as well as human-friendly
+   * representations of `span` and `sassStack` (if they're set).
    *
    * This message must be passed directly to the super constructor.
    *
@@ -12,18 +14,34 @@ export interface Exception extends Error {
   message: string;
 
   /**
-   * The Sass error message, excluding the span and stack.
+   * The Sass error message, excluding the human-friendly representation of
+   * `span` and `sassStack`.
    *
    * > The format can vary from implementation to implementation.
    */
   sassMessage: string;
 
   /**
-   * The Sass stack trace at the point the error was thrown.
+   * Syntax errors and errors thrown when evaluating a stylesheet must set this
+   * field to a human-friendly representation of the loads, function calls, and
+   * mixin includes that were active when this error was thrown.
    *
    * > The format can vary from implementation to implementation.
    */
   sassStack?: string;
+
+  /**
+   * Syntax errors and errors thrown when evaluating a stylesheet must set this
+   * field to a span whose `url` is the canonical URL of the stylesheet being
+   * parsed or evaluated, and whose `start` points to the line in that
+   * stylesheet on which the error occurred.
+   *
+   * > The other details of this span can vary from implementation to
+   * > implementation, but implementations are strongly encouraged to ensure
+   * > that this covers a span of text that clearly indicates the location of
+   * > the error.
+   */
+  span?: SourceSpan;
 
   /**
    * Provides a formatted string with useful information about the error.

--- a/spec/js-api/logger/source_span.d.ts
+++ b/spec/js-api/logger/source_span.d.ts
@@ -22,7 +22,7 @@ export interface SourceSpan {
   end: SourceLocation;
 
   /**
-   * The absolute URL of the file that this span refers to. For files on disk,
+   * The canonical URL of the file that this span refers to. For files on disk,
    * this must be a `file://` URL.
    *
    * This must be `undefined` for files that are passed to the compiler without


### PR DESCRIPTION
This is a fast-track proposal. It doesn't have corresponding
implementation or test CLs because the implementation and tests for
the new JS API don't yet exist.