### PR TITLE
Document the info field in the JS API

### DIFF
--- a/spec/js-api/index.d.ts
+++ b/spec/js-api/index.d.ts
@@ -74,3 +74,12 @@ export {LegacyFunction, LegacyValue, types} from './legacy/function';
 export {LegacyImporter} from './legacy/importer';
 export {LegacyOptions} from './legacy/options';
 export {LegacyResult, render, renderSync} from './legacy/render';
+
+/**
+ * Information about the Sass implementation. This must begin with a unique
+ * identifier for this package (typically but not necessarily the npm package
+ * name), followed by U+0009 TAB, followed by its npm package version. It may
+ * contain another tab character followed by additional information, but this is
+ * not required.
+ */
+export const info: string;


### PR DESCRIPTION
This was originally part of the legacy API, but I'm bringing it into
the main API so that *all* JS Sass packages provide identifying
information in the same format.