### PR TITLE
Create a parallel set of type annotations for documentation

### DIFF
--- a/js-api-doc/compile.d.ts
+++ b/js-api-doc/compile.d.ts
@@ -1,0 +1,27 @@
+import {URL} from 'url';
+import {RawSourceMap} from 'source-map-js';
+
+import {Options, StringOptions} from './options';
+
+export interface CompileResult {
+  css: string;
+  loadedUrls: URL[];
+  sourceMap?: RawSourceMap;
+}
+
+export function compile(path: string, options?: Options<'sync'>): CompileResult;
+
+export function compileAsync(
+  path: string,
+  options?: Options<'async'>
+): Promise<CompileResult>;
+
+export function compileString(
+  source: string,
+  options?: StringOptions<'sync'>
+): CompileResult;
+
+export function compileStringAsync(
+  source: string,
+  options?: StringOptions<'async'>
+): Promise<CompileResult>;

--- a/js-api-doc/exception.d.ts
+++ b/js-api-doc/exception.d.ts
@@ -1,0 +1,13 @@
+import {SourceSpan} from './logger';
+
+export class Exception extends Error {
+  message: string;
+
+  sassMessage: string;
+
+  sassStack: string;
+
+  span: SourceSpan;
+
+  toString(): string;
+}

--- a/js-api-doc/importer.d.ts
+++ b/js-api-doc/importer.d.ts
@@ -1,0 +1,62 @@
+import {URL} from 'url';
+
+import {Syntax} from './options';
+
+interface SyncFileImporter {
+  findFileUrl(
+    url: string,
+    options: {fromImport: boolean}
+  ): FileImporterResult | null;
+
+  canonicalize?: never;
+}
+
+interface AsyncFileImporter {
+  findFileUrl(
+    url: string,
+    options: {fromImport: boolean}
+  ): Promise<FileImporterResult | null> | FileImporterResult | null;
+
+  canonicalize?: never;
+}
+
+export interface FileImporterResult {
+  url: URL;
+
+  sourceMapUrl?: URL;
+}
+
+interface SyncImporter {
+  canonicalize(url: string, options: {fromImport: boolean}): URL | null;
+  load(canonicalUrl: URL): ImporterResult | null;
+  findFileUrl?: never;
+}
+
+interface AsyncImporter {
+  canonicalize(
+    url: string,
+    options: {fromImport: boolean}
+  ): Promise<URL | null> | URL | null;
+
+  load(
+    canonicalUrl: URL
+  ): Promise<ImporterResult | null> | ImporterResult | null;
+
+  findFileUrl?: never;
+}
+
+export interface ImporterResult {
+  css: string;
+
+  syntax: Syntax;
+
+  sourceMapUrl?: URL;
+}
+
+export type FileImporter<sync extends 'sync' | 'async'> = sync extends 'async'
+  ? AsyncFileImporter
+  : SyncFileImporter;
+
+export type Importer<sync extends 'sync' | 'async'> = sync extends 'async'
+  ? AsyncImporter
+  : SyncImporter;

--- a/js-api-doc/index.d.ts
+++ b/js-api-doc/index.d.ts
@@ -1,0 +1,50 @@
+// This is a mirror of the JS API definitions in `spec/js-api`, but with comments
+// written to provide user-facing documentation rather than to specify behavior for
+// implementations.
+
+export {
+  CompileResult,
+  compile,
+  compileAsync,
+  compileString,
+  compileStringAsync,
+} from './compile';
+export {Exception} from './exception';
+export {
+  FileImporter,
+  FileImporterResult,
+  Importer,
+  ImporterResult,
+} from './importer';
+export {Logger, SourceSpan, SourceLocation} from './logger';
+export {
+  CustomFunction,
+  Options,
+  OutputStyle,
+  StringOptions,
+  Syntax,
+} from './options';
+export {
+  ListSeparator,
+  SassArgumentList,
+  SassBoolean,
+  SassColor,
+  SassFunction,
+  SassList,
+  SassMap,
+  SassNumber,
+  SassString,
+  Value,
+  sassFalse,
+  sassNull,
+  sassTrue,
+} from './value';
+
+// Legacy APIs
+export {LegacyException} from './legacy/exception';
+export {LegacyFunction, LegacyValue, types} from './legacy/function';
+export {LegacyImporter} from './legacy/importer';
+export {LegacyOptions} from './legacy/options';
+export {LegacyResult, render, renderSync} from './legacy/render';
+
+export const info: string;

--- a/js-api-doc/legacy/exception.d.ts
+++ b/js-api-doc/legacy/exception.d.ts
@@ -1,0 +1,8 @@
+export interface LegacyException extends Error {
+  message: string;
+  formatted: string;
+  line: number;
+  column: number;
+  status: number;
+  file: string;
+}

--- a/js-api-doc/legacy/function.d.ts
+++ b/js-api-doc/legacy/function.d.ts
@@ -1,0 +1,91 @@
+import {PluginThis} from './plugin_this';
+
+type _SyncFunction = (this: PluginThis, ...args: LegacyValue[]) => LegacyValue;
+
+type _AsyncFunction = (
+  this: PluginThis,
+  ...args: [...LegacyValue[], (type: LegacyValue) => void]
+) => void;
+
+export type LegacyFunction<sync = 'sync' | 'async'> =
+  | _SyncFunction
+  | (sync extends 'async' ? _AsyncFunction : never);
+
+export type LegacyValue =
+  | types.Null
+  | types.Number
+  | types.String
+  | types.Boolean
+  | types.HslColor
+  | types.RgbColor
+  | types.List
+  | types.Map;
+
+export namespace types {
+  export class Null {
+    static NULL: Null;
+  }
+
+  export class Number {
+    constructor(value: number, unit?: string);
+    getValue(): number;
+    setValue(value: number): void;
+    getUnit(): string;
+    setUnit(unit: string): void;
+  }
+
+  export class String {
+    constructor(value: string);
+    getValue(): string;
+    setValue(value: string): void;
+  }
+
+  export class Boolean<T extends boolean = boolean> {
+    constructor(value: T);
+    getValue(): T;
+    static readonly TRUE: Boolean<true>;
+    static readonly FALSE: Boolean<false>;
+  }
+
+  export class HslColor {
+    constructor(h: number, s: number, l: number, a?: number);
+    getH(): number;
+    setH(value: number): void;
+    getS(): number;
+    setS(value: number): void;
+    getL(): number;
+    setL(value: number): void;
+    getA(): number;
+    setA(value: number): void;
+  }
+
+  export class RgbColor {
+    constructor(r: number, g: number, b: number, a?: number);
+    getR(): number;
+    setR(value: number): void;
+    getG(): number;
+    setG(value: number): void;
+    getB(): number;
+    setB(value: number): void;
+    getA(): number;
+    setA(value: number): void;
+  }
+
+  export class List {
+    constructor(length: number, commaSeparator?: boolean);
+    getValue(index: number): LegacyValue | undefined;
+    setValue(index: number, value: LegacyValue): void;
+    getSeparator(): boolean;
+    setSeparator(isComma: boolean): void;
+    getLength(): number;
+  }
+
+  export class Map {
+    constructor(length: number);
+    getValue(index: number): LegacyValue;
+    setValue(index: number, value: LegacyValue): void;
+    getKey(index: number): LegacyValue;
+    setKey(index: number, key: LegacyValue): void;
+    getLength(): number;
+  }
+}

--- a/js-api-doc/legacy/importer.d.ts
+++ b/js-api-doc/legacy/importer.d.ts
@@ -1,0 +1,22 @@
+import {PluginThis} from './plugin_this';
+
+interface ImporterThis extends PluginThis {
+  fromImport: boolean;
+}
+
+type _SyncImporter = (
+  this: ImporterThis,
+  url: string,
+  prev: string
+) => {file: string} | {contents: string};
+
+type _AsyncImporter = (
+  this: ImporterThis,
+  url: string,
+  prev: string,
+  done: (data: {file: string} | {contents: string} | Error) => void
+) => void;
+
+export type LegacyImporter<sync = 'sync' | 'async'> =
+  | _SyncImporter
+  | (sync extends 'async' ? _AsyncImporter : never);

--- a/js-api-doc/legacy/options.d.ts
+++ b/js-api-doc/legacy/options.d.ts
@@ -1,0 +1,44 @@
+import {Logger} from '../logger';
+import {LegacyImporter} from './importer';
+import {LegacyFunction} from './function';
+
+/**
+ *
+ * This is only exported so that it can be modified by proposals for new
+ * features. It should not be referred to by user code.
+ */
+export interface _Options<sync = 'sync' | 'async'> {
+  includePaths?: string[];
+  indentedSyntax?: boolean;
+  indentType?: 'space' | 'tab';
+  indentWidth?: number;
+  linefeed?: 'cr' | 'crlf' | 'lf' | 'lfcr';
+  omitSourceMapUrl?: boolean;
+  outFile?: string;
+  outputStyle?: 'compressed' | 'expanded' | 'nested' | 'compact';
+  sourceMap?: boolean | string;
+  sourceMapContents?: boolean;
+  sourceMapEmbed?: boolean;
+  sourceMapRoot?: string;
+  importer?: LegacyImporter<sync> | LegacyImporter<sync>[];
+  functions?: {[key: string]: LegacyFunction<sync>};
+
+  charset?: boolean;
+
+  quietDeps?: boolean;
+
+  verbose?: boolean;
+
+  logger?: Logger;
+}
+
+export type LegacyOptions<sync = 'sync' | 'async'> = _Options<sync> &
+  (
+    | {
+        file: string;
+      }
+    | {
+        data: string;
+        file?: string;
+      }
+  );

--- a/js-api-doc/legacy/plugin_this.d.ts
+++ b/js-api-doc/legacy/plugin_this.d.ts
@@ -1,0 +1,27 @@
+export interface PluginThis {
+  options: {
+    file?: string;
+
+    data?: string;
+
+    includePaths: string;
+
+    precision: 10;
+
+    style: number;
+
+    indentType: 1 | 0;
+
+    indentWidth: number;
+
+    linefeed: 'cr' | 'crlf' | 'lf' | 'lfcr';
+
+    result: {
+      stats: {
+        start: number;
+
+        entry: string;
+      };
+    };
+  };
+}

--- a/js-api-doc/legacy/render.d.ts
+++ b/js-api-doc/legacy/render.d.ts
@@ -1,0 +1,21 @@
+import {LegacyException} from './exception';
+import {LegacyOptions} from './options';
+
+export interface LegacyResult {
+  css: Buffer;
+  map?: Buffer;
+  stats: {
+    entry: string;
+    start: number;
+    end: number;
+    duration: number;
+    includedFiles: string[];
+  };
+}
+
+export function renderSync(options: LegacyOptions<'sync'>): LegacyResult;
+
+export function render(
+  options: LegacyOptions<'async'>,
+  callback: (exception: LegacyException, result: LegacyResult) => void
+): void;

--- a/js-api-doc/logger/index.d.ts
+++ b/js-api-doc/logger/index.d.ts
@@ -1,0 +1,21 @@
+import {SourceSpan} from './source_span';
+
+export {SourceLocation} from './source_location';
+export {SourceSpan} from './source_span';
+
+export interface Logger {
+  warn?(
+    message: string,
+    options: {
+      deprecation: boolean;
+      span?: SourceSpan;
+      stack?: string;
+    }
+  ): void;
+
+  debug?(message: string, options: {span: SourceSpan}): void;
+}
+
+export namespace Logger {
+  export const silent: Logger;
+}

--- a/js-api-doc/logger/source_location.d.ts
+++ b/js-api-doc/logger/source_location.d.ts
@@ -1,0 +1,7 @@
+export interface SourceLocation {
+  offset: number;
+
+  line: number;
+
+  column: number;
+}

--- a/js-api-doc/logger/source_span.d.ts
+++ b/js-api-doc/logger/source_span.d.ts
@@ -1,0 +1,15 @@
+import {URL} from 'url';
+
+import {SourceLocation} from './source_location';
+
+export interface SourceSpan {
+  start: SourceLocation;
+
+  end: SourceLocation;
+
+  url?: URL;
+
+  text: string;
+
+  context?: string;
+}

--- a/js-api-doc/options.d.ts
+++ b/js-api-doc/options.d.ts
@@ -1,0 +1,51 @@
+import {URL} from 'url';
+
+import {FileImporter, Importer} from './importer';
+import {Logger} from './logger';
+import {Value} from './value';
+
+export type Syntax = 'scss' | 'indented' | 'css';
+
+export type OutputStyle = 'expanded' | 'compressed';
+
+export type CustomFunction<sync extends 'sync' | 'async'> = sync extends 'sync'
+  ? (args: Value[]) => Value
+  : (args: Value[]) => Value | Promise<Value>;
+
+type _Importer<sync extends 'sync' | 'async'> =
+  | Importer<sync>
+  | FileImporter<sync>;
+
+export interface Options<sync extends 'sync' | 'async'> {
+  alertAscii?: boolean;
+
+  alertColor?: boolean;
+
+  functions?: Record<string, CustomFunction<sync>>;
+
+  importers?: _Importer<sync>[];
+
+  loadPaths?: string[];
+
+  logger?: Logger;
+
+  quietDeps?: boolean;
+
+  sourceMap?: boolean;
+
+  style?: OutputStyle;
+
+  verbose?: boolean;
+}
+
+export type StringOptions<sync extends 'sync' | 'async'> = Options<sync> & {
+  syntax?: Syntax;
+} & (
+    | {
+        url?: URL;
+      }
+    | {
+        importer: _Importer<sync>;
+        url: URL;
+      }
+  );

--- a/js-api-doc/value/argument_list.d.ts
+++ b/js-api-doc/value/argument_list.d.ts
@@ -1,0 +1,15 @@
+import {List, OrderedMap} from 'immutable';
+
+import {Value} from './index';
+import {SassList, ListSeparator} from './list';
+
+export class SassArgumentList extends SassList {
+  constructor(
+    contents: Value[] | List<Value>,
+    keywords: Record<string, Value> | OrderedMap<string, Value>,
+    /** @default ',' */
+    separator?: ListSeparator
+  );
+
+  get keywords(): OrderedMap<string, Value>;
+}

--- a/js-api-doc/value/boolean.d.ts
+++ b/js-api-doc/value/boolean.d.ts
@@ -1,0 +1,9 @@
+import {Value} from './index';
+
+export const sassTrue: SassBoolean;
+
+export const sassFalse: SassBoolean;
+
+export interface SassBoolean extends Value {
+  get value(): boolean;
+}

--- a/js-api-doc/value/color.d.ts
+++ b/js-api-doc/value/color.d.ts
@@ -1,0 +1,65 @@
+import {Value} from './index';
+
+export class SassColor extends Value {
+  static rgb(
+    red: number,
+    green: number,
+    blue: number,
+    alpha?: number
+  ): SassColor;
+
+  static hsl(
+    hue: number,
+    saturation: number,
+    lightness: number,
+    alpha?: number
+  ): SassColor;
+
+  static hwb(
+    hue: number,
+    whiteness: number,
+    blackness: number,
+    alpha?: number
+  ): SassColor;
+
+  get red(): number;
+
+  get green(): number;
+
+  get blue(): number;
+
+  get hue(): number;
+
+  get saturation(): number;
+
+  get lightness(): number;
+
+  get whiteness(): number;
+
+  get blackness(): number;
+
+  get alpha(): number;
+
+  changeRgb(options: {
+    red?: number;
+    green?: number;
+    blue?: number;
+    alpha?: number;
+  }): SassColor;
+
+  changeHsl(options: {
+    hue?: number;
+    saturation?: number;
+    lightness?: number;
+    alpha?: number;
+  }): SassColor;
+
+  changeHwb(options: {
+    hue?: number;
+    whiteness?: number;
+    blackness?: number;
+    alpha?: number;
+  }): SassColor;
+
+  changeAlpha(alpha: number): SassColor;
+}

--- a/js-api-doc/value/function.d.ts
+++ b/js-api-doc/value/function.d.ts
@@ -1,0 +1,5 @@
+import {Value} from './index';
+
+export class SassFunction extends Value {
+  constructor(signature: string, callback: (args: Value[]) => Value);
+}

--- a/js-api-doc/value/index.d.ts
+++ b/js-api-doc/value/index.d.ts
@@ -1,0 +1,54 @@
+import {List, OrderedMap, ValueObject} from 'immutable';
+
+import {SassBoolean} from './boolean';
+import {SassColor} from './color';
+import {SassFunction} from './function';
+import {ListSeparator} from './list';
+import {SassMap} from './map';
+import {SassNumber} from './number';
+import {SassString} from './string';
+
+export {SassArgumentList} from './argument_list';
+export {SassBoolean, sassTrue, sassFalse} from './boolean';
+export {SassColor} from './color';
+export {SassFunction} from './function';
+export {SassList, ListSeparator} from './list';
+export {SassMap} from './map';
+export {SassNumber} from './number';
+export {SassString} from './string';
+
+export const sassNull: Value;
+
+export abstract class Value implements ValueObject {
+  get asList(): List<Value>;
+
+  get hasBrackets(): boolean;
+
+  get isTruthy(): boolean;
+
+  get realNull(): null | Value;
+
+  get separator(): ListSeparator;
+
+  sassIndexToListIndex(sassIndex: Value, name?: string): number;
+
+  assertBoolean(name?: string): SassBoolean;
+
+  assertColor(name?: string): SassColor;
+
+  assertFunction(name?: string): SassFunction;
+
+  assertMap(name?: string): SassMap;
+
+  assertNumber(name?: string): SassNumber;
+
+  assertString(name?: string): SassString;
+
+  tryMap(): OrderedMap<Value, Value> | null;
+
+  equals(other: Value): boolean;
+
+  hashCode(): number;
+
+  toString(): string;
+}

--- a/js-api-doc/value/list.d.ts
+++ b/js-api-doc/value/list.d.ts
@@ -1,0 +1,26 @@
+import {List} from 'immutable';
+
+import {Value} from './index';
+
+export type ListSeparator = ',' | '/' | ' ' | null;
+
+export class SassList extends Value {
+  constructor(
+    contents: Value[] | List<Value>,
+    options?: {
+      /** @default ',' */
+      separator?: ListSeparator;
+      /** @default false */
+      brackets?: boolean;
+    }
+  );
+
+  static empty(options?: {
+    /** @default null */
+    separator?: ListSeparator;
+    /** @default false */
+    brackets?: boolean;
+  }): SassList;
+
+  get separator(): ListSeparator;
+}

--- a/js-api-doc/value/map.d.ts
+++ b/js-api-doc/value/map.d.ts
@@ -1,0 +1,13 @@
+import {OrderedMap} from 'immutable';
+
+import {Value} from './index';
+
+export class SassMap extends Value {
+  constructor(contents: OrderedMap<Value, Value>);
+
+  static empty(): SassMap;
+
+  get contents(): OrderedMap<Value, Value>;
+
+  tryMap(): OrderedMap<Value, Value>;
+}

--- a/js-api-doc/value/number.d.ts
+++ b/js-api-doc/value/number.d.ts
@@ -1,0 +1,87 @@
+import {List} from 'immutable';
+
+import {Value} from './index';
+
+export class SassNumber extends Value {
+  constructor(value: number, unit?: string);
+
+  static withUnits(
+    value: number,
+    options?: {
+      numeratorUnits?: string[] | List<string>;
+      denominatorUnits?: string[] | List<string>;
+    }
+  ): SassNumber;
+
+  get value(): number;
+
+  get isInt(): boolean;
+
+  get asInt(): number | null;
+
+  get numeratorUnits(): List<string>;
+
+  get denominatorUnits(): List<string>;
+
+  get hasUnits(): boolean;
+
+  assertInt(name?: string): number;
+
+  assertInRange(min: number, max: number, name?: string): number;
+
+  assertNoUnits(name?: string): SassNumber;
+
+  assertUnit(unit: string, name?: string): SassNumber;
+
+  hasUnit(unit: string): boolean;
+
+  compatibleWithUnit(unit: string): boolean;
+
+  convert(
+    newNumerators: string[] | List<string>,
+    newDenominators: string[] | List<string>,
+    name?: string
+  ): SassNumber;
+
+  convertToMatch(
+    other: SassNumber,
+    name?: string,
+    otherName?: string
+  ): SassNumber;
+
+  convertValue(
+    newNumerators: string[] | List<string>,
+    newDenominators: string[] | List<string>,
+    name?: string
+  ): number;
+
+  convertValueToMatch(
+    other: SassNumber,
+    name?: string,
+    otherName?: string
+  ): number;
+
+  coerce(
+    newNumerators: string[] | List<string>,
+    newDenominators: string[] | List<string>,
+    name?: string
+  ): SassNumber;
+
+  coerceToMatch(
+    other: SassNumber,
+    name?: string,
+    otherName?: string
+  ): SassNumber;
+
+  coerceValue(
+    newNumerators: string[] | List<string>,
+    newDenominators: string[] | List<string>,
+    name?: string
+  ): number;
+
+  coerceValueToMatch(
+    other: SassNumber,
+    name?: string,
+    otherName?: string
+  ): number;
+}

--- a/js-api-doc/value/string.d.ts
+++ b/js-api-doc/value/string.d.ts
@@ -1,0 +1,21 @@
+import {Value} from './index';
+
+export class SassString extends Value {
+  constructor(
+    text: string,
+    options?: {
+      /** @default true */
+      quotes?: boolean;
+    }
+  );
+
+  static empty(options?: {/** @default true */ quotes?: boolean}): SassString;
+
+  get text(): string;
+
+  get hasQuotes(): boolean;
+
+  get sassLength(): number;
+
+  sassIndexToStringIndex(sassIndex: Value, name?: string): number;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,18 @@
       "dependencies": {
         "@types/diff": "^5.0.1",
         "@types/glob": "^7.1.4",
+        "@types/prettier": "^2.4.1",
+        "@types/strip-comments": "^2.0.1",
         "colors": "^1.3.3",
         "diff": "^4.0.1",
-        "glob": "^7.1.3",
+        "glob": "^7.2.0",
         "immutable": "^4.0.0-rc.12",
         "markdown-link-check": "git+https://sassbot@github.com/nex3/markdown-link-check.git#check-references",
         "markdown-toc": "^1.2.0",
-        "source-map-js": "^0.6.2"
+        "prettier": "^2.4.1",
+        "source-map-js": "^0.6.2",
+        "strip-comments": "^2.0.1",
+        "ts-node": "^10.2.1"
       },
       "devDependencies": {
         "@types/node": "^14.11.2",
@@ -128,6 +133,25 @@
         "node": ">=4"
       }
     },
+    "node_modules/@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.6.1.tgz",
+      "integrity": "sha512-DX3Z+T5dt1ockmPdobJS/FAsQPW4V4SrWEhD2iYQT2Cb2tQsiMnYxrcUH9By/Z3B+v0S5LMBkQtV/XOBbpLEOg==",
+      "dependencies": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -224,6 +248,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg=="
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw=="
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg=="
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
+    },
     "node_modules/@types/diff": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.0.1.tgz",
@@ -265,6 +309,16 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
+    },
+    "node_modules/@types/prettier": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw=="
+    },
+    "node_modules/@types/strip-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/strip-comments/-/strip-comments-2.0.1.tgz",
+      "integrity": "sha512-7xjBu+wvKSRHSmgZoRAfUBZMIupd7634b2+uI2qeBDUvfoX+VELjuWCzlL6CF40eG/TGKwU+pqoJfvcvs3fzKA=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "4.29.2",
@@ -443,6 +497,14 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -594,6 +656,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -1017,6 +1084,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -1888,9 +1960,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2804,6 +2876,11 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+    },
     "node_modules/map-obj": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
@@ -3391,10 +3468,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
-      "dev": true,
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -4111,6 +4187,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strip-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
+      "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -4294,6 +4378,60 @@
         "node": ">=8"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.2.1.tgz",
+      "integrity": "sha512-hCnyOyuGmD5wHleOQX6NIjJtYVIO8bPP8F2acWkB4W06wdlkgyvJtubO/I9NkI88hCFECbsEgoLc0VNkYmcSfw==",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.6.1",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/acorn": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+      "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -4373,7 +4511,6 @@
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
       "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4586,6 +4723,14 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "engines": {
+        "node": ">=6"
+      }
     }
   },
   "dependencies": {
@@ -4673,6 +4818,19 @@
         }
       }
     },
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg=="
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.6.1.tgz",
+      "integrity": "sha512-DX3Z+T5dt1ockmPdobJS/FAsQPW4V4SrWEhD2iYQT2Cb2tQsiMnYxrcUH9By/Z3B+v0S5LMBkQtV/XOBbpLEOg==",
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -4748,6 +4906,26 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg=="
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw=="
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg=="
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
+    },
     "@types/diff": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.0.1.tgz",
@@ -4789,6 +4967,16 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
+    },
+    "@types/prettier": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw=="
+    },
+    "@types/strip-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/strip-comments/-/strip-comments-2.0.1.tgz",
+      "integrity": "sha512-7xjBu+wvKSRHSmgZoRAfUBZMIupd7634b2+uI2qeBDUvfoX+VELjuWCzlL6CF40eG/TGKwU+pqoJfvcvs3fzKA=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.29.2",
@@ -4884,6 +5072,11 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
     },
     "ajv": {
       "version": "6.12.6",
@@ -4994,6 +5187,11 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
       "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -5322,6 +5520,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -5972,9 +6175,9 @@
       }
     },
     "glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -6680,6 +6883,11 @@
         }
       }
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+    },
     "map-obj": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
@@ -7113,10 +7321,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
-      "dev": true
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA=="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -7646,6 +7853,11 @@
       "resolved": "https://registry.npmjs.org/strip-color/-/strip-color-0.1.0.tgz",
       "integrity": "sha1-EG9l09PmotlAHKwOsM6LinArT3s="
     },
+    "strip-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
+      "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw=="
+    },
     "strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -7790,6 +8002,32 @@
       "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
     },
+    "ts-node": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.2.1.tgz",
+      "integrity": "sha512-hCnyOyuGmD5wHleOQX6NIjJtYVIO8bPP8F2acWkB4W06wdlkgyvJtubO/I9NkI88hCFECbsEgoLc0VNkYmcSfw==",
+      "requires": {
+        "@cspotcode/source-map-support": "0.6.1",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+          "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q=="
+        }
+      }
+    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -7850,8 +8088,7 @@
     "typescript": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
-      "dev": true
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA=="
     },
     "unique-string": {
       "version": "2.0.0",
@@ -8011,6 +8248,11 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,19 +12,25 @@
     "link-check": "npx ts-node test/link-check.ts",
     "toc-check": "npx ts-node test/toc-check.ts",
     "update-toc": "npx ts-node tool/update-toc.ts",
+    "js-api-doc-check": "npx ts-node test/js-api-doc-check.ts",
     "fix": "gts fix",
-    "test": "gts lint && tsc --noEmit && npm run toc-check && npm run link-check"
+    "test": "gts lint && tsc --noEmit && npm run toc-check && npm run link-check && npm run js-api-doc-check"
   },
   "dependencies": {
     "@types/diff": "^5.0.1",
     "@types/glob": "^7.1.4",
+    "@types/prettier": "^2.4.1",
+    "@types/strip-comments": "^2.0.1",
     "colors": "^1.3.3",
     "diff": "^4.0.1",
-    "glob": "^7.1.3",
+    "glob": "^7.2.0",
     "immutable": "^4.0.0-rc.12",
     "markdown-link-check": "git+https://sassbot@github.com/nex3/markdown-link-check.git#check-references",
     "markdown-toc": "^1.2.0",
-    "source-map-js": "^0.6.2"
+    "prettier": "^2.4.1",
+    "source-map-js": "^0.6.2",
+    "strip-comments": "^2.0.1",
+    "ts-node": "^10.2.1"
   },
   "devDependencies": {
     "@types/node": "^14.11.2",

--- a/test/js-api-doc-check.ts
+++ b/test/js-api-doc-check.ts
@@ -1,0 +1,44 @@
+import * as colors from 'colors/safe';
+import * as diff from 'diff';
+import * as fs from 'fs';
+import * as glob from 'glob';
+import * as p from 'path';
+import * as prettier from 'prettier';
+import strip = require('strip-comments');
+
+for (const specPath of glob.sync('spec/js-api/**/*.d.ts')) {
+  const specFile = prettier.format(strip(fs.readFileSync(specPath, 'utf-8')), {
+    filepath: specPath,
+  });
+  const docPath = p.join('js-api-doc', p.relative('spec/js-api', specPath));
+
+  if (!fs.existsSync(docPath)) {
+    process.stderr.write(
+      colors.red(`${specPath} exists but ${docPath} does not.\n`)
+    );
+    process.exitCode = 1;
+    continue;
+  }
+
+  const docFile = prettier.format(strip(fs.readFileSync(docPath, 'utf-8')), {
+    filepath: specPath,
+  });
+  if (specFile === docFile) continue;
+
+  const diffResult = diff.createTwoFilesPatch(
+    specPath,
+    docPath,
+    specFile,
+    docFile
+  );
+  for (const line of diffResult.split('\n')) {
+    if (line.startsWith('-')) {
+      process.stderr.write(colors.red(`${line}\n`));
+    } else if (line.startsWith('+')) {
+      process.stderr.write(colors.green(`${line}\n`));
+    } else {
+      process.stderr.write(`${line}\n`);
+    }
+  }
+  process.exitCode = 1;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,5 @@
       "*": ["./tool/types/*"]
     }
   },
-  "include": ["accepted/**/*.ts", "proposal/**/*.ts", "spec/**/*.ts", "tool/**/*.ts", "test/**/*.ts"]
+  "include": ["accepted/**/*.ts", "proposal/**/*.ts", "spec/**/*.ts", "tool/**/*.ts", "test/**/*.ts", "js-api-doc/**/*.ts"]
 }


### PR DESCRIPTION
Because the doc comments for spec/js-api are written for implementation
authors, they aren't very useful as documentation for end-users. This gives
us a place to write user-facing documentation as well as a test that
verifies that the underlying type declarations are kept in sync.