### PR TITLE
Broaden the the Node.js package importer's notion of "entrypoint"

### DIFF
--- a/js-api-doc/importer.d.ts
+++ b/js-api-doc/importer.d.ts
@@ -435,8 +435,8 @@ export class NodePackageImporter {
    * one of its parent directories, up to the filesystem root.
    *
    * Relative paths will be resolved relative to the current working directory.
-   * If a path is not provided, the default value of `require.main.filename`
-   * will be used.
+   * If a path is not provided, this defaults to the parent directory of the
+   * Node.js entrypoint. If that's not available, this will throw an error.
    */
   constructor(entryPointDirectory?: string);
 }

--- a/spec/js-api/compile.d.ts.md
+++ b/spec/js-api/compile.d.ts.md
@@ -134,15 +134,12 @@ Compiles the Sass file at `path`:
     > This primarily refers to a browser environment, but applies to other
     > sandboxed JavaScript environments as well.
 
-  * Let `entryPointDirectory` be the class's `entryPointDirectory` value if set,
-    resolved relative to the current working directory, and otherwise the parent
-    directory of `require.main.filename`. If `entryPointDirectory` is not passed
-    and `require.main.filename` is not available, throw an error.
-
   * Let `pkgImporter` be a [Node Package Importer] with an associated
-    `entryPointURL` of the absolute file URL for`entryPointDirectory`.
+    `entryPointURL` of the absolute file URL for the object's
+    [`entryPointDirectory`].
 
     [Node Package Importer]: ../modules.md#node-package-importer
+    [`entryPointDirectory`]: importer.d.ts.md#constructor
 
   * Replace the item with `pkgImporter` in a copy of `options.importers`.
 
@@ -205,13 +202,9 @@ Compiles the Sass `source`:
     > This primarily refers to a browser environment, but applies to other
     > sandboxed JavaScript environments as well.
 
-  * Let `entryPointDirectory` be the class's `entryPointDirectory` value if set,
-    resolved relative to the current working directory, and otherwise the parent
-    directory of `require.main.filename`. If `entryPointDirectory` is not passed
-    and `require.main.filename` is not available, throw an error.
-
   * Let `pkgImporter` be a [Node Package Importer] with an associated
-    `entryPointURL` of the absolute file URL for`entryPointDirectory`.
+    `entryPointURL` of the absolute file URL for the object's
+    [`entryPointDirectory`].
 
   * Replace the item with `pkgImporter` in a copy of `options.importers`.
 

--- a/spec/js-api/importer.d.ts.md
+++ b/spec/js-api/importer.d.ts.md
@@ -170,9 +170,46 @@ declare const nodePackageImporterKey: unique symbol;
 export class NodePackageImporter {
   /** Used to distinguish this type from any arbitrary object. */
   private readonly [nodePackageImporterKey]: true;
+```
 
+#### `entryPointDirectory`
+
+This is a private, spec-only string property that's used to determine the value
+of the `parentURL` parameter to `PACKAGE_RESOLVE` function from the [Node.js
+Resolution Algorithm].
+
+[Node.js Resolution Algorithm]: https://nodejs.org/api/esm.html#resolution-algorithm-specification
+
+#### Constructor
+
+Creates a `NodePackageImporter`:
+
+* If no filesystem is available, throw an error.
+
+  > This primarily refers to a browser environment, but applies to other
+  > sandboxed JavaScript environments as well.
+
+* If `entryPointDirectory` is not `undefined`, set the `entryPointDirectory`
+  property to its value.
+
+* Otherwise, if the path to the first JavaScript file that was loaded from the
+  filesystem exists, set the `entryPointDirectory` property to the directory
+  containing that path.
+
+  > In Node.js, this can be accessed using `require.main.filename` if the
+  > entrypoint is CommonJS, but otherwise must be determined using
+  > `process.argv[1]`. See nodejs/node#49440.
+
+* Otherwise, throw an error.
+
+* Return `this`.
+
+```ts
   constructor(entryPointDirectory?: string);
-}
+```
+
+```ts
+} // NodePackageImporter
 ```
 
 ### `ImporterResult`

--- a/spec/js-api/importer.d.ts.md
+++ b/spec/js-api/importer.d.ts.md
@@ -16,6 +16,8 @@ import {PromiseOr} from './util/promise_or';
   * [`Importer`](#importer)
     * [`nonCanonicalScheme`](#noncanonicalscheme)
   * [`NodePackageImporter`](#nodepackageimporter)
+    * [`entryPointDirectory`](#entrypointdirectory)
+    * [Constructor](#constructor)
   * [`ImporterResult`](#importerresult)
 
 ## Types


### PR DESCRIPTION
This also updates the spec for `NodePackageImporter` to correctly
document indicate that errors should be thrown during construction.

Closes https://github.com/sass/sass/issues/3792
See sass/dart-sass#2178

This is a [fast-track fix](https://github.com/sass/sass/blob/main/CONTRIBUTING.md#fast-track).