### PR TITLE
Document the progress of deprecating `@import`

### DIFF
--- a/accepted/module-system.md
+++ b/accepted/module-system.md
@@ -1795,3 +1795,8 @@ removing `@import` has been pushed back. We now intend to wait until 80% of
 users are using Dart Sass (measured by npm downloads) before deprecating
 `@import`, and wait at least a year after that and likely more before removing
 it entirely.
+
+**March 2023**: As week of Mar 06 to Mar 12, the npm downloads of the sass and
+node-sass packages are 11,700,729 and 2,831,234 respectively, meaning we have
+reached 80.5% adoption rate for Dart Sass, which is above the target for making
+the deprecation `@import` current.


### PR DESCRIPTION
This PR updates the documentation tracking the progress of deprecating `@import`, to state that we have reached the 80% adoption target for Dart Sass in order to move this deprecation from "future" to "current".

cc @nex3 @jathak