### PR TITLE
Use the URL type from the DOM definitions, not from Node

### DIFF
--- a/js-api-doc/compile.d.ts
+++ b/js-api-doc/compile.d.ts
@@ -1,4 +1,3 @@
-import {URL} from 'url';
 import {RawSourceMap} from 'source-map-js';
 
 import {Options, StringOptions} from './options';

--- a/js-api-doc/importer.d.ts
+++ b/js-api-doc/importer.d.ts
@@ -1,5 +1,3 @@
-import {URL} from 'url';
-
 import {Syntax} from './options';
 import {PromiseOr} from './util/promise_or';
 

--- a/js-api-doc/logger/source_span.d.ts
+++ b/js-api-doc/logger/source_span.d.ts
@@ -1,5 +1,3 @@
-import {URL} from 'url';
-
 import {SourceLocation} from './source_location';
 
 /**

--- a/js-api-doc/options.d.ts
+++ b/js-api-doc/options.d.ts
@@ -1,5 +1,3 @@
-import {URL} from 'url';
-
 import {FileImporter, Importer} from './importer';
 import {Logger} from './logger';
 import {Value} from './value';

--- a/spec/js-api/compile.d.ts
+++ b/spec/js-api/compile.d.ts
@@ -1,4 +1,3 @@
-import {URL} from 'url';
 import {RawSourceMap} from 'source-map-js'; // https://www.npmjs.com/package/source-map-js
 
 import {Options, StringOptions} from './options';

--- a/spec/js-api/importer.d.ts
+++ b/spec/js-api/importer.d.ts
@@ -1,5 +1,3 @@
-import {URL} from 'url';
-
 import {Syntax} from './options';
 import {PromiseOr} from './util/promise_or';
 

--- a/spec/js-api/logger/source_span.d.ts
+++ b/spec/js-api/logger/source_span.d.ts
@@ -1,5 +1,3 @@
-import {URL} from 'url';
-
 import {SourceLocation} from './source_location';
 
 /**

--- a/spec/js-api/options.d.ts
+++ b/spec/js-api/options.d.ts
@@ -1,5 +1,3 @@
-import {URL} from 'url';
-
 import {FileImporter, Importer} from './importer';
 import {Logger} from './logger';
 import {Value} from './value';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "allowJs": true,
     "rootDir": ".",
+    "lib": ["dom"],
     "paths": {
       "*": ["./tool/types/*"]
     }


### PR DESCRIPTION
The two aren't quite interchangeable: the Node definition has a few
more fields, which means that URLs created naively with `new URL()`
aren't assignable to that type.