### PR TITLE
Fix some incorrect documentation/typings in LegacyPluginThis.options

### DIFF
--- a/js-api-doc/legacy/plugin_this.d.ts
+++ b/js-api-doc/legacy/plugin_this.d.ts
@@ -27,8 +27,8 @@ export interface LegacyPluginThis {
 
     /**
      * The value passed to [[LegacySharedOptions.includePaths]] separated by
-     * `";"` on Windows or `":"` on other operating systems, or an empty
-     * array if no value was passed.
+     * `";"` on Windows or `":"` on other operating systems. This always
+     * includes the current working directory as the first entry.
      */
     includePaths: string;
 
@@ -47,10 +47,10 @@ export interface LegacyPluginThis {
     indentWidth: number;
 
     /**
-     * The value passed to [[LegacySharedOptions.linefeed]], or `"lf"`
+     * The value passed to [[LegacySharedOptions.linefeed]], or `"\n"`
      * otherwise.
      */
-    linefeed: 'cr' | 'crlf' | 'lf' | 'lfcr';
+    linefeed: '\r' | '\r\n' | '\n' | '\n\r';
 
     /** A partially-constructed [[LegacyResult]] object. */
     result: {

--- a/spec/js-api/legacy/plugin_this.d.ts
+++ b/spec/js-api/legacy/plugin_this.d.ts
@@ -42,10 +42,15 @@ export interface LegacyPluginThis {
     indentWidth: number;
 
     /**
-     * The `linefeed` option passed to the `render()` or `renderSync()`, or
-     * `'lf'` if no value was passed.
+     * A value based on the `linefeed` option passed to the `render()` or
+     * `renderSync()`:
+     *
+     * * If `linefeed` is `"cr"`, this must be `"\r"`.
+     * * If `linefeed` is `"crlf"`, this must be `"\r\n"`.
+     * * If `linefeed` is `"lf"` or `undefined`, this must be `"\n"`.
+     * * If `linefeed` is `"lfcr"`, this must be `"\n\r"`.
      */
-    linefeed: 'cr' | 'crlf' | 'lf' | 'lfcr';
+    linefeed: '\r' | '\r\n' | '\n' | '\n\r';
 
     result: {
       stats: {


### PR DESCRIPTION
The new documentation/typings reflect the actual behavior of both Node
Sass and Dart Sass.