### PR TITLE
Make `options.quotes` optional.

### DIFF
--- a/spec/js-api/value/string.d.ts
+++ b/spec/js-api/value/string.d.ts
@@ -17,7 +17,7 @@ export class SassString extends Value {
     text: string,
     options?: {
       /** @default true */
-      quotes: boolean;
+      quotes?: boolean;
     }
   );
 
@@ -30,7 +30,7 @@ export class SassString extends Value {
    */
   static empty(options?: {
     /** @default true */
-    quotes: boolean;
+    quotes?: boolean;
   }): SassString;
 
   /** The contents of `internal` serialized as UTF-16 code units. */

--- a/spec/js-api/value/string.d.ts
+++ b/spec/js-api/value/string.d.ts
@@ -28,7 +28,7 @@ export class SassString extends Value {
    *   `options.quotes`.
    * - Return `this`.
    */
-  static empty(options?: {quotes?: boolean}): SassString;
+  static empty(options?: {/** @default true */ quotes?: boolean}): SassString;
 
   /** The contents of `internal` serialized as UTF-16 code units. */
   get text(): string;

--- a/spec/js-api/value/string.d.ts
+++ b/spec/js-api/value/string.d.ts
@@ -28,10 +28,7 @@ export class SassString extends Value {
    *   `options.quotes`.
    * - Return `this`.
    */
-  static empty(options?: {
-    /** @default true */
-    quotes?: boolean;
-  }): SassString;
+  static empty(options?: {quotes?: boolean}): SassString;
 
   /** The contents of `internal` serialized as UTF-16 code units. */
   get text(): string;


### PR DESCRIPTION
This is better aligned with how optional options are handled by all
other Values (e.g. SassNumber, SassList).