### PR TITLE
Package Importer updates

### DIFF
--- a/proposal/package-importer.changes.md
+++ b/proposal/package-importer.changes.md
@@ -6,6 +6,8 @@
 * Remove specified order in the global import list, as users can specify the
   order within the `importers` option.
 
+* Specify importer ordering for the Legacy API.
+
 ## Draft 1
 
 * Initial draft

--- a/proposal/package-importer.changes.md
+++ b/proposal/package-importer.changes.md
@@ -1,0 +1,10 @@
+## Draft 1.1
+
+* Throw an error if `nodePackageImporter` is used in the browser.
+
+* Remove specified order in the global import list, as users can specify the
+  order within the `importers` option.
+
+## Draft 1
+
+* Initial draft

--- a/proposal/package-importer.changes.md
+++ b/proposal/package-importer.changes.md
@@ -1,6 +1,7 @@
 ## Draft 1.1
 
-* Throw an error if `nodePackageImporter` is used in the browser.
+* Throw an error if `nodePackageImporter` is used in the browser or other
+  environment without filesystem access.
 
 * Remove specified order in the global import list, as users can specify the
   order within the `importers` option.

--- a/proposal/package-importer.d.ts.md
+++ b/proposal/package-importer.d.ts.md
@@ -273,8 +273,12 @@ Javascript Compile API, insert:
 ### Legacy API `pkgImporter`
 
 If set, the compiler will use the specified built-in package importer to resolve
-any URL with the `pkg:` scheme. Currently, the only available package importer
-is `node`, which follows Node resolution logic to locate Sass files.
+any URL with the `pkg:` scheme. This step will be inserted immediately before
+the existing legacy importer logic, and if the package importer returns `null`,
+the legacy importer logic will be invoked.
+
+Currently, the only available package importer is `node`, which follows Node
+resolution logic to locate Sass files.
 
 Defaults to undefined.
 

--- a/proposal/package-importer.d.ts.md
+++ b/proposal/package-importer.d.ts.md
@@ -256,7 +256,10 @@ Javascript Compile API, insert:
 * If any object in `options.importers` is exactly equal to the object
   `nodePackageImporter`:
 
-  * If the execution environment is the browser, throw an error.
+  * If no filesystem is available, throw an error.
+
+  > This primarily refers to a browser environment, but applies to other
+  > sandboxed JavaScript environments as well.
 
   * Let `pkgImporter` be a [Node Package Importer] with an associated
     `entryPointURL` of `require.main.filename`.

--- a/proposal/package-importer.d.ts.md
+++ b/proposal/package-importer.d.ts.md
@@ -256,6 +256,8 @@ Javascript Compile API, insert:
 * If any object in `options.importers` is exactly equal to the object
   `nodePackageImporter`:
 
+  * If the execution environment is the browser, throw an error.
+
   * Let `pkgImporter` be a [Node Package Importer] with an associated
     `entryPointURL` of `require.main.filename`.
 
@@ -305,11 +307,7 @@ Package Importers must reject the following patterns:
 * A URL whose path begins with `/`.
 * A URL with non-empty/null username, password, host, port, query, or fragment.
 
-Package Importers must be added to the [global importer list] immediately after any
-user-provided importers.
-
 [importer]: ../spec/modules.md#importer
-[global importer list]: ../spec/modules.md#global-importer-list
 
 ### Node Package Importer
 

--- a/proposal/package-importer.d.ts.md
+++ b/proposal/package-importer.d.ts.md
@@ -258,8 +258,8 @@ Javascript Compile API, insert:
 
   * If no filesystem is available, throw an error.
 
-  > This primarily refers to a browser environment, but applies to other
-  > sandboxed JavaScript environments as well.
+    > This primarily refers to a browser environment, but applies to other
+    > sandboxed JavaScript environments as well.
 
   * Let `pkgImporter` be a [Node Package Importer] with an associated
     `entryPointURL` of `require.main.filename`.


### PR DESCRIPTION
Changes: 

* Throw an error if `nodePackageImporter` is used in the browser.

* Remove specified order in the global import list, as users can specify the
  order within the `importers` option.

Closes https://github.com/sass/sass/issues/3701