### PR TITLE
[Calc Functions] Match the spec's behavior better for percentages

### DIFF
--- a/accepted/calc-functions.changes.md
+++ b/accepted/calc-functions.changes.md
@@ -1,3 +1,20 @@
+## Draft 1.4
+
+* Don't exempt percentages from most functions' simplification logic, since
+  those functions don't allow _any_ units in CSS, including percents. Now only
+  `abs()`, `sign()`, `atan2()`, and `hypot()` check for known units because CSS
+  allows percentages for them but they aren't linear so they can't be resolved
+  in terms of percentages in Sass.
+
+* Add non-normative notes clarifying when units are implicitly disallowed by
+  passing them on to built-in Sass functions.
+
+* Clarify that `log()` can invoke the built-in Sass function with one or two
+  arguments.
+
+* Remove duplicated text checking for too few arguments for `pow()` and
+  `atan2()`.
+
 ## Draft 1.3
 
 * Update the definition of potentially slash-separated numbers to exclude

--- a/accepted/calc-functions.changes.md
+++ b/accepted/calc-functions.changes.md
@@ -9,6 +9,9 @@
 * Throw an error if `clamp()` or `hypot()` has known-incompatible arguments even
   if they aren't all numbers.
 
+* Throw an error if any argument to `pow()` or `log()` is a number with units,
+  even if the function can't otherwise be simplified.
+
 * Add non-normative notes clarifying when units are implicitly disallowed by
   passing them on to built-in Sass functions.
 

--- a/accepted/calc-functions.changes.md
+++ b/accepted/calc-functions.changes.md
@@ -6,6 +6,9 @@
   allows percentages for them but they aren't linear so they can't be resolved
   in terms of percentages in Sass.
 
+* Throw an error if `clamp()` or `hypot()` has known-incompatible arguments even
+  if they aren't all numbers.
+
 * Add non-normative notes clarifying when units are implicitly disallowed by
   passing them on to built-in Sass functions.
 

--- a/accepted/calc-functions.md
+++ b/accepted/calc-functions.md
@@ -300,8 +300,8 @@ This algorithm takes a calculation `calc` and returns a number or a calculation.
 
   [`sass:math`]: ../spec/built-in-modules/math.md
 
-  > Other than `round()`, all of these functions will throw errors if their
-  > arguments have any units.
+  > The `sass:math` functions will check units here for the functions that
+  > require specific or no units.
 
 * If `calc`'s name is `"abs"` and `arguments` contains exactly a single number
   with [known units], return the result of passing that number to the function

--- a/accepted/calc-functions.md
+++ b/accepted/calc-functions.md
@@ -328,7 +328,7 @@ This algorithm takes a calculation `calc` and returns a number or a calculation.
 * If `calc`'s name is `"log"`, return the result of passing its arguments to the
   [`log()` function] in [`sass:math`].
 
-  [`log()` function]: #log
+  [`log()` function]: ../spec/built-in-modules/math.md#log
 
   > This will throw an error if any arguments have units.
 
@@ -338,7 +338,7 @@ This algorithm takes a calculation `calc` and returns a number or a calculation.
 
   > This will throw an error if either argument has units.
 
-  [`pow()` function]: #pow
+  [`pow()` function]: ../spec/built-in-modules/math.md#pow
 
 * If `calc`'s name is `"atan2"` and `arguments` contains two numbers which both
   have [known units], return the result of passing those numbers to the
@@ -349,7 +349,7 @@ This algorithm takes a calculation `calc` and returns a number or a calculation.
   > `atan2()` passes percentages along to the browser because they may resolve
   > to negative values, and `atan2(-x, -y) != atan2(x, y)`.
 
-  [`atan2()` function]: #atan2
+  [`atan2()` function]: ../spec/built-in-modules/math.md#atan2
 
 * If `calc`'s name is `"mod"` or `"rem"`:
 

--- a/accepted/calc-functions.md
+++ b/accepted/calc-functions.md
@@ -1,4 +1,4 @@
-# Calculation Functions: Draft 1.3
+# Calculation Functions: Draft 1.4
 
 *([Issue](https://github.com/sass/sass/issues/3504))*
 
@@ -294,16 +294,25 @@ This algorithm takes a calculation `calc` and returns a number or a calculation.
   > otherwise calculations' arguments must match the expected number.
 
 * If `calc`'s name is `"sin"`, `"cos"`, `"tan"`, `"asin"`, `"acos"`, `"atan"`,
-  `"sqrt"`, `"abs"`, `"log"`, or `"round"` and `arguments` contains exactly a
-  single number with [known units], return the result of passing that number to
-  the function in [`sass:math`] whose name matches `calc`'s.
+  `"sqrt"`, `"log"`, or `"round"` and `arguments` contains exactly a single
+  number, return the result of passing that number to the function in
+  [`sass:math`] whose name matches `calc`'s.
 
-  [known units]: #known-units
   [`sass:math`]: ../spec/built-in-modules/math.md
 
+  > Other than `round()`, all of these functions will throw errors if their
+  > arguments have any units.
+
+* If `calc`'s name is `"abs"` and `arguments` contains exactly a single number
+  with [known units], return the result of passing that number to the function
+  in [`sass:math`] whose name matches `calc`'s.
+
+  [known units]: #known-units
+
 * If `calc`'s name is `"exp"` and `arguments` contains exactly a single number
-  `number` with [known units], return the result of calling `math.pow(math.$e,
-  number)`.
+  `number`, return the result of calling `math.pow(math.$e, number)`.
+
+  > This will throw an error if the argument has units.
 
 * If `calc`'s name is `"sign"` and `arguments` contains exactly a single number
   `number` with [known units]:
@@ -316,14 +325,31 @@ This algorithm takes a calculation `calc` and returns a number or a calculation.
 
   > To match CSS's behavior, these computations _don't_ use fuzzy comparisons.
 
-* If `calc`'s name is `"atan2"`, `"pow"`, or `"log"`:
+* If `calc`'s name is `"log"`, return the result of passing its arguments to the
+  [`log()` function] in [`sass:math`].
 
-  * If `calc`'s name isn't `"log"`, `arguments` has only one element, and it's
-    not an unquoted string or a `CalculationInterpolation`, throw an error.
+  [`log()` function]: #log
 
-  * Otherwise, if `arguments` contains exactly two numbers with [known units],
-    return the result of passing that number to the function in [`sass:math`]
-    whose name matches `calc`'s.
+  > This will throw an error if any arguments have units.
+
+* If `calc`'s name is `"pow"`, and `arguments` contains exactly two numbers,
+  return the result of passing those numbers to the [`pow()` function] in
+  [`sass:math`].
+
+  > This will throw an error if either argument has units.
+
+  [`pow()` function]: #pow
+
+* If `calc`'s name is `"atan2"` and `arguments` contains two numbers which both
+  have [known units], return the result of passing those numbers to the
+  [`atan2()` function] in [`sass:math`].
+
+  > This will throw an error if either argument has units.
+  >
+  > `atan2()` passes percentages along to the browser because they may resolve
+  > to negative values, and `atan2(-x, -y) != atan2(x, y)`.
+
+  [`atan2()` function]: #atan2
 
 * If `calc`'s name is `"mod"` or `"rem"`:
 
@@ -332,10 +358,6 @@ This algorithm takes a calculation `calc` and returns a number or a calculation.
 
   * Otherwise, if `arguments` contains exactly two numbers `dividend` and
     `modulus`:
-
-    > These numbers need not have known units, since mod and rem are linear
-    > functions so they'll work equivalently for percentages as for the numbers
-    > they represent.
 
     * If `dividend` and `modulus` are [definitely-incompatible], throw an error.
 
@@ -353,7 +375,6 @@ This algorithm takes a calculation `calc` and returns a number or a calculation.
       * Otherwise, return `result`.
 
   [definitely-incompatible]: ../spec/types/number.md#possibly-compatible-numbers
-  [compatible]: ../spec/types/number.md#compatible-units
   [exactly equals]: #exact-equality
 
 * If `calc`'s name is `"round"`:
@@ -399,7 +420,7 @@ This algorithm takes a calculation `calc` and returns a number or a calculation.
         * If `step`'s value is infinite:
 
           * If `strategy`'s value is `"nearest"` or `"to-zero"`, return `+0` if
-            `number`'s value is positive or `+0` and `-0` otherwise.
+            `number`'s value is positive or `+0`, and `-0` otherwise.
 
           * If `strategy`'s value is `"up"`, return positive infinity if
             `number`'s value is positive, `+0` if `number`'s value is `+0`, and
@@ -445,13 +466,17 @@ This algorithm takes a calculation `calc` and returns a number or a calculation.
     * Otherwise, if any two of those arguments are [definitely-incompatible],
       throw an error.
 
-* If `calc`'s name is `"hypot"` and `arguments` are all numbers:
+* If `calc`'s name is `"hypot"` and `arguments` are all numbers with [known
+  units]:
 
   * If those arguments are mutually [compatible], return the result of calling
     `math.hypot()` with those arguments.
 
   * Otherwise, if any two of those arguments are [definitely-incompatible],
     throw an error.
+
+  > `hypot()` has an exemption for percentages because it squares its inputs, so
+  > `hypot(-x, -y) != -hypot(x, y)`.
 
 * If `calc`'s name is `"min"` or `"max"` and `arguments` are all numbers:
 

--- a/accepted/calc-functions.md
+++ b/accepted/calc-functions.md
@@ -325,18 +325,21 @@ This algorithm takes a calculation `calc` and returns a number or a calculation.
 
   > To match CSS's behavior, these computations _don't_ use fuzzy comparisons.
 
-* If `calc`'s name is `"log"`, return the result of passing its arguments to the
-  [`log()` function] in [`sass:math`].
+* If `calc`'s name is `"log"`:
+
+  * If any argument is a number with units, throw an error.
+
+  * Otherwise, if `arguments` contains exactly two numbers, return the result of
+    passing its arguments to the [`log()` function] in [`sass:math`].
 
   [`log()` function]: ../spec/built-in-modules/math.md#log
 
-  > This will throw an error if any arguments have units.
+* If `calc`'s name is `"pow"`:
 
-* If `calc`'s name is `"pow"`, and `arguments` contains exactly two numbers,
-  return the result of passing those numbers to the [`pow()` function] in
-  [`sass:math`].
+  * If any argument is a number with units, throw an error.
 
-  > This will throw an error if either argument has units.
+  * Otherwise, if `arguments` contains exactly two numbers, return the result of
+    passing those numbers to the [`pow()` function] in [`sass:math`].
 
   [`pow()` function]: ../spec/built-in-modules/math.md#pow
 

--- a/accepted/calc-functions.md
+++ b/accepted/calc-functions.md
@@ -458,25 +458,23 @@ This algorithm takes a calculation `calc` and returns a number or a calculation.
   * If `arguments` has fewer than three elements, and none of those are unquoted
     strings or `CalculationInterpolation`s, throw an error.
 
-  * Otherwise, if `arguments` are all numbers:
+  * Otherwise, if any two elements of `arguments` are [definitely-incompatible]
+    numbers, throw an error.
 
-    * If those arguments are mutually [compatible], return the result of calling
-      `math.clamp()` with those arguments.
+  * Otherwise, if `arguments` are all mutually [compatible] numbers, return the
+    result of calling `math.clamp()` with those arguments.
 
-    * Otherwise, if any two of those arguments are [definitely-incompatible],
-      throw an error.
+* If `calc`'s name is `"hypot"`:
 
-* If `calc`'s name is `"hypot"` and `arguments` are all numbers with [known
-  units]:
-
-  * If those arguments are mutually [compatible], return the result of calling
-    `math.hypot()` with those arguments.
-
-  * Otherwise, if any two of those arguments are [definitely-incompatible],
+  * If any two elements of `arguments` are [definitely-incompatible] numbers,
     throw an error.
 
-  > `hypot()` has an exemption for percentages because it squares its inputs, so
-  > `hypot(-x, -y) != -hypot(x, y)`.
+  * Otherwise, if all `arguments` are all numbers with [known units] that are
+    mutually [compatible], return the result of calling `math.hypot()` with
+    those arguments.
+
+    > `hypot()` has an exemption for percentages because it squares its inputs,
+    > so `hypot(-x, -y) != -hypot(x, y)`.
 
 * If `calc`'s name is `"min"` or `"max"` and `arguments` are all numbers:
 


### PR DESCRIPTION
More functions disallow percentages in CSS than our spec did, so this
updates the spec to match.