### PR TITLE
[Previous URL] Expand to embedded protocol and filesystem importers

### DIFF
--- a/proposal/prev-url.d.ts.changes.md
+++ b/proposal/prev-url.d.ts.changes.md
@@ -1,6 +1,14 @@
+## Draft 2.0
+
+* Expand the proposal to cover the embedded protocol as well.
+
+* Always pass `containingUrl` to `FilesystemImporter`s, since they always return
+  `file:` canonical URLs and are never invoked for absolute `file:` URLs.
+
 ## Draft 1.1
 
-* Throw an error when an importer returns a canonical URL using its non-canonical schemes.
+* Throw an error when an importer returns a canonical URL using its
+  non-canonical schemes.
 
 ## Draft 1
 

--- a/proposal/prev-url.d.ts.md
+++ b/proposal/prev-url.d.ts.md
@@ -17,10 +17,20 @@ import {PromiseOr} from '../spec/js-api/util/promise_or';
       * [Unavailable for Pre-Resolved Loads](#unavailable-for-pre-resolved-loads)
       * [Unavailable for Absolute Loads](#unavailable-for-absolute-loads)
 * [Types](#types)
+  * [`FileImporter`](#fileimporter)
+    * [`findFileUrl`](#findfileurl)
   * [`Importer`](#importer)
     * [`nonCanonicalScheme`](#noncanonicalscheme)
     * [`canonicalize`](#canonicalize)
 * [Embedded Protocol](#embedded-protocol)
+  * [`Importer`](#importer-1)
+    * [`non_canonical_scheme`](#non_canonical_scheme)
+  * [`CanonicalizeRequest`](#canonicalizerequest)
+    * [`containing_url`](#containing_url)
+  * [`CanonicalizeResponse`](#canonicalizeresponse)
+    * [`url`](#url)
+  * [`FileImportRequest`](#fileimportrequest)
+    * [`containing_url`](#containing_url-1)
 
 ## Background
 
@@ -184,6 +194,10 @@ findFileUrl(
 ): PromiseOr<URL | null, sync>;
 ```
 
+```ts
+} // FileImporter
+```
+
 ### `Importer`
 
 Replace the first two bullet points for [invoking an importer with a string]
@@ -239,7 +253,7 @@ nonCanonicalScheme?: string | string[];
 ```
 
 ```ts
-} // module
+} // Importer
 ```
 
 ## Embedded Protocol

--- a/proposal/prev-url.d.ts.md
+++ b/proposal/prev-url.d.ts.md
@@ -231,9 +231,9 @@ interface Importer<sync extends 'sync' | 'async' = 'sync' | 'async'> {
 The set of URL schemes that are considered *non-canonical* for this importer. If
 this is a single string, treat it as a list containing that string.
 
-Before beginning compilation, throw an error if any element of this contains a
-character other than a lowercase ASCII letter, an ASCII numeral, U+002B (`+`),
-U+002D (`-`), or U+002E (`.`).
+Before beginning compilation, throw an error if any element of this is empty or
+contains a character other than a lowercase ASCII letter, an ASCII numeral,
+U+002B (`+`), U+002D (`-`), or U+002E (`.`).
 
 > Uppercase letters are normalized to lowercase in the `URL` constructor, so for
 > simplicity and efficiency we only allow lowercase here.

--- a/proposal/prev-url.d.ts.md
+++ b/proposal/prev-url.d.ts.md
@@ -284,7 +284,7 @@ The compiler must set this if and only if `url` is relative or its scheme is
 [non-canonical][non-canonical-proto] for the importer being invoked, unless the
 current source file has no canonical URL.
 
-[non-canonical-proto]: #non-canonical-scheme
+[non-canonical-proto]: #non_canonical_scheme
 
 ```proto
 optional string containing_url = 6;

--- a/spec/embedded-protocol.md
+++ b/spec/embedded-protocol.md
@@ -376,7 +376,7 @@ compatible" change because older hosts can simply opt not to use it, even though
 from the perspective of the compiler a new message type would be a breaking
 change.
 
-[the protocol buffer rules for updating a message type]: https://developers.google.com/protocol-buffers/docs/proto#updating
+[the protocol buffer rules for updating a message type]: https://protobuf.dev/programming-guides/proto3/#updating
 
 Hosts are generally expected to be responsible for installing appropriate
 compiler versions as part of their installation process, which should limit the


### PR DESCRIPTION
This updates the embedded protocol to support the proposal and adds
support for passing the previous URL to filesystem importers.