### PR TITLE
Note configurations are shared across all files in a module by instance given a uniquely-identifying opaque ID

### DIFF
--- a/spec/at-rules/forward.md
+++ b/spec/at-rules/forward.md
@@ -48,9 +48,10 @@ To execute a `@forward` rule `rule`:
 
 * If `rule` has an `AsClause` with identifier `prefix`:
 
-  * Let `rule-config` be an empty [configuration][].
+  * Let `rule-config` be an empty [configuration] inheriting the opaque ID
+    from [the current configuration].
 
-  * For each variable `variable` in [the current configuration][]:
+  * For each variable `variable` in the current configuration:
 
     * If `variable`'s name begins with `prefix`:
 
@@ -66,7 +67,7 @@ To execute a `@forward` rule `rule`:
 
 * If `rule` has a `WithClause`:
 
-  * Set `rule-config` to a copy of itself.
+  * Set `rule-config` to a copy of itself including its opaque ID.
 
   * For each `ForwardWithArgument` `argument` in this clause:
 
@@ -96,7 +97,7 @@ To execute a `@forward` rule `rule`:
 * For every member `member` in `forwarded`:
 
   * Let `name` be `member`'s name.
-  
+
   * If `rule` has an `AsClause` `as`, prepend `as`'s identifier to `name` (after
     the `$` if `member` is a variable).
 

--- a/spec/at-rules/forward.md
+++ b/spec/at-rules/forward.md
@@ -48,8 +48,8 @@ To execute a `@forward` rule `rule`:
 
 * If `rule` has an `AsClause` with identifier `prefix`:
 
-  * Let `rule-config` be an empty [configuration] inheriting the opaque ID
-    from [the current configuration].
+  * Let `rule-config` be an empty [configuration] with the same opaque ID as
+    [the current configuration].
 
   * For each variable `variable` in the current configuration:
 

--- a/spec/modules.md
+++ b/spec/modules.md
@@ -260,11 +260,13 @@ This algorithm takes a string `argument` and [configuration](#configuration)
 
 * If `file` is null, throw an error.
 
-* If `file` has already been [executed][]:
+* If `file` has already been [executed] by the [Loading a Module] procedure:
 
   [executed]: spec.md#executing-a-file
+  [Loading a Module]: #loading-a-module
 
-  * If `config` has a different ID than before and is not empty, throw an error.
+  * If `config` is not empty and has a different ID than the configuration that
+    was passed the first time `file` was executed, throw an error.
 
     > An ID may be reused in a new configuration via [`@forwards .. with`].
 

--- a/spec/modules.md
+++ b/spec/modules.md
@@ -263,16 +263,18 @@ This algorithm takes a string `argument` and [configuration](#configuration)
 * If `file` has already been [executed] by the [Loading a Module] procedure:
 
   [executed]: spec.md#executing-a-file
-  [Loading a Module]: #loading-a-module
 
   * If `config` is not empty and has a different ID than the configuration that
-    was passed the first time `file` was executed, throw an error.
+    was passed the first time `file` was executed by the [Loading a Module]
+    procedure, throw an error.
 
     > An ID may be reused in a new configuration via [`@forwards .. with`].
 
     [`@forwards .. with`]: ../spec/at-rules/forward.md#semantics
 
   * Otherwise, return the module that execution produced.
+
+  [Loading a Module]: #loading-a-module
 
 * If `file` is currently being executed, throw an error.
 

--- a/spec/modules.md
+++ b/spec/modules.md
@@ -38,7 +38,7 @@ Two members are considered identical if they have the same name, type, source
 location, and were defined in or forwarded from the same original module.
 
 > Each member type has its own namespace in Sass, so for example the mixin
-> `name` doesn't conflict with the function `name` or the variable `$name`. 
+> `name` doesn't conflict with the function `name` or the variable `$name`.
 
 ### CSS Tree
 
@@ -52,9 +52,9 @@ An *empty CSS tree* contains no statements.
 ### Configuration
 
 A *configuration* is a map from [variable](variables.md) names to SassScript
-values. An *empty configuration* contains no entries.
+values and an opaque ID. An *empty configuration* contains no entries.
 
-[source file]: syntax.md#source-file
+A new *configuration* ID is unique unless otherwise specified.
 
 ### Module
 
@@ -62,11 +62,11 @@ A *module* is a collection of various properties:
 
 * A set of [members](#member) that contains at most one member of any given type
   and name.
-  
+
   > For example, a module may not have two variables named `$name`, although it
   > may contain a function and a mixin with the same name or two functions with
   > different names.
-  
+
   > The names (and mixin and function signatures) of a module's members are
   > static, and can be determined without executing its associated source file.
   > This means that any possible module for a given source file has the same
@@ -98,6 +98,8 @@ A *module* is a collection of various properties:
 
   > Note that [built-in modules](#built-in-module) *do not* have source files
   > associated with them.
+
+  [source file]: syntax.md#source-file
 
 * An absolute URL, known as the module's *canonical URL*. If the module has a
   source file, this must be the same as the source file's canonical URL.
@@ -262,7 +264,11 @@ This algorithm takes a string `argument` and [configuration](#configuration)
 
   [executed]: spec.md#executing-a-file
 
-  * If `config` is not empty, throw an error.
+  * If `config` has a different ID than before and is not empty, throw an error.
+
+    > An ID may be reused in a new configuration via [`@forwards .. with`].
+
+    [`@forwards .. with`]: ../spec/at-rules/forward.md#semantics
 
   * Otherwise, return the module that execution produced.
 


### PR DESCRIPTION
See:
- https://github.com/sass/sass-spec/pull/1796
- https://github.com/sass/dart-sass/pull/1739