### PR TITLE
Add the syntax definition for the import rule

### DIFF
--- a/spec/at-rules/import.md
+++ b/spec/at-rules/import.md
@@ -6,6 +6,23 @@ still supported for backwards-compatibility.
 
 [`@use` rule]: use.md
 
+## Table of Contents
+
+* [Syntax](#syntax)
+* [Semantics](#semantics)
+
+## Syntax
+
+<x><pre>
+**ImportRule**                ::= '@import' ImportArgument (',' ImportArgument)*
+**ImportArgument**            ::= ImportUrl ImportSupportsDeclaration? [MediaQueryList][]?
+**ImportUrl**                 ::= QuotedString | [InterpolatedUrl][]
+**ImportSupportsDeclaration** ::= 'supports(' SupportsDeclaration ')'
+</pre></x>
+
+[InterpolatedUrl]: ../syntax.md#InterpolatedUrl
+[MediaQueryList]: media.md#syntax
+
 ## Semantics
 
 To execute an `@import` rule `rule`:
@@ -16,8 +33,9 @@ To execute an `@import` rule `rule`:
 
     * `argument`'s URL string begins with `http://` or `https://`.
     * `argument`'s URL string ends with `.css`.
-    * `argument`'s URL string is syntactically defined as a `url()`.
-    * `argument` has a media query and/or a supports query.
+    * `argument`'s URL is an `InterpolatedUrl`.
+    * `argument` has an `ImportSupportsDeclaration`.
+    * `argument` has a `MediaQueryList`.
 
     > Note that this means that imports that explicitly end with `.css` are
     > treated as plain CSS `@import` rules, rather than importing stylesheets as

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -7,6 +7,7 @@
   * [Vendor Prefix](#vendor-prefix)
 * [Grammar](#grammar)
   * [`InterpolatedIdentifier`](#interpolatedidentifier)
+  * [`InterpolatedUrl`](#interpolatedurl)
   * [`Name`](#name)
   * [`SpecialFunctionExpression`](#specialfunctionexpression)
   * [`PseudoSelector`](#pseudoselector)
@@ -49,6 +50,17 @@ as the *unprefixed identifier*.
 [Name]: #name
 
 No whitespace is allowed between components of an `InterpolatedIdentifier`.
+
+### `InterpolatedUrl`
+
+<x><pre>
+**InterpolatedUrl**         ::= 'url(' (QuotedString | InterpolatedUnquotedUrlContents) ')'
+**InterpolatedUnquotedUrlContents** ::= ([unescaped url contents][] | [escape][] | Interpolation)*
+</pre></x>
+
+[unescaped url contents]: https://www.w3.org/TR/css-syntax-3/#url-token-diagram
+
+No whitespace is allowed between components of an `InterpolatedUnquotedUrlContents`.
 
 ### `Name`
 


### PR DESCRIPTION
This adds the BNF for the existing support of `@import`. Once it is merged, I will update #3290 to update that BNF with the layer condition.

I took 2 shortcuts here:
- I referenced `SupportsDeclaration` without declaring it (declaring it would be the scope of the BNF for the `@supports` rule, which is not yet in the spec). Note that there are precedents for that (for instance, `ArgumentDeclaration` is used in several places but not declared either)
- for `InterpolatedDynamicUrl`, I used a `unescaped url contents` pointing to the CSS spec about url-token, even though this is only a subpart of the `url-token` diagram and not a reusable diagram on its own (unlike `escape`)