### PR TITLE
Update spec for relative imports in `compileString()`

### DIFF
--- a/js-api-doc/options.d.ts
+++ b/js-api-doc/options.d.ts
@@ -333,8 +333,8 @@ export interface Options<sync extends 'sync' | 'async'> {
  * Options that can be passed to [[compileString]] or [[compileStringAsync]].
  *
  * If the [[StringOptionsWithImporter.importer]] field isn't passed, the
- * entrypoint file can't load files relative to itself and the [[url]] field is
- * optional.
+ * entrypoint file can load files relative to itself if a `file://` URL is
+ * passed to the [[url]] field.
  *
  * @typeParam sync - This lets the TypeScript checker verify that asynchronous
  * [[Importer]]s, [[FileImporter]]s, and [[CustomFunction]]s aren't passed to
@@ -354,9 +354,11 @@ export interface StringOptionsWithoutImporter<sync extends 'sync' | 'async'>
   syntax?: Syntax;
 
   /**
-   * The canonical URL of the entrypoint stylesheet. If this isn't passed along
-   * with [[StringOptionsWithoutImporter.importer]], it's optional and only used
-   * for error reporting.
+   * The canonical URL of the entrypoint stylesheet.
+   *
+   * A relative load's URL is first resolved relative to [[url]], then resolved
+   * to a file on disk if it's a `file://` URL. If it can't be resolved to a
+   * file on disk, it's then passed to [[importers]] and [[loadPaths]].
    *
    * @category Input
    */

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -141,7 +141,8 @@ It runs as follows:
     > This importer will only ever be passed absolute URLs, so its base won't
     > matter.
 
-  * If `url` is not a `file:` URL, set `importer` to be a no-op importer.
+  * If `url` is not a `file:` URL, set `importer` to be a function that always
+    returns null.
 
 * Let `file` be the [source file][] with `ast`, canonical URL `url`, and
   importer `importer`.

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -133,7 +133,15 @@ It runs as follows:
     > value, implementations should help users understand the source of the string
     > if possible.
 
-* If `importer` is null, set it to a function that always returns null.
+* If `importer` is null:
+
+  * If `url` is a `file:` URL, set `importer` to be a [filesystem importer] with an
+    arbitrary `base`.
+
+    > This importer will only ever be passed absolute URLs, so its base won't
+    > matter.
+
+  * If `url` is not a `file:` URL, set `importer` to be a no-op importer.
 
 * Let `file` be the [source file][] with `ast`, canonical URL `url`, and
   importer `importer`.


### PR DESCRIPTION
The current documentation for the `url` field in `StringOptionsWithoutImporter` is incorrect that it does not match the behavior defined in [js-api-spec](https://github.com/sass/sass-spec/blob/126d17ff9f77372b6f68cb0d43dd357165519c93/js-api-spec/compile.test.ts#L124-L133) and actual implementation:

``` js
    it('url is used to resolve relative loads', () =>
      sandbox(dir => {
        dir.write({'foo/bar/_other.scss': 'a {b: c}'});

        expect(
          compileString('@use "other";', {
            url: dir.url('foo/bar/style.scss'),
          }).css
        ).toBe('a {\n  b: c;\n}');
      }));
```

- Fixes https://github.com/sass/dart-sass/issues/1657.