### PR TITLE
Improve the JS API documentation for `Logger.warn()`

### DIFF
--- a/js-api-doc/index.d.ts
+++ b/js-api-doc/index.d.ts
@@ -29,7 +29,7 @@ export {
   ImporterResult,
   NodePackageImporter,
 } from './importer';
-export {Logger, SourceSpan, SourceLocation} from './logger';
+export {Logger, LoggerWarnOptions, SourceSpan, SourceLocation} from './logger';
 export {
   CustomFunction,
   Options,

--- a/js-api-doc/logger/index.d.ts
+++ b/js-api-doc/logger/index.d.ts
@@ -5,6 +5,39 @@ export {SourceLocation} from './source_location';
 export {SourceSpan} from './source_span';
 
 /**
+ * The deprecation options passed to {@link Logger.warn}.
+ *
+ * If the warning isn't a deprecation, `deprecation` is `false` and the
+ * `deprecationType` isn't set. If it is a deprecation, `deprecation` is `true`
+ * and `deprecation` is a {@link Deprecation}.
+ */
+type LoggerWarnDeprecationOptions =
+  | {
+      deprecation: true;
+      deprecationType: Deprecation;
+    }
+  | {deprecation: false};
+
+/** The options passed to {@link Logger.warn}. */
+interface LoggerWarnOptions extends LoggerWarnDeprecationOptions {
+  /**
+   * The location in the Sass source code that generated this warning.
+   *
+   * This may be unset if the warning didn't come from Sass source, for example
+   * if it's from a deprecated JavaScript option.
+   */
+  span?: SourceSpan;
+
+  /**
+   * The Sass stack trace at the point the warning was issued.
+   *
+   * This may be unset if the warning didn't come from Sass source, for example
+   * if it's from a deprecated JavaScript option.
+   */
+  stack?: string;
+}
+
+/**
  * An object that can be passed to {@link LegacySharedOptions.logger} to control
  * how Sass emits warnings and debug messages.
  *
@@ -42,24 +75,11 @@ export interface Logger {
    *
    * If this is `undefined`, Sass will print warnings to standard error.
    *
+   * `options` may contain the following fields:
+   *
    * @param message - The warning message.
-   * @param options.deprecation - Whether this is a deprecation warning.
-   * @param options.deprecationType - The type of deprecation this warning is
-   * for, if any.
-   * @param options.span - The location in the Sass source code that generated this
-   * warning.
-   * @param options.stack - The Sass stack trace at the point the warning was issued.
    */
-  warn?(
-    message: string,
-    options: (
-      | {
-          deprecation: true;
-          deprecationType: Deprecation;
-        }
-      | {deprecation: false}
-    ) & {span?: SourceSpan; stack?: string}
-  ): void;
+  warn?(message: string, options: LoggerWarnOptions): void;
 
   /**
    * This method is called when Sass emits a debug message due to a [`@debug`

--- a/js-api-doc/logger/index.d.ts
+++ b/js-api-doc/logger/index.d.ts
@@ -5,21 +5,14 @@ export {SourceLocation} from './source_location';
 export {SourceSpan} from './source_span';
 
 /**
- * The deprecation options passed to {@link Logger.warn}.
+ * Options passed to {@link Logger.warn}.
  *
- * If the warning isn't a deprecation, `deprecation` is `false` and the
- * `deprecationType` isn't set. If it is a deprecation, `deprecation` is `true`
- * and `deprecation` is a {@link Deprecation}.
+ * This is separate from {@link LoggerWarnOptions} in order to represent in
+ * TypeScript that the {@link LoggerWarnDeprecationOptions.deprecationType}
+ * option is only available if {@link LoggerWarnDeprecationOptions.deprecation}
+ * is `true`.
  */
-type LoggerWarnDeprecationOptions =
-  | {
-      deprecation: true;
-      deprecationType: Deprecation;
-    }
-  | {deprecation: false};
-
-/** The options passed to {@link Logger.warn}. */
-interface LoggerWarnOptions extends LoggerWarnDeprecationOptions {
+interface LoggerWarnBaseOptions {
   /**
    * The location in the Sass source code that generated this warning.
    *
@@ -36,6 +29,31 @@ interface LoggerWarnOptions extends LoggerWarnDeprecationOptions {
    */
   stack?: string;
 }
+
+/**
+ * Options passed to {@link Logger.warn} specifically for deprecation warnings.
+ */
+interface LoggerWarnDeprecationOptions extends LoggerWarnBaseOptions {
+  /** Whether this is a deprecation warning or not. */
+  deprecation: true;
+
+  /** The deprecation type this warning represents. */
+  deprecationType: Deprecation;
+}
+
+/**
+ * Options passed to {@link Logger.warn} specifically for warnings that are not
+ * for deprecations.
+ */
+interface LoggerWarnNonDeprecationOptions extends LoggerWarnBaseOptions {
+  /** Whether this is a deprecation warning or not. */
+  deprecation: false;
+}
+
+/** The options passed to {@link Logger.warn}. */
+export type LoggerWarnOptions =
+  | LoggerWarnDeprecationOptions
+  | LoggerWarnNonDeprecationOptions;
 
 /**
  * An object that can be passed to {@link LegacySharedOptions.logger} to control

--- a/js-api-doc/logger/index.d.ts
+++ b/js-api-doc/logger/index.d.ts
@@ -5,55 +5,31 @@ export {SourceLocation} from './source_location';
 export {SourceSpan} from './source_span';
 
 /**
- * Options passed to {@link Logger.warn}.
+ * The options passed to {@link Logger.warn}.
  *
- * This is separate from {@link LoggerWarnOptions} in order to represent in
- * TypeScript that the {@link LoggerWarnDeprecationOptions.deprecationType}
- * option is only available if {@link LoggerWarnDeprecationOptions.deprecation}
- * is `true`.
+ * * `deprecation`: Whether this is a deprecation warning.
+ *
+ * * `deprecationType`: The type of deprecation. Only set if `deprecation` is
+ *   true.
+ *
+ * * `span`: The location in the Sass source code that generated this warning.
+ *   This may be unset if the warning didn't come from Sass source, for
+ *   example if it's from a deprecated JavaScript option.
+ *
+ * * `stack`: The Sass stack trace at the point the warning was issued. This may
+ *   be unset if the warning didn't come from Sass source, for example if it's
+ *   from a deprecated JavaScript option.
  */
-interface LoggerWarnBaseOptions {
-  /**
-   * The location in the Sass source code that generated this warning.
-   *
-   * This may be unset if the warning didn't come from Sass source, for example
-   * if it's from a deprecated JavaScript option.
-   */
+export type LoggerWarnOptions = (
+  | {
+      deprecation: true;
+      deprecationType: Deprecation;
+    }
+  | {deprecation: false}
+) & {
   span?: SourceSpan;
-
-  /**
-   * The Sass stack trace at the point the warning was issued.
-   *
-   * This may be unset if the warning didn't come from Sass source, for example
-   * if it's from a deprecated JavaScript option.
-   */
   stack?: string;
-}
-
-/**
- * Options passed to {@link Logger.warn} specifically for deprecation warnings.
- */
-interface LoggerWarnDeprecationOptions extends LoggerWarnBaseOptions {
-  /** Whether this is a deprecation warning or not. */
-  deprecation: true;
-
-  /** The deprecation type this warning represents. */
-  deprecationType: Deprecation;
-}
-
-/**
- * Options passed to {@link Logger.warn} specifically for warnings that are not
- * for deprecations.
- */
-interface LoggerWarnNonDeprecationOptions extends LoggerWarnBaseOptions {
-  /** Whether this is a deprecation warning or not. */
-  deprecation: false;
-}
-
-/** The options passed to {@link Logger.warn}. */
-export type LoggerWarnOptions =
-  | LoggerWarnDeprecationOptions
-  | LoggerWarnNonDeprecationOptions;
+};
 
 /**
  * An object that can be passed to {@link LegacySharedOptions.logger} to control

--- a/spec/js-api/index.d.ts.md
+++ b/spec/js-api/index.d.ts.md
@@ -66,7 +66,7 @@ export {
   ImporterResult,
   NodePackageImporter,
 } from './importer';
-export {Logger, SourceSpan, SourceLocation} from './logger';
+export {Logger, LoggerWarnOptions, SourceSpan, SourceLocation} from './logger';
 export {
   CustomFunction,
   Options,

--- a/spec/js-api/logger/index.d.ts.md
+++ b/spec/js-api/logger/index.d.ts.md
@@ -27,24 +27,16 @@ The options passed to `Logger.warn`. These are split out for documentation
 purposes.
 
 ```ts
-
-interface LoggerWarnBaseOptions {
+export type LoggerWarnOptions = (
+  | {
+      deprecation: true;
+      deprecationType: Deprecation;
+    }
+  | {deprecation: false}
+) & {
   span?: SourceSpan;
   stack?: string;
-}
-
-interface LoggerWarnDeprecationOptions extends LoggerWarnBaseOptions {
-  deprecation: true;
-  deprecationType: Deprecation;
-}
-
-interface LoggerWarnNonDeprecationOptions extends LoggerWarnBaseOptions {
-  deprecation: false;
-}
-
-export type LoggerWarnOptions =
-  | LoggerWarnDeprecationOptions
-  | LoggerWarnNonDeprecationOptions;
+};
 ```
 
 ### `Logger`

--- a/spec/js-api/logger/index.d.ts.md
+++ b/spec/js-api/logger/index.d.ts.md
@@ -27,17 +27,24 @@ The options passed to `Logger.warn`. These are split out for documentation
 purposes.
 
 ```ts
-type LoggerWarnDeprecationOptions =
-  | {
-      deprecation: true;
-      deprecationType: Deprecation;
-    }
-  | {deprecation: false};
 
-interface LoggerWarnOptions extends LoggerWarnDeprecationOptions {
+interface LoggerWarnBaseOptions {
   span?: SourceSpan;
   stack?: string;
 }
+
+interface LoggerWarnDeprecationOptions extends LoggerWarnBaseOptions {
+  deprecation: true;
+  deprecationType: Deprecation;
+}
+
+interface LoggerWarnNonDeprecationOptions extends LoggerWarnBaseOptions {
+  deprecation: false;
+}
+
+export type LoggerWarnOptions =
+  | LoggerWarnDeprecationOptions
+  | LoggerWarnNonDeprecationOptions;
 ```
 
 ### `Logger`

--- a/spec/js-api/logger/index.d.ts.md
+++ b/spec/js-api/logger/index.d.ts.md
@@ -11,6 +11,7 @@ export {SourceSpan} from './source_span';
 ## Table of Contents
 
 * [Types](#types)
+  * [`LoggerWarnOptions`](#loggerwarnoptions)
   * [`Logger`](#logger)
     * [`warn`](#warn)
     * [`debug`](#debug)
@@ -19,6 +20,25 @@ export {SourceSpan} from './source_span';
     * [`silent`](#silent)
 
 ## Types
+
+### `LoggerWarnOptions`
+
+The options passed to `Logger.warn`. These are split out for documentation
+purposes.
+
+```ts
+type LoggerWarnDeprecationOptions =
+  | {
+      deprecation: true;
+      deprecationType: Deprecation;
+    }
+  | {deprecation: false};
+
+interface LoggerWarnOptions extends LoggerWarnDeprecationOptions {
+  span?: SourceSpan;
+  stack?: string;
+}
+```
 
 ### `Logger`
 
@@ -67,16 +87,7 @@ If this field is defined, the compiler must not surface warnings in any way
 other than inkoving `warn`.
 
 ```ts
-warn?(
-  message: string,
-  options: (
-    | {
-        deprecation: true;
-        deprecationType: Deprecation;
-      }
-    | {deprecation: false}
-  ) & {span?: SourceSpan; stack?: string}
-): void;
+warn?(message: string, options: LoggerWarnOptions): void;
 ```
 
 #### `debug`


### PR DESCRIPTION
This is not a functional change. The old type for this was too
complicated for TypeDoc to parse, so the documentation was being
hidden.