### PR TITLE
Exempt Twitter links from the link check test

### DIFF
--- a/test/link-check.ts
+++ b/test/link-check.ts
@@ -73,6 +73,8 @@ function runLinkCheck(
           baseUrl: '',
           // If Github rate limit is reached, wait 60s and try again.
           retryOn429: true,
+          // Twitter links consistently fail.
+          ignorePatterns: [{pattern: /^https?:\/\/twitter\.com(\/|$)/}],
         },
         (error, results) => {
           if (error) {

--- a/tool/types/markdown-link-check.d.ts
+++ b/tool/types/markdown-link-check.d.ts
@@ -3,6 +3,7 @@ declare module 'markdown-link-check' {
     export interface Options {
       baseUrl?: string;
       retryOn429?: boolean;
+      ignorePatterns: Array<{pattern: RegExp}>;
     }
 
     export interface Result {


### PR DESCRIPTION
These have recently begun failing and blocking our CI.