### PR TITLE
Fix some bugs in the style rule and extend specs

### DIFF
--- a/spec/at-rules/extend.md
+++ b/spec/at-rules/extend.md
@@ -160,7 +160,13 @@ that includes CSS for *all* modules transitively used or forwarded by
 
     * Let `selector` be `extend(rule's selector, domestic's extensions)`.
 
-    * Let `selector-lists` be an empty set of selector lists.
+    * Remove from `selector` any [complex selectors] containing a placeholder
+      selector that begins with `-` or `_` from `css`'s selector.
+
+    * If `selector` is empty, move on to the next `rule`.
+
+    * Let `selector-lists` be a set of selector lists containing only
+      `selector`.
 
     * For each module `foreign` in `downstream`:
 
@@ -171,7 +177,7 @@ that includes CSS for *all* modules transitively used or forwarded by
         > means that `foreign`'s own extensions will already have been resolved
         > by the time we start working on modules upstream of it.
 
-      * Add `selector` to `selector-lists`.
+      * Add `extended-selector` to `selector-lists`.
 
     * Set `new-selectors[rule]` to a selector that matches the union of all
       elements matched by selectors in `selector-lists`. This selector must obey
@@ -187,6 +193,12 @@ that includes CSS for *all* modules transitively used or forwarded by
       > selector. The new complex selectors in `selector` generated from
       > `domestic`'s extensions don't count as "original", and may be optimized
       > away.
+
+      If none of the selectors in `selector-lists` match any elements, add
+      nothing to `new-selectors`.
+
+      > This may occur if `selector-lists` contains placeholder selectors that
+      > haven't been extended.
 
     * For every extension `extension` whose extender appears in `rule`'s
       selector:
@@ -224,9 +236,15 @@ that includes CSS for *all* modules transitively used or forwarded by
 
     * Otherwise, add a copy of `statement` to the end of `css`, with any style
       rules' selectors replaced with the corresponding selectors in
-      `new-selectors`.
+      `new-selectors`. Omit any style rules that don't have corresponding
+      selectors in `new-selectors`.
+
+      > This will omit style rules that contain un-extended placeholder
+      > selectors.
 
 * Return `css`.
+
+[complex selectors]: https://drafts.csswg.org/selectors-4/#complex
 
 ### Extending a Selector
 

--- a/spec/style-rules.md
+++ b/spec/style-rules.md
@@ -4,6 +4,7 @@
 
 * [Definitions](#definitions)
   * [Current Style Rule](#current-style-rule)
+  * [Current Keyframe Block](#current-keyframe-block)
 * [Semantics](#semantics)
 
 ## Definitions
@@ -11,21 +12,42 @@
 ### Current Style Rule
 
 The *current style rule* is the CSS style rule that was created by the innermost
-[execution of a style rule](#semantics).
+[execution of a style rule](#semantics), `@media` rule, `@supports` rule, or
+unknown at-rule.
+
+### Current Keyframe Block
+
+The *current keyframe block* is the CSS keyframe block that was created by the
+innermost [execution of a style rule](#semantics).
 
 ## Semantics
 
 To execute a style rule `rule`:
 
-* Let `selector` be the result of evaluating all interpolation in `rule`'s
-  selector and parsing the result as a selector list.
+* Let `selector-text` be the result of evaluating all interpolation in `rule`'s
+  selector.
 
-* Let `parent` be the [current style rule] or current at-rule if one exists, or
-  the innermost if both exist.
+* Let `parent` be the [current style rule], at-rule, or keyframe block if one
+  exists, or the innermost if multiple exist.
 
   [current style rule]: #current-style-rule
 
-* If `parent` is a style rule whose stylesheet wasn't [parsed as CSS]:
+* If `parent` is a keyframe block, throw an error.
+
+* Otherwise, if `parent` is an unknown at-rule whose name without vendor
+  prefixes is "keyframes":
+
+  * Let `selector` be the result of parsing `selector-text` as a keyframe
+    selector.
+
+  * Append a keyframe block with selector `selector` to `parent`.
+
+  * Evaluate each child of `rule`.
+
+  * Cease evaluating `rule`.
+
+* Otherwise, if `parent` is a style rule whose stylesheet wasn't [parsed as
+  CSS]:
 
   [parsed as CSS]: syntax.md#parsing-text-as-css
 
@@ -47,26 +69,20 @@ To execute a style rule `rule`:
 
 * Let `css` be a CSS style rule with selector `selector`.
 
-* Execute each child `child` of `rule`.
+* If `parent` is set and its stylesheet was [parsed as CSS], append `css` to
+  `parent`.
+
+* Otherwise, if there is a current at-rule, append `css` to its children.
+
+* Otherwise, append `css` to [the current module]'s CSS.
+
+  [the current module]: spec.md#current-module
+
+* Execute each child of `rule`.
 
 * If `css` contains any children and `selector` is [bogus], throw an error.
 
   [bogus]: selectors.md#bogus-selector
 
-* Remove any [complex selectors][] containing a placeholder selector that
-  begins with `-` or `_` from `css`'s selector.
-  
-  [complex selectors]: https://drafts.csswg.org/selectors-4/#complex
-
-* Unless `css`'s selector is now empty:
-  
-  * If `parent` is set and its stylesheet was [parsed as CSS], append `css` to
-    `parent`
-
-  * Otherwise, if there is a current at-rule, append `css` to its children.
-  
-    > This was intended to be in the current spec, but was overlooked.
-
-  * Otherwise, append `css` to [the current module]'s CSS.
-
-  [the current module]: spec.md#current-module
+* Otherwise, if `css` contains no children, remove it from the current module's
+  CSS.


### PR DESCRIPTION
* Adds style rules to the stylesheet when they're encountered rather
  than after all their children have run, so that nested rules appear
  after their parents.

* Removes private placeholder selectors from style rules *after*
  they've been extended by local extensions.

* Explicitly handle omitting placeholder-only selectors from the CSS
  generated by Resolving Extensions.