### PR TITLE
Add explicit support for multiple adjacent `/` separators

### DIFF
--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -257,7 +257,7 @@ modifications. The following productions should produce errors:
 
 * Uses or declarations of Sass variables.
 
-* `//`-style ("silent") comments.
+* `//`-style ("silent") comments outside of an expression context.
 
 In addition, some productions should be parsed differently than they would be in
 SCSS:
@@ -270,6 +270,10 @@ SCSS:
 
 * The tokens `not`, `or`, `and`, and `null` should be parsed as unquoted
   strings.
+
+* In an expression context, `//` is not parsed as a silent comment. Instead, two
+  adjacent `/`s in a [`SlashListExpression`] may have no whitespace between
+  them, so `//` is parsed as two slash separators in a slash-separated list.
 
 ### Consuming an Identifier
 

--- a/spec/types/list.md
+++ b/spec/types/list.md
@@ -54,9 +54,12 @@ absolute value is larger than the length of that list.
 **BracketedListExpression** ::= '[' ContainedListExpression ']'
 **ContainedListExpression** ::= CommaListExpression ','?
 **CommaListExpression**     ::= SlashListExpression (',' SlashListExpression)*
-**SlashListExpression**     ::= SpaceListExpression ('/' SpaceListExpression)*
+**SlashListExpression**     ::= SpaceListExpression (('/' SpaceListExpression?)* '/' SpaceListExpression)?
 **SpaceListExpression**     ::= SumExpression+
 </pre></x>
+
+Every pair of adjacent `/`s in a `SlashListExpression` must be separated by
+whitespace or comments, unless the stylesheet is being parsed as CSS.
 
 > Note that `/` may *not* be used in single-element lists the way `,` is. That
 > is, `(foo,)` is valid, but `(foo/)` is not.
@@ -74,4 +77,6 @@ absolute value is larger than the length of that list.
 ### `SlashListExpression`
 
 To evaluate a `SlashListExpression`, evaluate each of its `SpaceListExpression`s
-and return a slash-separated list that contains each of the results in order.
+and return a slash-separated list that contains each of the results in order. If
+any `/` isn't followed by a `SpaceListExpression`, use an empty unquoted string
+as its value instead.


### PR DESCRIPTION
This is supported in some odd corners of CSS syntax.

Closes #3797

[skip dart-sass]
[skip sass-embedded]