### PR TITLE
fix: add node types to prod dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,11 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "sass",
       "dependencies": {
         "@types/diff": "^5.0.1",
         "@types/glob": "^7.1.4",
+        "@types/node": "^14.11.2",
         "@types/prettier": "^2.4.1",
         "colors": "^1.3.3",
         "diff": "^5.0.0",
@@ -20,7 +22,6 @@
         "typedoc": "^0.22.4"
       },
       "devDependencies": {
-        "@types/node": "^14.11.2",
         "gts": "^3.1.0",
         "typescript": "^4.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "prettier": "^2.4.1",
     "source-map-js": "^0.6.2",
     "ts-node": "^10.2.1",
-    "typedoc": "^0.22.4"
+    "typedoc": "^0.22.4",
+    "@types/node": "^14.11.2"
   },
   "devDependencies": {
-    "@types/node": "^14.11.2",
     "gts": "^3.1.0",
     "typescript": "^4.0.3"
   }


### PR DESCRIPTION
You ship your own types now, but actually depend on node's types in those types.

`@types/node` is currently a dev dependency, which means we don't pull it down automatically when we install `sass`. That means the sass types will fail to compile, since the node types it depends on will be missing.

It should really be a production dependency.

Slight pain since it means non-ts consumers will have to pull it down, but it is the way. If you're publishing typescript types, your type dependencies need to be declared as regular dependencies.

let me know your thoughts