### PR TITLE
Change markdownlint script executable, fix removed link

### DIFF
--- a/accepted/calculation-api.d.ts.md
+++ b/accepted/calculation-api.d.ts.md
@@ -290,6 +290,8 @@ export type CalculationOperator = '+' | '-' | '*' | '/';
 
 The JS API representation of a Sass [`CalculationOperation`].
 
+[`CalculationOperation`]: ../spec/types/calculation.md#types
+
 ```ts
 export class CalculationOperation implements ValueObject {
 ```

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "typedoc": "npm run tangle && npx typedoc --treatWarningsAsErrors js-api-doc/index.d.ts",
     "tangle": "npx ts-node tool/tangle.ts",
     "untangle": "npx ts-node tool/untangle.ts",
-    "markdownlint": "npx markdownlint-cli '**/*.md' '*.md' --ignore 'node_modules/**'",
+    "markdownlint": "npx markdownlint-cli2 '**/*.md' '*.md' --ignore 'node_modules/**'",
     "fix": "npm run update-toc && npm run markdownlint -- --fix && npm run tangle && gts fix && npm run untangle",
     "test": "npm run tangle && gts lint && tsc --noEmit && npm run toc-check && npm run link-check && npm run js-api-doc-check && npm run typedoc"
   },


### PR DESCRIPTION
The Calculation API link was missing the backticks, and so it was removed in the initial linting. 

I switched to `markdownlint-cli2` to match the installed package and CI.