### PR TITLE
Fix FileImporter example documentation to `require` correct module

### DIFF
--- a/js-api-doc/importer.d.ts
+++ b/js-api-doc/importer.d.ts
@@ -23,7 +23,7 @@ import {PromiseOr} from './util/promise_or';
  * @example
  *
  * ```js
- * const {fileURLToPath} = require('url');
+ * const {pathToFileURL} = require('url');
  *
  * sass.compile('style.scss', {
  *   importers: [{


### PR DESCRIPTION
Fixes #3267.

This PR updates the example code in the [FileImporter](https://sass-lang.com/documentation/js-api/interfaces/FileImporter) documentation, to import Node's `url` module [`pathToFileURL`](https://github.com/sass/sass/issues/3267) instead of [`fileURLToPath`](https://nodejs.org/api/url.html#urlfileurltopathurl).