### PR TITLE
[Plain CSS Nesting] Mark as accepted

### DIFF
--- a/accepted/plain-css-nesting.changes.md
+++ b/accepted/plain-css-nesting.changes.md
@@ -1,6 +1,6 @@
 ## Draft 1.2
 
-* Trigger plain CSS nesting behavior based on the type of _the parent_ rule's
+* Trigger plain CSS nesting behavior based on the type of *the parent* rule's
   stylesheet, so that we don't unexpectedly generate plain-CSS nesting for
   previously un-nested `@import` and `meta.load-css()` rules.
 

--- a/accepted/plain-css-nesting.changes.md
+++ b/accepted/plain-css-nesting.changes.md
@@ -1,3 +1,9 @@
+## Draft 1.2
+
+* Trigger plain CSS nesting behavior based on the type of _the parent_ rule's
+  stylesheet, so that we don't unexpectedly generate plain-CSS nesting for
+  previously un-nested `@import` and `meta.load-css()` rules.
+
 ## Draft 1.1
 
 * Trigger plain CSS nesting behavior based on the type of a rule's stylesheet,

--- a/accepted/plain-css-nesting.md
+++ b/accepted/plain-css-nesting.md
@@ -1,4 +1,4 @@
-# Plain CSS Nesting: Draft 1
+# Plain CSS Nesting: Draft 1.2
 
 *([Issue](https://github.com/sass/sass/issues/3524),
 [Changelog](plain-css-nesting.changes.md))*
@@ -93,7 +93,12 @@ To execute a style rule `rule`:
 * Let `selector` be the result of evaluating all interpolation in `rule`'s
   selector and parsing the result as a selector list.
 
-* **If `rule`'s stylesheet wasn't [parsed as CSS]**:
+* **Let `parent` by the [current style rule] or current at-rule if one exists,
+  or the innermost if both exist.**
+
+  [current style rule]: ../spec/style-rules.md#current-style-rule
+
+* **If `parent` is a style rule whose stylesheet wasn't [parsed as CSS]:**
 
   [parsed as CSS]: ../spec/syntax.md#parsing-text-as-css
 
@@ -101,19 +106,17 @@ To execute a style rule `rule`:
   > behavior occurs even when plain CSS is evaluated in a Sass context, such as
   > through a nested `@import` or a `meta.load-css()` call.
 
-  * If there is a [current style rule]:
+  * **If `selector` contains one or more parent selectors and `rule`'s
+    stylesheet wasn't [parsed as CSS], replace those parent selectors with the
+    current style rule's selector and set `selector` to the result.**
 
-    * If `selector` contains one or more parent selectors, replace them with the
-      current style rule's selector and set `selector` to the result.
+  * **Otherwise, nest `selector` within the current style rule's selector using
+    the [descendant combinator] and set `selector` to the result.**
 
-    * Otherwise, nest `selector` within the current style rule's selector using
-      the [descendant combinator] and set `selector` to the result.
-
-  * Otherwise, if `selector` contains one or more parent selectors, throw an
-    error.
-
-  [current style rule]: ../spec/style-rules.md#current-style-rule
   [descendant combinator]: https://www.w3.org/TR/selectors-3/#descendant-combinators
+
+* **Otherwise, if `selector` contains one or more parent selectors and `rule`'s
+  stylesheet wasn't [parsed as CSS], throw an error.**
 
 * Let `css` be a CSS style rule with selector `selector`.
 
@@ -129,12 +132,11 @@ To execute a style rule `rule`:
   [complex selectors]: https://drafts.csswg.org/selectors-4/#complex
 
 * Unless `css`'s selector is now empty:
+  
+  * **If `parent` is set and its stylesheet was [parsed as CSS], append `css` to
+    `parent`**
 
-  * **If `rule`'s stylesheet was [parsed as CSS] and there is a [current style
-    rule] or a current at-rule, append `css` to whichever of the two exists, or
-    the innermost if both exist.**
-
-  * **If there is a current at-rule, append `css` to its children.**
+  * **Otherwise, if there is a current at-rule, append `css` to its children.**
   
     > This was intended to be in the current spec, but was overlooked.
 


### PR DESCRIPTION
This also updates the draft so that

```scss
a {
  @include meta.load-css("plain.css");
}
```

only generates plain CSS nesting if `plain.css` contained nesting.

See #3524