### PR TITLE
Make LegacyFileOptions.data optional

### DIFF
--- a/js-api-doc/legacy/options.d.ts
+++ b/js-api-doc/legacy/options.d.ts
@@ -553,7 +553,7 @@ export interface LegacyFileOptions<sync extends 'sync' | 'async'>
    *
    * @category Input
    */
-  data: never;
+  data?: never;
 }
 
 /**

--- a/spec/js-api/legacy/options.d.ts
+++ b/spec/js-api/legacy/options.d.ts
@@ -78,7 +78,7 @@ export interface LegacyFileOptions<sync extends 'sync' | 'async'>
   extends LegacySharedOptions<sync> {
   file: string;
 
-  data: never;
+  data?: never;
 }
 
 export interface LegacyStringOptions<sync extends 'sync' | 'async'>


### PR DESCRIPTION
If this is mandatory, the compiler will complain if it's not passed,
but it's typed as `never` so it's impossible to pass a valid value.