### PR TITLE
[Colors 4] Require quoted strings for `color.is-missing()`

### DIFF
--- a/proposal/color-4-new-spaces.changes.md
+++ b/proposal/color-4-new-spaces.changes.md
@@ -1,3 +1,8 @@
+## Draft 1.8
+
+* Require a quoted string for `color.is-missing()` for consistency with other
+  color functions and ease of use with channels whose names overlap with colors.
+
 ## Draft 1.7
 
 * Resolve missing `alpha` channels *after* premultiplying colors.

--- a/proposal/color-4-new-spaces.md
+++ b/proposal/color-4-new-spaces.md
@@ -1,4 +1,4 @@
-# CSS Color Level 4, New Color Spaces: Draft 1.7
+# CSS Color Level 4, New Color Spaces: Draft 1.8
 
 *([Issue](https://github.com/sass/sass/issues/2831))*
 
@@ -1581,7 +1581,7 @@ is-missing($color, $channel)
 
 * If `$color` is not a color, throw an error.
 
-* If `$channel` is not an unquoted string, throw an error.
+* If `$channel` is not a quoted string, throw an error.
 
 * If `$channel == alpha` (ignoring case), let `value` be the alpha value of
   `$color`.


### PR DESCRIPTION
See #2831