### PR TITLE
Fix the toc tool to insert the toc

### DIFF
--- a/tool/toc.ts
+++ b/tool/toc.ts
@@ -25,7 +25,7 @@ export function getCurrent(markdown: string): string | null {
   const endIndex = markdown.indexOf('## ', startIndex) - 1;
   if (endIndex < 0) return null;
 
-  return markdown.substring(startIndex, endIndex).trim();
+  return markdown.substring(startIndex, endIndex).trim() || null;
 }
 
 /** Returns the expected table of contents for `markdown`. */


### PR DESCRIPTION
When the file contains an existing TOC title without its content, the logic at https://github.com/sass/sass/blob/a93aec70924fc9b5d71463ca8039a3a49dce82a3/tool/update-toc.ts#L9 was failing due to returning an empty string rather than `null`