### PR TITLE
Get rid of explicit heads-up and compatibility HTML

### DIFF
--- a/js-api-doc/legacy/function.d.ts
+++ b/js-api-doc/legacy/function.d.ts
@@ -142,12 +142,8 @@ export namespace types {
     /**
      * Returns the value of the number, ignoring units.
      *
-     * <div class="sl-c-callout sl-c-callout--warning"><h3>⚠ Heads up!</h3>
-     *
-     * This means that `96px` and `1in` will return different values, even
-     * though they represent the same length.
-     *
-     * </div>
+     * **Heads up!** This means that `96px` and `1in` will return different
+     * values, even though they represent the same length.
      *
      * @example
      *
@@ -195,26 +191,18 @@ export namespace types {
   /**
    * Sass's [string type](https://sass-lang.com/documentation/values/strings).
    *
-   * <div class="sl-c-callout sl-c-callout--warning"><h3>⚠ Heads up!</h3>
-   *
-   * This API currently provides no way of distinguishing between a
-   * [quoted](https://sass-lang.com/documentation/values/strings#quoted) and
+   * **Heads up!** This API currently provides no way of distinguishing between
+   * a [quoted](https://sass-lang.com/documentation/values/strings#quoted) and
    * [unquoted](https://sass-lang.com/documentation/values/strings#unquoted)
    * string.
-   *
-   * </div>
    */
   export class String {
     /**
      * Creates an unquoted string with the given contents.
      *
-     * <div class="sl-c-callout sl-c-callout--warning"><h3>⚠ Heads up!</h3>
-     *
-     * This API currently provides no way of creating a
+     * **Heads up!** This API currently provides no way of creating a
      * [quoted](https://sass-lang.com/documentation/values/strings#quoted)
      * string.
-     *
-     * </div>
      */
     constructor(value: string);
 
@@ -247,12 +235,8 @@ export namespace types {
      * Destructively modifies this string by setting its numeric value to
      * `value`.
      *
-     * <div class="sl-c-callout sl-c-callout--warning"><h3>⚠ Heads up!</h3>
-     *
-     * Even if the string was originally quoted, this will cause it to become
-     * unquoted.
-     *
-     * </div>
+     * **Heads up!** Even if the string was originally quoted, this will cause
+     * it to become unquoted.
      *
      * @deprecated Use [[constructor]] instead.
      */
@@ -266,12 +250,8 @@ export namespace types {
    * [truthiness](https://sass-lang.com/documentation/at-rules/control/if#truthiness-and-falsiness)
    * by treating `false` and `null` as falsey and everything else as truthy.
    *
-   * <div class="sl-c-callout sl-c-callout--warning"><h3>⚠ Heads up!</h3>
-   *
-   * Boolean values can't be constructed, they can only be accessed through the
-   * [[TRUE]] and [[FALSE]] constants.
-   *
-   * </div>
+   * **Heads up!** Boolean values can't be constructed, they can only be
+   * accessed through the [[TRUE]] and [[FALSE]] constants.
    */
   export class Boolean<T extends boolean = boolean> {
     /**
@@ -426,25 +406,17 @@ export namespace types {
   /**
    * Sass's [list type](https://sass-lang.com/documentation/values/lists).
    *
-   * <div class="sl-c-callout sl-c-callout--warning"><h3>⚠ Heads up!</h3>
-   *
-   * This list type’s methods use 0-based indexing, even though within Sass
-   * lists use 1-based indexing. These methods also don’t support using negative
-   * numbers to index backwards from the end of the list.
-   *
-   * </div>
+   * **Heads up!** This list type’s methods use 0-based indexing, even though
+   * within Sass lists use 1-based indexing. These methods also don’t support
+   * using negative numbers to index backwards from the end of the list.
    */
   export class List {
     /**
      * Creates a new Sass list.
      *
-     * <div class="sl-c-callout sl-c-callout--warning"><h3>⚠ Heads up!</h3>
-     *
-     * The initial values of the list elements are undefined. These elements
-     * must be set using [[setValue]] before accessing them or passing the list
-     * back to Sass.
-     *
-     * </div>
+     * **Heads up!** The initial values of the list elements are undefined.
+     * These elements must be set using [[setValue]] before accessing them or
+     * passing the list back to Sass.
      *
      * @example
      *
@@ -538,28 +510,19 @@ export namespace types {
   /**
    * Sass's [map type](https://sass-lang.com/documentation/values/maps).
    *
-   * <div class="sl-c-callout sl-c-callout--warning"><h3>⚠ Heads up!</h3>
-   *
-   * This map type is represented as a list of key-value pairs rather than a
-   * mapping from keys to values. The only way to find the value associated with
-   * a given key is to iterate through the map checking for that key.
-   *
-   * Maps created through this API are still forbidden from having duplicate
+   * **Heads up!** This map type is represented as a list of key-value pairs
+   * rather than a mapping from keys to values. The only way to find the value
+   * associated with a given key is to iterate through the map checking for that
+   * key. Maps created through this API are still forbidden from having duplicate
    * keys.
-   *
-   * </div>
    */
   export class Map {
     /**
      * Creates a new Sass map.
      *
-     * <div class="sl-c-callout sl-c-callout--warning"><h3>⚠ Heads up!</h3>
-     *
-     * The initial keys and values of the map are undefined. They must be set
-     * using [[setKey]] and [[setValue]] before accessing them or passing the
-     * map back to Sass.
-     *
-     * </div>
+     * **Heads up!** The initial keys and values of the map are undefined. They
+     * must be set using [[setKey]] and [[setValue]] before accessing them or
+     * passing the map back to Sass.
      *
      * @example
      *

--- a/js-api-doc/legacy/importer.d.ts
+++ b/js-api-doc/legacy/importer.d.ts
@@ -3,17 +3,13 @@ import {LegacyPluginThis} from './plugin_this';
 /** The value of `this` in the context of a [[LegacyImporter]] function. */
 interface LegacyImporterThis extends LegacyPluginThis {
   /**
-   * <dl class="impl-status sl-c-description-list sl-c-description-list--horizontal">
-   *   <div class="compatibility">Compatibility:</div>
-   *   <div><dt>Dart&nbsp;Sass</dt> <dd>since&nbsp;<span class="caps">1.33.0</span></dd></div>
-   *   <div><dt>Node&nbsp;Sass</dt> <dd>✗</dd></div>
-   * </dl>
-   *
    * Whether the importer is being invoked because of a Sass `@import` rule, as
    * opposed to a `@use` or `@forward` rule.
    *
    * This should *only* be used for determining whether or not to load
    * [import-only files](https://sass-lang.com/documentation/at-rules/import#import-only-files).
+   *
+   * @compatibility dart: "1.33.0", node: false
    */
   fromImport: boolean;
 }

--- a/js-api-doc/legacy/options.d.ts
+++ b/js-api-doc/legacy/options.d.ts
@@ -134,12 +134,8 @@ export interface LegacySharedOptions<sync extends 'sync' | 'async'> {
    * to determine the URL used to link from the generated CSS to the source map,
    * and from the source map to the Sass source files.
    *
-   * <div class="sl-c-callout sl-c-callout--warning"><h3>⚠ Heads up!</h3>
-   *
-   * Despite the name, Sass does *not* write the CSS output to this file. The
-   * caller must do that themselves.
-   *
-   * </div>
+   * **Heads up!** Despite the name, Sass does *not* write the CSS output to
+   * this file. The caller must do that themselves.
    *
    * ```js
    * result = sass.renderSync({
@@ -427,13 +423,9 @@ export interface LegacySharedOptions<sync extends 'sync' | 'async'> {
    * types](https://sass-lang.com/documentation/js-api#value-types), and must
    * return the same.
    *
-   * <div class="sl-c-callout sl-c-callout--warning"><h3>⚠ Heads up!</h3>
-   *
-   * When writing custom functions, it’s important to ensure that all the
-   * arguments are the types you expect. Otherwise, users’ stylesheets could
-   * crash in hard-to-debug ways or, worse, compile to meaningless CSS.
-   *
-   * </div>
+   * **Heads up!** When writing custom functions, it’s important to ensure that
+   * all the arguments are the types you expect. Otherwise, users’ stylesheets
+   * could crash in hard-to-debug ways or, worse, compile to meaningless CSS.
    *
    * @example
    *
@@ -519,15 +511,11 @@ export interface LegacySharedOptions<sync extends 'sync' | 'async'> {
    * your own. However, please <em>also</em> notify your dependencies of the deprecations
    * so that they can get fixed as soon as possible!
    *
-   * <div class="sl-c-callout sl-c-callout--warning"><h3>⚠ Heads up!</h3>
-   *
-   * If [[render]] or [[renderSync]] is called without
+   * **Heads up!** If [[render]] or [[renderSync]] is called without
    * [[LegacyFileOptions.file]] or [[LegacyStringOptions.file]], <em>all</em>
    * stylesheets it loads will be considered dependencies. Since it doesn’t have
    * a path of its own, everything it loads is coming from a load path rather
    * than a relative import.
-   *
-   * </div>
    *
    * @defaultValue `false`
    * @category Messages

--- a/js-api-doc/legacy/options.d.ts
+++ b/js-api-doc/legacy/options.d.ts
@@ -12,17 +12,6 @@ import {LegacyFunction} from './function';
  */
 export interface LegacySharedOptions<sync extends 'sync' | 'async'> {
   /**
-   * <dl class="impl-status sl-c-description-list sl-c-description-list--horizontal">
-   *   <div class="compatibility">Compatibility (<code>SASS_PATH</code>):</div>
-   *   <div><dt>Dart&nbsp;Sass</dt> <dd>since&nbsp;<span class="caps">1.15.0</span></dd></div>
-   *   <div><dt>Node&nbsp;Sass</dt> <dd>since&nbsp;<span class="caps">3.9.0</span></dd></div>
-   *   <div><a>▶</a></div>
-   * </dl>
-   * <div class="sl-c-callout sl-c-callout--impl-status">
-   *   Earlier versions of Dart Sass and Node Sass didn’t support the
-   *   <code>SASS_PATH</code> environment variable.
-   * </div>
-   *
    * This array of strings option provides [load
    * paths](https://sass-lang.com/documentation/at-rules/import#load-paths) for
    * Sass to look for stylesheets. Earlier load paths will take precedence over
@@ -45,16 +34,14 @@ export interface LegacySharedOptions<sync extends 'sync' | 'async'> {
    * ```
    *
    * @category Input
+   * @compatibility feature: "SASS_PATH", dart: "1.15.0", node: "3.9.0"
+   *
+   * Earlier versions of Dart Sass and Node Sass didn’t support the `SASS_PATH`
+   * environment variable.
    */
   includePaths?: string[];
 
   /**
-   * <dl class="impl-status sl-c-description-list sl-c-description-list--horizontal">
-   *   <div class="compatibility">Compatibility:</div>
-   *   <div><dt>Dart&nbsp;Sass</dt> <dd>✓</dd></div>
-   *   <div><dt>Node&nbsp;Sass</dt> <dd>since&nbsp;<span class="caps">3.0.0</span></dd></div>
-   * </dl>
-   *
    * Whether the generated CSS should use spaces or tabs for indentation.
    *
    * ```js
@@ -70,32 +57,22 @@ export interface LegacySharedOptions<sync extends 'sync' | 'async'> {
    *
    * @defaultValue `'space'`
    * @category Output
+   * @compatibility dart: true, node: "3.0.0"
    */
   indentType?: 'space' | 'tab';
 
   /**
-   * <dl class="impl-status sl-c-description-list sl-c-description-list--horizontal">
-   *   <div class="compatibility">Compatibility:</div>
-   *   <div><dt>Dart&nbsp;Sass</dt> <dd>✓</dd></div>
-   *   <div><dt>Node&nbsp;Sass</dt> <dd>since&nbsp;<span class="caps">3.0.0</span></dd></div>
-   * </dl>
-   *
    * How many spaces or tabs (depending on [[indentType]]) should be used per
    * indentation level in the generated CSS. It must be between 0 and 10
    * (inclusive).
    *
    * @defaultValue `2`
    * @category Output
+   * @compatibility dart: true, node: "3.0.0"
    */
   indentWidth?: number;
 
   /**
-   * <dl class="impl-status sl-c-description-list sl-c-description-list--horizontal">
-   *   <div class="compatibility">Compatibility:</div>
-   *   <div><dt>Dart&nbsp;Sass</dt> <dd>✓</dd></div>
-   *   <div><dt>Node&nbsp;Sass</dt> <dd>since&nbsp;<span class="caps">3.0.0</span></dd></div>
-   * </dl>
-   *
    * Which character sequence to use at the end of each line in the generated
    * CSS. It can have the following values:
    *
@@ -106,6 +83,7 @@ export interface LegacySharedOptions<sync extends 'sync' | 'async'> {
    *
    * @defaultValue `'lf'`
    * @category Output
+   * @compatibility dart: true, node: "3.0.0"
    */
   linefeed?: 'cr' | 'crlf' | 'lf' | 'lfcr';
 
@@ -316,39 +294,6 @@ export interface LegacySharedOptions<sync extends 'sync' | 'async'> {
   sourceMapRoot?: string;
 
   /**
-   * <dl class="impl-status sl-c-description-list sl-c-description-list--horizontal">
-   *   <div class="compatibility">Compatibility:</div>
-   *   <div><dt>Dart&nbsp;Sass</dt> <dd>✓</dd></div>
-   *   <div><dt>Node&nbsp;Sass</dt> <dd>since&nbsp;<span class="caps">3.0.0</span></dd></div>
-   *   <div><a>▶</a></div>
-   * </dl>
-   * <div class="sl-c-callout sl-c-callout--impl-status">
-   *   <p>Versions of Node Sass before 3.0.0 don’t support arrays of importers,
-   *   nor do they support importers that return <code>Error</code> objects.
-   *   <p>Versions of Node Sass before 2.0.0 don’t support the
-   *   <code>importer</code> option at all.
-   * </div>
-   * <dl class="impl-status sl-c-description-list sl-c-description-list--horizontal">
-   *   <div class="compatibility">Compatibility (Import order):</div>
-   *   <div><dt>Dart&nbsp;Sass</dt> <dd>since&nbsp;<span class="caps">1.20.2</span></dd></div>
-   *   <div><dt>Node&nbsp;Sass</dt> <dd>since&nbsp;<span class="caps">✗</span></dd></div>
-   *   <div><a>▶</a></div>
-   * </dl>
-   * <div class="sl-c-callout sl-c-callout--impl-status">
-   *   <p>Versions of Dart Sass before 1.20.2 preferred resolving imports using
-   *   load paths (<a href="https://sass-lang.com/documentation/js-api#includepaths">includePaths</a>)
-   *   before resolving them using custom importers.
-   *   <p>All versions of Node Sass currently pass imports to importers before
-   *   loading them relative to the file in which the <code>@import</code>
-   *   appears. This behavior is considered incorrect and should not be relied
-   *   on because it violates the principle of <em>locality</em>, which says
-   *   that it should be possible to reason about a stylesheet without knowing
-   *   everything about how the entire system is set up. If a user tries to
-   *   import a stylesheet relative to another stylesheet, that import should
-   *   <em>always</em> work. It shouldn’t be possible for some configuration
-   *   somewhere else to break it.
-   * </div>
-   *
    * Additional handler(s) for loading files when a [`@use`
    * rule](https://sass-lang.com/documentation/at-rules/use) or an [`@import`
    * rule](https://sass-lang.com/documentation/at-rules/import) is encountered.
@@ -410,6 +355,27 @@ export interface LegacySharedOptions<sync extends 'sync' | 'async'> {
    * ```
    *
    * @category Plugins
+   * @compatibility dart: true, node: "3.0.0"
+   *
+   * Versions of Node Sass before 3.0.0 don’t support arrays of importers, nor
+   * do they support importers that return `Error` objects.
+   *
+   * Versions of Node Sass before 2.0.0 don’t support the `importer` option at
+   * all.
+   *
+   * @compatibility feature: "Import order", dart: "1.20.2", node: false
+   *
+   * Versions of Dart Sass before 1.20.2 preferred resolving imports using
+   * [[includePaths]] before resolving them using custom importers.
+   *
+   * All versions of Node Sass currently pass imports to importers before
+   * loading them relative to the file in which the `@import` appears. This
+   * behavior is considered incorrect and should not be relied on because it
+   * violates the principle of *locality*, which says that it should be possible
+   * to reason about a stylesheet without knowing everything about how the
+   * entire system is set up. If a user tries to import a stylesheet relative to
+   * another stylesheet, that import should *always* work. It shouldn’t be
+   * possible for some configuration somewhere else to break it.
    */
   importer?: LegacyImporter<sync> | LegacyImporter<sync>[];
 
@@ -480,28 +446,17 @@ export interface LegacySharedOptions<sync extends 'sync' | 'async'> {
   functions?: {[key: string]: LegacyFunction<sync>};
 
   /**
-   * <dl class="impl-status sl-c-description-list sl-c-description-list--horizontal">
-   *   <div class="compatibility">Compatibility:</div>
-   *   <div><dt>Dart&nbsp;Sass</dt> <dd>since&nbsp;<span class="caps">1.39.0</span></dd></div>
-   *   <div><dt>Node&nbsp;Sass</dt> <dd>✗</div>
-   * </dl>
-   *
    * By default, if the CSS document contains non-ASCII characters, Sass adds a
    * `@charset` declaration (in expanded output mode) or a byte-order mark (in
    * compressed mode) to indicate its encoding to browsers or other consumers.
    * If `charset` is `false`, these annotations are omitted.
    *
    * @category Output
+   * @compatibility dart: "1.39.0", node: false
    */
   charset?: boolean;
 
   /**
-   * <dl class="impl-status sl-c-description-list sl-c-description-list--horizontal">
-   *   <div class="compatibility">Compatibility:</div>
-   *   <div><dt>Dart&nbsp;Sass</dt> <dd>since&nbsp;<span class="caps">1.35.0</span></dd></div>
-   *   <div><dt>Node&nbsp;Sass</dt> <dd>✗</div>
-   * </dl>
-   *
    * If this option is set to `true`, Sass won’t print warnings that are caused
    * by dependencies. A “dependency” is defined as any file that’s loaded
    * through [[loadPaths]] or [[importer]]. Stylesheets that are imported
@@ -519,16 +474,11 @@ export interface LegacySharedOptions<sync extends 'sync' | 'async'> {
    *
    * @defaultValue `false`
    * @category Messages
+   * @compatibility dart: "1.35.0", node: false
    */
   quietDeps?: boolean;
 
   /**
-   * <dl class="impl-status sl-c-description-list sl-c-description-list--horizontal">
-   *   <div class="compatibility">Compatibility:</div>
-   *   <div><dt>Dart&nbsp;Sass</dt> <dd>since&nbsp;<span class="caps">1.35.0</span></dd></div>
-   *   <div><dt>Node&nbsp;Sass</dt> <dd>✗</div>
-   * </dl>
-   *
    * By default, Dart Sass will print only five instances of the same
    * deprecation warning per compilation to avoid deluging users in console
    * noise. If you set `verbose` to `true`, it will instead print every
@@ -536,16 +486,11 @@ export interface LegacySharedOptions<sync extends 'sync' | 'async'> {
    *
    * @defaultValue `false`
    * @category Messages
+   * @compatibility dart: "1.35.0", node: false
    */
   verbose?: boolean;
 
   /**
-   * <dl class="impl-status sl-c-description-list sl-c-description-list--horizontal">
-   *   <div class="compatibility">Compatibility:</div>
-   *   <div><dt>Dart&nbsp;Sass</dt> <dd>since&nbsp;<span class="caps">1.43.0</span></dd></div>
-   *   <div><dt>Node&nbsp;Sass</dt> <dd>✗</dd></div>
-   * </dl>
-   *
    * An object to use to handle warnings and/or debug messages from Sass.
    *
    * By default, Sass emits warnings and debug messages to standard error, but
@@ -556,6 +501,7 @@ export interface LegacySharedOptions<sync extends 'sync' | 'async'> {
    * messages.
    *
    * @category Messages
+   * @compatibility dart: "1.43.0", node: false
    */
   logger?: Logger;
 }
@@ -571,22 +517,6 @@ export interface LegacySharedOptions<sync extends 'sync' | 'async'> {
 export interface LegacyFileOptions<sync extends 'sync' | 'async'>
   extends LegacySharedOptions<sync> {
   /**
-   * <dl class="impl-status sl-c-description-list sl-c-description-list--horizontal">
-   *   <div class="compatibility">Compatibility (Plain CSS files):</div>
-   *   <div><dt>Dart&nbsp;Sass</dt> <dd>since&nbsp;<span class="caps">1.11.0</span></dd></div>
-   *   <div><dt>Node&nbsp;Sass</dt> <dd>partial</dd></div>
-   *   <div><a>▶</a></div>
-   * </dl>
-   * <div class="sl-c-callout sl-c-callout--impl-status">
-   *   <p>Node Sass and older versions of Dart Sass support loading files with
-   *   the extension <code>.css</code>, but contrary to the specification
-   *   they’re treated as SCSS files rather than being parsed as CSS. This
-   *   behavior has been deprecated and should not be relied on. Any files that
-   *   use Sass features should use the <code>.scss</code> extension.
-   *   <p>All versions of Node Sass and Dart Sass otherwise support the file
-   *   option as described below.
-   * </div>
-   *
    * The path to the file for Sass to load and compile. If the file’s extension
    * is `.scss`, it will be parsed as SCSS; if it’s `.sass`, it will be parsed
    * as the indented syntax; and if it’s `.css`, it will be parsed as plain CSS.
@@ -599,6 +529,16 @@ export interface LegacyFileOptions<sync extends 'sync' | 'async'>
    * ```
    *
    * @category Input
+   * @compatibility feature: "Plain CSS files", dart: "1.11.0", node: "partial"
+   *
+   * Node Sass and older versions of Dart Sass support loading files with the
+   * extension `.css`, but contrary to the specification they’re treated as SCSS
+   * files rather than being parsed as CSS. This behavior has been deprecated
+   * and should not be relied on. Any files that use Sass features should use
+   * the `.scss` extension.
+   *
+   * All versions of Node Sass and Dart Sass otherwise support the file option
+   * as described below.
    */
   file: string;
 

--- a/js-api-doc/legacy/render.d.ts
+++ b/js-api-doc/legacy/render.d.ts
@@ -108,13 +108,9 @@ export function renderSync(options: LegacyOptions<'sync'>): LegacyResult;
  * `callback` with a [[LegacyResult]] if compilation succeeds or
  * [[LegacyException]] if it fails.
  *
- * <div class="sl-c-callout sl-c-callout--warning"><h3>⚠ Heads up!</h3>
- *
- * When using Dart Sass, **[[renderSync]] is almost twice as fast as
- * [[render]]** by default, due to the overhead of making the entire evaluation
- * process asynchronous.
- *
- * </div>
+ * **Heads up!** When using Dart Sass, **[[renderSync]] is almost twice as fast
+ * as [[render]]** by default, due to the overhead of making the entire
+ * evaluation process asynchronous.
  *
  * ```js
  * const sass = require('sass'); // or require('node-sass');

--- a/js-api-doc/logger/index.d.ts
+++ b/js-api-doc/logger/index.d.ts
@@ -68,13 +68,9 @@ export interface Logger {
 }
 
 /**
- * <dl class="impl-status sl-c-description-list sl-c-description-list--horizontal">
- *   <div class="compatibility">Compatibility:</div>
- *   <div><dt>Dart&nbsp;Sass</dt> <dd>since&nbsp;<span class="caps">1.43.0</span></dd></div>
- *   <div><dt>Node&nbsp;Sass</dt> <dd>✗</dd></div>
- * </dl>
- *
  * A namespace for built-in [[Logger]]s.
+ *
+ * @compatibility dart: "1.43.0", node: false
  */
 export namespace Logger {
   /** A [[Logger]] that silently ignores all warnings and debug messages. */


### PR DESCRIPTION
The Sass site can now consume these as Markdown and @-tags,
respectively.

See sass/sass-site#588