### PR TITLE
Fix NodePackageImporter version compatibility

### DIFF
--- a/js-api-doc/importer.d.ts
+++ b/js-api-doc/importer.d.ts
@@ -415,7 +415,7 @@ declare const nodePackageImporterKey: unique symbol;
  * package, a user can import that file using `@use
  * "pkg:uicomponents/src/sass/colors";`.
  *
- * @compatibility dart: "2.0", node: false
+ * @compatibility dart: "1.71.0", node: false
  * @category Importer
  */
 export class NodePackageImporter {

--- a/test/link-check.ts
+++ b/test/link-check.ts
@@ -106,6 +106,8 @@ function runLinkCheck(
             {pattern: /^https?:\/\/blogs\.msdn\.microsoft\.com(\/|$)/},
             // Link consistently fails within CI
             {pattern: /^https:\/\/runtime-keys\.proposal\.wintercg\.org(\/|$)/},
+            // Stackoverflow links can get rate-limited on GitHub Actions
+            {pattern: /^https:\/\/stackoverflow\.com(\/|$)/},
           ],
         },
         (error, results) => {


### PR DESCRIPTION
https://sass-lang.com/documentation/js-api/classes/nodepackageimporter/ says it's compatible with `Dart Sass since 2.0`, this PR changes it to `1.71.0`.
