### PR TITLE
Add support for the relative color syntax from CSS Color 5

### DIFF
--- a/proposal/color-4-new-spaces.changes.md
+++ b/proposal/color-4-new-spaces.changes.md
@@ -1,3 +1,8 @@
+## Draft 1.11
+
+* Add support for the relative color syntax in the algorithm parsing color
+  arguments, for CSS compatibility.
+
 ## Draft 1.10
 
 * Properly scale `%` return values for `color.channel()`.

--- a/proposal/color-4-new-spaces.md
+++ b/proposal/color-4-new-spaces.md
@@ -1,4 +1,4 @@
-# CSS Color Level 4, New Color Spaces: Draft 1.10
+# CSS Color Level 4, New Color Spaces: Draft 1.11
 
 *([Issue](https://github.com/sass/sass/issues/2831))*
 
@@ -1022,6 +1022,10 @@ The procedure is:
 * Otherwise:
 
   * If `components` is not an unbracketed space-separated list, throw an error.
+
+  * If the first element of `components` is an unquoted string which is
+    case-insensitively equal to `from`, return an unquoted string with the
+    value of `input`.
 
   * If `space` is null:
 

--- a/spec/functions.md
+++ b/spec/functions.md
@@ -272,6 +272,10 @@ plain CSS function named `"rgb"` that function is named `"rgba"` instead.
 
     * If `rgb` is not an unbracketed space-separated list, throw an error.
 
+    * If the first element of `rgb` is an unquoted string which is
+      case-insensitively equal to `from`, return a plain CSS function string
+      with the name `"rgb"` and the argument `$channels`.
+
     * If `rgb` has more than three elements, throw an error.
 
     * If `rgb` has fewer than three elements:
@@ -288,6 +292,10 @@ plain CSS function named `"rgb"` that function is named `"rgba"` instead.
       return the result.
 
   * If `$channels` is not an unbracketed space-separated list, throw an error.
+
+  * If the first element of `$channels` is an unquoted string which is
+    case-insensitively equal to `from`, return a plain CSS function string
+    with the name `"rgb"` and the argument `$channels`.
 
   * If `$channels` has more than three elements, throw an error.
 
@@ -398,6 +406,10 @@ plain CSS function named `"hsl"` that function is named `"hsla"` instead.
 
     * If `hsl` is not an unbracketed space-separated list, throw an error.
 
+    * If the first element of `hsl` is an unquoted string which is
+      case-insensitively equal to `from`, return a plain CSS function string
+      with the name `"hsl"` and the argument `$channels`.
+
     * If `hsl` has more than three elements, throw an error.
 
     * If `hsl` has fewer than three elements:
@@ -414,6 +426,10 @@ plain CSS function named `"hsl"` that function is named `"hsla"` instead.
       arguments and return the result.
 
   * If `$channels` is not an unbracketed space-separated list, throw an error.
+
+  * If the first element of `$channels` is an unquoted string which is
+    case-insensitively equal to `from`, return a plain CSS function string
+    with the name `"hsl"` and the argument `$channels`.
 
   * If `$channels` has more than three elements, throw an error.
 


### PR DESCRIPTION
When using the relative color syntax, the color function is emitted as a CSS function (similar to cases using a CSS variable in arguments).

This fast track proposal updates the definition of the `rgb` and `hsl` global functions. The proposal for color spaces is also updated to reflect the new parsing.

#3673