### PR TITLE
Replace FileImporterResult with a plain URL

### DIFF
--- a/js-api-doc/importer.d.ts
+++ b/js-api-doc/importer.d.ts
@@ -9,15 +9,9 @@ export interface FileImporter<
   findFileUrl(
     url: string,
     options: {fromImport: boolean}
-  ): PromiseOr<FileImporterResult | null, sync>;
+  ): PromiseOr<URL | null, sync>;
 
   canonicalize?: never;
-}
-
-export interface FileImporterResult {
-  url: URL;
-
-  sourceMapUrl?: URL;
 }
 
 export interface Importer<sync extends 'sync' | 'async' = 'sync' | 'async'> {

--- a/js-api-doc/index.d.ts
+++ b/js-api-doc/index.d.ts
@@ -13,12 +13,7 @@ export {
 /** @hidden */
 export {Exception} from './exception';
 /** @hidden */
-export {
-  FileImporter,
-  FileImporterResult,
-  Importer,
-  ImporterResult,
-} from './importer';
+export {FileImporter, Importer, ImporterResult} from './importer';
 export {Logger, SourceSpan, SourceLocation} from './logger';
 /** @hidden */
 export {

--- a/spec/js-api/importer.d.ts
+++ b/spec/js-api/importer.d.ts
@@ -44,32 +44,9 @@ export interface FileImporter<
   findFileUrl(
     url: string,
     options: {fromImport: boolean}
-  ): PromiseOr<FileImporterResult | null, sync>;
+  ): PromiseOr<URL | null, sync>;
 
   canonicalize?: never;
-}
-
-export interface FileImporterResult {
-  /**
-   * The partially-resolved `file:` URL of a file on disk.
-   *
-   * > Because this is [resolved] after being returned, it doesn't need to be a
-   * > full canonical URL. Users' `FileImporter`s may simply append the relative
-   * > URL to a path and let the compiler resolve extensions, partials, and
-   * > index files.
-   *
-   * [resolved]: ../spec/modules.md#resolving-a-file-url
-   */
-  url: URL;
-
-  /**
-   * A browser-accessible URL indicating the resolved location of the imported
-   * stylesheet.
-   *
-   * The implementation must use this URL in source maps to refer to source
-   * spans in `css`.
-   */
-  sourceMapUrl?: URL;
 }
 
 /**

--- a/spec/js-api/index.d.ts
+++ b/spec/js-api/index.d.ts
@@ -38,12 +38,7 @@ export {
   compileStringAsync,
 } from './compile';
 export {Exception} from './exception';
-export {
-  FileImporter,
-  FileImporterResult,
-  Importer,
-  ImporterResult,
-} from './importer';
+export {FileImporter, Importer, ImporterResult} from './importer';
 export {Logger, SourceSpan, SourceLocation} from './logger';
 export {
   CustomFunction,


### PR DESCRIPTION
Supplying a source map URL doesn't make sense for a file importer, for
two reasons:

1. A canonical `file:` URL is already the recommended source map URL
   because it's always available on the local system.

2. Because a FileImporter doesn't know the fully-resolved canonical
   URL of the file it loads, it doesn't have any way of determining
   what the full source map URL should be anyway.