### PR TITLE
Use buf instead of protoc to compile protobufs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: arduino/setup-protoc@v1
-        with: { version: "3.x", repo-token: "${{ github.token }}" }
+      - uses: bufbuild/buf-setup-action@v1.26.1
+        with: {github_token: "${{ github.token }}"}
       - name: Generate protobuf code
-        run: protoc --js_out=/tmp spec/embedded_sass.proto
+        run: buf generate --output=/tmp --path=spec/embedded_sass.proto
 
   embedded_protocol_versions:
     name: "Validate Embedded Protocol versions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - uses: bufbuild/buf-setup-action@v1.26.1
         with: {github_token: "${{ github.token }}"}
       - name: Generate protobuf code
-        run: buf generate --output=/tmp --path=spec/embedded_sass.proto
+        run: buf generate
 
   embedded_protocol_versions:
     name: "Validate Embedded Protocol versions"

--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ typings/
 # End of https://www.gitignore.io/api/node
 
 /docs
+/gen

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,0 +1,4 @@
+version: v1
+plugins:
+- plugin: buf.build/bufbuild/es
+  out: gen

--- a/buf.work.yaml
+++ b/buf.work.yaml
@@ -1,0 +1,2 @@
+version: v1
+directories: [spec]


### PR DESCRIPTION
This is a more consistent way of testing the validation of protobufs. This now avoids relying on protoc which dropped built-in support for generating JS. Fixes #3666