### PR TITLE
[First-Class Calc] Fix a parenthesizing bug

### DIFF
--- a/spec/types/calculation.md
+++ b/spec/types/calculation.md
@@ -159,8 +159,8 @@ To serialize a `CalculationOperation`:
 * If either:
 
   * the right value is a `CalculationInterpolation`, or
-  * the operator is `"*"` and the right value is a `CalculationOperation` with
-    operator `"+"` or `"-"`, or
+  * the operator is `"*"` or `"-"` and the right value is a
+    `CalculationOperation` with operator `"+"` or `"-"`, or
   * the operator is `"/"` and the right value is a `CalculationOperation`,
 
   emit `"("` followed by `right` followed by `")"`. Otherwise, emit `right`.


### PR DESCRIPTION
`a - (b - c)` should preserve the parentheses of the right-hand
operand, but we weren't doing so.

See #3147