### PR TITLE
Add a license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,10 @@
+MIT License
+
+Copyright (c) The Sass Authors
+Copyright (c) 2006-2016 Hampton Catlin, Natalie Weizenbaum, and Chris Eppstein
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
As stated in #3239, the license is not set. I suggest using MIT license for this repo.
# Why?
Specifications and API documentation are used by developers as a reference to build new tools. When it's not licensed, it's proprietary. This makes some problems.
- SASS-based languages must write new specification instead of modifying SASS Spec. This wastes developers' time describing how things work, rather than taking the finished material.
- After Oracle sues Google for using the Java API, it is better to add a license wherever the API is, rather than think it is not covered.
After all, the specification is derived from Ruby SASS reference. You need to credit that authors. I added credits to the license file.
I added MIT LICENSE, because it's state "software and all associated documentation", and implementations of SASS may refer to these specs, so this repo should be under MIT. And sass-spec repo is MIT-Licensed too.