### PR TITLE
Fix a typo

### DIFF
--- a/proposal/embedded-protocol-2.md
+++ b/proposal/embedded-protocol-2.md
@@ -52,7 +52,7 @@ This proposal makes three breaking changes to the embedded Sass protocol:
 * Use optional fields as defined in protocol buffers 3.15.0 instead of treating
   default field values as absent.
 
-* Move `CompileSuccess.loaded_urls` to `CompileResult.loaded_urls` so it's
+* Move `CompileSuccess.loaded_urls` to `CompileResponse.loaded_urls` so it's
   available even when compilation fails.
 
 ### Design Decisions


### PR DESCRIPTION
As we meant to move `loaded_urls` one level up, the protobuf type should be `CompileResponse`, instead of the JavaScript type `CompileResult`.

@nex3