### PR TITLE
Remove 'spec/**/*.ts' from tsconfig.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
       "*": ["./tool/types/*"]
     }
   },
-  "include": ["accepted/**/*.ts", "proposal/**/*.ts", "spec/**/*.ts", "tool/**/*.ts", "test/**/*.ts", "js-api-doc/**/*.ts"]
+  "include": ["accepted/**/*.ts", "proposal/**/*.ts", "tool/**/*.ts", "test/**/*.ts", "js-api-doc/**/*.ts"]
 }


### PR DESCRIPTION
This fixes issues for tools that compile the entire project (such as sass-site CI). The issue was that the 'spec' directory no longer contains valid TS after moving to the 'literate' tool.

Fixes https://github.com/sass/sass-site/issues/726