### PR TITLE
Fix the algorithm computing the default use namespace

### DIFF
--- a/spec/at-rules/use.md
+++ b/spec/at-rules/use.md
@@ -95,8 +95,8 @@ This algorithm takes a `@use` rule `rule`, and returns either an identifier or
 * Let `basename` be the text after the final `/` in `path`, or the entire `path`
   if `path` doesn't contain `/`.
 
-* Let `module-name` be the text before the first `.` in `path`, or the entire
-  `path` if `path` doesn't contain `.`.
+* Let `module-name` be the text before the first `.` in `basename`, or the entire
+  `basename` if `basename` doesn't contain `.`.
 
 * If `module-name` begins with `_`, remove the leading `_` and set `module-name`
   to the result.


### PR DESCRIPTION
The described algorithm contains a mistake. It should use the `basename` defined in the previous step to compute the module name, not the full path.

dart-sass already implements the proper behavior using the basename, so this makes the spec match the reference implementation.