### PR TITLE
Fix typo in variable name

### DIFF
--- a/proposal/color-4-new-spaces.md
+++ b/proposal/color-4-new-spaces.md
@@ -310,7 +310,7 @@ $orange-oklch: oklch(68.72% 20.966858279% 41.4189852913deg);
 $equal: $orange-rgb == $orange-oklch;
 
 // result: true
-$same: color.same($orange-rb, $orange-oklch);
+$same: color.same($orange-rgb, $orange-oklch);
 ```
 
 ### Existing Sass Color Functions


### PR DESCRIPTION
Same typo also occurs in https://sass-lang.com/blog/request-for-comments-color-spaces