### PR TITLE
[Hotfix Node Package Importer]- Handle subpath without extensions

### DIFF
--- a/accepted/package-importer.d.ts.md
+++ b/accepted/package-importer.d.ts.md
@@ -554,8 +554,8 @@ potential subpaths, resolving for partials and file extensions.
 
   * Add `subpath` to `paths`.
 
-* Otherwise, add `subpath` + `.scss`, `subpath` + `.sass`, and `subpath` +
-  `.css` to `paths`.
+* Otherwise, add `subpath`, `subpath` + `.scss`, `subpath` + `.sass`, and
+  `subpath` + `.css` to `paths`.
 
 * If `subpath`'s [basename] does not start with `_`, for each `item` in
   `paths`, prepend `"_"` to the basename, and add to `paths`.

--- a/spec/modules.md
+++ b/spec/modules.md
@@ -737,8 +737,8 @@ potential subpaths, resolving for partials and file extensions.
 
   * Add `subpath` to `paths`.
 
-* Otherwise, add `subpath` + `.scss`, `subpath` + `.sass`, and `subpath` +
-  `.css` to `paths`.
+* Otherwise, add `subpath`, `subpath` + `.scss`, `subpath` + `.sass`, and
+  `subpath` + `.css` to `paths`.
 
 * If `subpath`'s [basename] does not start with `_`, for each `item` in
   `paths`, prepend `"_"` to the basename, and add to `paths`.


### PR DESCRIPTION
https://github.com/sass/dart-sass/issues/2183

Adds `subpath` to the list of `export load paths`.

dart-sass- https://github.com/sass/dart-sass/pull/2184
sass-spec- https://github.com/sass/sass-spec/pull/1960