### PR TITLE
Allow SassFunction signatures to be checked on return

### DIFF
--- a/spec/js-api/options.d.ts
+++ b/spec/js-api/options.d.ts
@@ -60,8 +60,16 @@ export interface Options<sync extends 'sync' | 'async'> {
    *
    * [<ident-token>]: https://drafts.csswg.org/css-syntax-3/#ident-token-diagram
    *
-   * The compiler must throw an error if the `CustomFunction` does not return a
-   * `Value`.
+   * If the `CustomFunction` returns an invalid value, or a value that
+   * transitively contains an invalid value, the compiler must treat that as the
+   * Sass function throwing an error. The following values are considered
+   * invalid:
+   * 
+   * * An object that's not an instance of the `Value` class.
+   *
+   * * A `SassFunction` whose `signature` field isn't a valid Sass function
+   *   signature that could appear after the `@function` directive in a Sass
+   *   stylesheet.
    */
   functions?: Record<string, CustomFunction<sync>>;
 

--- a/spec/js-api/options.d.ts
+++ b/spec/js-api/options.d.ts
@@ -64,10 +64,10 @@ export interface Options<sync extends 'sync' | 'async'> {
    * transitively contains an invalid value, the compiler must treat that as the
    * Sass function throwing an error. The following values are considered
    * invalid:
-   * 
-   * * An object that's not an instance of the `Value` class.
    *
-   * * A `SassFunction` whose `signature` field isn't a valid Sass function
+   * - An object that's not an instance of the `Value` class.
+   *
+   * - A `SassFunction` whose `signature` field isn't a valid Sass function
    *   signature that could appear after the `@function` directive in a Sass
    *   stylesheet.
    */

--- a/spec/js-api/value/function.d.ts
+++ b/spec/js-api/value/function.d.ts
@@ -17,14 +17,12 @@ export class SassFunction extends Value {
    *   > This is optional to allow for implementations of the value API that
    *   > don't have easy access to a Sass parser, such as the embedded host.
    *   > These implementations must instead throw an error when the invalid
-   *   > function
+   *   > function is returned from the custom function.
    *
    * - Set `internal` to a Sass function with signature set to `signature` that,
    *   upon execution, runs `callback` and returns the result.
    *
    * - Return `this`.
-   *
-   * An implementation may verify that `signature` is a valid function signature
    */
   constructor(
     /**

--- a/spec/js-api/value/function.d.ts
+++ b/spec/js-api/value/function.d.ts
@@ -9,9 +9,22 @@ export class SassFunction extends Value {
   /**
    * Creates a Sass function:
    *
+   * - If `signature` isn't a valid Sass function signature that could appear
+   *   after the `@function` directive in a Sass stylesheet (such as
+   *   `mix($color1, $color2, $weight: 50%)`), the implementation *may* throw an
+   *   error.
+   *
+   *   > This is optional to allow for implementations of the value API that
+   *   > don't have easy access to a Sass parser, such as the embedded host.
+   *   > These implementations must instead throw an error when the invalid
+   *   > function
+   *
    * - Set `internal` to a Sass function with signature set to `signature` that,
    *   upon execution, runs `callback` and returns the result.
+   *
    * - Return `this`.
+   *
+   * An implementation may verify that `signature` is a valid function signature
    */
   constructor(
     /**


### PR DESCRIPTION
This allows implementations to avoid needing to have an
easily-accessible Sass parser in JS.