### PR TITLE
Document existing indented syntax

### DIFF
--- a/spec/at-rules/for.md
+++ b/spec/at-rules/for.md
@@ -9,14 +9,14 @@
 
 <x><pre>
 **ForRule**            ::= '@for' [PlainVariable] FromDeclaration
-&#32;                      (ToDeclaration | ThroughDeclaration) ForBlock
+&#32;                      (ToDeclaration | ThroughDeclaration) [Block]
 **FromDeclaration**    ::= 'from' Expression
 **ToDeclaration**      ::= 'to' Expression
 **ThroughDeclaration** ::= 'through' Expression
-**ForBlock**           ::= '{' Statements '}'
 </pre></x>
 
 [PlainVariable]: ../variables.md#syntax
+[Block]: ../statement.md#block
 
 ## Semantics
 

--- a/spec/at-rules/import.md
+++ b/spec/at-rules/import.md
@@ -22,12 +22,11 @@ still supported for backwards-compatibility.
 **ImportMedia**           ::= [MediaFeatureInParens] (',' [MediaQueryList])\*
 &#32;                       | InterpolatedIdentifier (',' [MediaQueryList])\*
 **ImportSupports**        ::= 'supports(' SupportsDeclaration ')'
-**ImportFunction**        ::= [InterpolatedIdentifier]¹ '(' [InterpolatedDeclarationValue]? ')'
+**ImportFunction**        ::= [InterpolatedIdentifier]¹ '(' InterpolatedDeclarationValue? ')'
 **ImportUrl**             ::= QuotedString | [InterpolatedUrl]
 </pre></x>
 
 [InterpolatedIdentifier]: ../syntax.md#interpolatedidentifier
-[InterpolatedDeclarationValue]: ../declarations.md#syntax
 [InterpolatedUrl]: ../syntax.md#interpolatedurl
 [MediaFeatureInParens]: media.md#syntax
 [MediaQueryList]: media.md#syntax

--- a/spec/at-rules/import.md
+++ b/spec/at-rules/import.md
@@ -22,11 +22,12 @@ still supported for backwards-compatibility.
 **ImportMedia**           ::= [MediaFeatureInParens] (',' [MediaQueryList])\*
 &#32;                       | InterpolatedIdentifier (',' [MediaQueryList])\*
 **ImportSupports**        ::= 'supports(' SupportsDeclaration ')'
-**ImportFunction**        ::= [InterpolatedIdentifier]¹ '(' InterpolatedDeclarationValue? ')'
+**ImportFunction**        ::= [InterpolatedIdentifier]¹ '(' [InterpolatedDeclarationValue]? ')'
 **ImportUrl**             ::= QuotedString | [InterpolatedUrl]
 </pre></x>
 
 [InterpolatedIdentifier]: ../syntax.md#interpolatedidentifier
+[InterpolatedDeclarationValue]: ../declarations.md#syntax
 [InterpolatedUrl]: ../syntax.md#interpolatedurl
 [MediaFeatureInParens]: media.md#syntax
 [MediaQueryList]: media.md#syntax

--- a/spec/at-rules/mixin.md
+++ b/spec/at-rules/mixin.md
@@ -17,11 +17,10 @@
 ### Syntax
 
 <x><pre>
-**MixinRule** ::= '@mixin' [\<ident-token>] [ArgumentDeclaration]? [Block]
+**MixinRule** ::= '@mixin' [\<ident-token>] ArgumentDeclaration? [Block]
 </pre></x>
 
 [\<ident-token>]: https://drafts.csswg.org/css-syntax-3/#ident-token-diagram
-[ArgumentDeclaration]: ../syntax.md#argumentdeclaration
 [Block]: ../statement.md#block
 
 No whitespace is allowed between the `Identifier` and the `ArgumentDeclaration`

--- a/spec/at-rules/mixin.md
+++ b/spec/at-rules/mixin.md
@@ -17,10 +17,12 @@
 ### Syntax
 
 <x><pre>
-**MixinRule** ::= '@mixin' [\<ident-token>] ArgumentDeclaration? '{' Statements '}'
+**MixinRule** ::= '@mixin' [\<ident-token>] [ArgumentDeclaration]? [Block]
 </pre></x>
 
 [\<ident-token>]: https://drafts.csswg.org/css-syntax-3/#ident-token-diagram
+[ArgumentDeclaration]: ../syntax.md#argumentdeclaration
+[Block]: ../statement.md#block
 
 No whitespace is allowed between the `Identifier` and the `ArgumentDeclaration`
 in `MixinRule`.
@@ -75,7 +77,7 @@ To execute a `@mixin` rule `rule`:
 <x><pre>
 **IncludeRule**      ::= '@include' [NamespacedIdentifier] ArgumentInvocation?
 &#32;                    ContentBlock?
-**ContentBlock**     ::= UsingDeclaration? '{' Statements '}'
+**ContentBlock**     ::= UsingDeclaration? Block
 **UsingDeclaration** ::= 'using' ArgumentDeclaration
 </pre></x>
 

--- a/spec/at-rules/mixin.md
+++ b/spec/at-rules/mixin.md
@@ -76,7 +76,7 @@ To execute a `@mixin` rule `rule`:
 <x><pre>
 **IncludeRule**      ::= '@include' [NamespacedIdentifier] ArgumentInvocation?
 &#32;                    ContentBlock?
-**ContentBlock**     ::= UsingDeclaration? Block
+**ContentBlock**     ::= UsingDeclaration? [Block]
 **UsingDeclaration** ::= 'using' ArgumentDeclaration
 </pre></x>
 

--- a/spec/at-rules/unknown.md
+++ b/spec/at-rules/unknown.md
@@ -8,10 +8,11 @@
 
 <x><pre>
 **UnknownAtRule** ::= '@' [InterpolatedIdentifier] InterpolatedValue?
-&#32;                   ('{' Statements '}')?
+&#32;                   [Block]?
 </pre></x>
 
 [InterpolatedIdentifier]: ../syntax.md#interpolatedidentifier
+[Block]: ../statement.md#block
 
 No whitespace is allowed after `@`. As with all statements, an `UnknownAtRule`
 without a block must be separated from other statements with a semicolon.

--- a/spec/at-rules/unknown.md
+++ b/spec/at-rules/unknown.md
@@ -7,8 +7,7 @@
 > structures it allows.
 
 <x><pre>
-**UnknownAtRule** ::= '@' [InterpolatedIdentifier] InterpolatedValue?
-&#32;                   [Block]?
+**UnknownAtRule** ::= '@' [InterpolatedIdentifier] InterpolatedValue? [Block]?
 </pre></x>
 
 [InterpolatedIdentifier]: ../syntax.md#interpolatedidentifier

--- a/spec/declarations.md
+++ b/spec/declarations.md
@@ -11,9 +11,11 @@
 
 <x><pre>
 **Declaration**         ::= StandardDeclaration | CustomDeclaration
-**StandardDeclaration** ::= [InterpolatedIdentifier]¹ ':' (Value | Value? Block )
+**StandardDeclaration** ::= [InterpolatedIdentifier]¹ ':' (Value | Value? [Block] )
 **CustomDeclaration**   ::= [InterpolatedIdentifier]² ':' InterpolatedDeclarationValue
 </pre></x>
+
+[Block]: statement.md#block
 
 1. This may not begin with "--".
 2. This *must* begin with "--".

--- a/spec/declarations.md
+++ b/spec/declarations.md
@@ -10,10 +10,9 @@
 ## Syntax
 
 <x><pre>
-**Declaration**              ::= StandardDeclaration | CustomDeclaration
-**StandardDeclaration**      ::= [InterpolatedIdentifier]¹ ':' (Value | Value? Block )
-**CustomDeclaration**        ::= [InterpolatedIdentifier]² ':' InterpolatedDeclarationValue
-InterpolatedDeclarationValue ::= (Interpolation | String)+
+**Declaration**         ::= StandardDeclaration | CustomDeclaration
+**StandardDeclaration** ::= [InterpolatedIdentifier]¹ ':' (Value | Value? Block )
+**CustomDeclaration**   ::= [InterpolatedIdentifier]² ':' InterpolatedDeclarationValue
 </pre></x>
 
 1. This may not begin with "--".

--- a/spec/declarations.md
+++ b/spec/declarations.md
@@ -10,9 +10,10 @@
 ## Syntax
 
 <x><pre>
-**Declaration**         ::= StandardDeclaration | CustomDeclaration
-**StandardDeclaration** ::= [InterpolatedIdentifier]¹ ':' (Value | Value? '{' Statements '}')
-**CustomDeclaration**   ::= [InterpolatedIdentifier]² ':' InterpolatedDeclarationValue
+**Declaration**              ::= StandardDeclaration | CustomDeclaration
+**StandardDeclaration**      ::= [InterpolatedIdentifier]¹ ':' (Value | Value? Block )
+**CustomDeclaration**        ::= [InterpolatedIdentifier]² ':' InterpolatedDeclarationValue
+InterpolatedDeclarationValue ::= (Interpolation | String)+
 </pre></x>
 
 1. This may not begin with "--".

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -10,6 +10,10 @@
   * [IndentedStatements](#indentedstatements)
   * [Statements](#statements)
   * [Block](#block)
+  * [Comments](#comments)
+    * [LoudComment](#loudcomment)
+    * [SilentComment](#silentcomment)
+    * [WhitespaceComment](#whitespacecomment)
   * [Whitespace](#whitespace)
   * [Indentation](#indentation)
 
@@ -60,8 +64,10 @@ If a `WhitespaceComment` would be ambiguous with a `Statement` in the
 ### IndentedStatements
 
 <x><pre>
-**IndentedStatements**  ::= (Statement IndentedSame)* Statement
+**IndentedStatements**  ::= (Statement [IndentSame])* Statement
 </pre></x>
+
+[IndentSame]: #indentation
 
 ### Statements
 
@@ -78,12 +84,11 @@ If a `WhitespaceComment` would be ambiguous with a `Statement` in the
 
 <x><pre>
 **ScssBlock**      ::= '{' [ScssStatements] '}'
-**IndentedBlock**  ::= [IndentMore] [IndentedStatements] [IndentLess]
+**IndentedBlock**  ::= [IndentMore] [IndentedStatements]
 **Block**          ::= (ScssBlock | IndentedBlock)¹
 </pre></x>
 
 [IndentMore]: #indentation
-[IndentLess]: #indentation
 
 1: Only the production for the current syntax is valid.
 
@@ -92,8 +97,8 @@ If a `WhitespaceComment` would be ambiguous with a `Statement` in the
 #### LoudComment
 
 <x><pre>
-**ScssLoudComment**          ::= '/*' '!'? (.* | Interpolation)* '*/'
-**IndentedLoudComment**      ::= '/*' '!'? ([^IndentedLess] | Interpolation)*
+**ScssLoudComment**          ::= '/*' '!'? (.* | Interpolation)*'*/'
+**IndentedLoudComment**      ::= '/*' '!'? (.* | Interpolation)*
 **LoudComment**              ::= (ScssLoudComment | IndentedLoudComment)¹
 </pre></x>
 
@@ -104,8 +109,8 @@ If a `WhitespaceComment` would be ambiguous with a `Statement` in the
 #### SilentComment
 
 <x><pre>
-**ScssSilentComment**          ::= '//' [^LineBreak]*
-**IndentedSilentComment**      ::= '//' [^IndentedLess]*
+**ScssSilentComment**          ::= '//' .*
+**IndentedSilentComment**      ::= '//' .*
 **SilentComment**              ::= (ScssSilentComment | IndentedSilentComment)¹
 </pre></x>
 
@@ -114,9 +119,9 @@ If a `WhitespaceComment` would be ambiguous with a `Statement` in the
 #### WhitespaceComment
 
 <x><pre>
-**ScssWhitespaceComment**          ::= '//' .* '//' | '/*' .* '*/'
+**ScssWhitespaceComment**          ::= '//' .*'//' | '/*' .*'*/'
 **IndentedWhitespaceComment**      ::= '/*' .* '*/'
-**WhitespaceComment*¹              ::= ScssWhitespaceComment 
+**WhitespaceComment*¹              ::= ScssWhitespaceComment
 &#32;                                | IndentedWhitespaceComment
 </pre></x>
 
@@ -124,14 +129,11 @@ If a `WhitespaceComment` would be ambiguous with a `Statement` in the
 
 ### Whitespace
 
-> Whitespace separates productions inside a statement when disambiguation is
-> necessary. The Whitespace productions do not separate Statements.
-
 <x><pre>
 **LineBreak**               ::= CarriageReturn | LineFeed | FormFeed
 **ScssWhitespace**          ::= LineBreak | Space | Tab
 **IndentedWhitespace**      ::= Space | Tab
-**Whitespace**              ::= (ScssWhitespace | IndentedWhitespace)¹ 
+**Whitespace**              ::= (ScssWhitespace | IndentedWhitespace)¹
 &#32;                         | [WhitespaceComment]
 </pre></x>
 
@@ -142,10 +144,12 @@ If a `WhitespaceComment` would be ambiguous with a `Statement` in the
 ### Indentation
 
 <x><pre>
-**IndentCharacter**         ::= Space | Tab
-**IndentSame**              ::= [LineBreak] [IndentCharacter]{ Current }
-**IndentLess**              ::= [LineBreak] [IndentCharacter]{ 0, Current - 1 }
-**IndentMore**              ::= [LineBreak] [IndentCharacter]{ Current + 1, }
+**WhitespaceOnlyLine**          ::= IndentSame (Whitespace)*
+**IndentCharacter**             ::= Space | Tab
+**IndentSame**                  ::= [WhitespaceOnlyLine]* [LineBreak]
+&#32;                               [IndentCharacter]{ Current }
+**IndentMore**                  ::= [WhitespaceOnlyLine]* [LineBreak]
+&#32;                               [IndentCharacter]{ Current + 1, }
 </pre></x>
 
 [LineBreak]: #whitespace
@@ -156,8 +160,7 @@ The [IndentCharacter] must be the [document indentation character].
 [document indentation character]: #document-indentation-character
 
 `Current` is the [current indentation level] for a document. After consuming an
-`IndentSame`, `IndentLess`, or `IndentMore` production, the [current indentation
-level] is set to the number of [IndentCharacter]s found. At the end of a
-document, the [current indentation level] is set to 0.
+`IndentSame` or `IndentMore` production, the [current indentation level] is set
+to the number of [IndentCharacter]s found.
 
 [current indentation level]: #current-indentation-level

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -55,7 +55,7 @@ character used in an [`IndentMore`] production in a document.
 **ScssStatements**      ::= (Statement ';'?¹)* Statement?
 </pre></x>
 
-1. This production is mandatory unless the previous `Statement` is a
+1: This production is mandatory unless the previous `Statement` is a
 `LoudComment`, `SilentComment`, or ends in a `Block`.
 
 If a `WhitespaceComment` would be ambiguous with a `Statement` in the
@@ -81,7 +81,7 @@ productions.
 [ScssStatements]: #scssstatements
 [IndentedStatements]: #indentedstatements
 
-1. Only the production for the current syntax is valid.
+1: Only the production for the current syntax is valid.
 
 ### Block
 
@@ -93,7 +93,7 @@ productions.
 
 [IndentMore]: #indentation
 
-1. Only the production for the current syntax is valid.
+1: Only the production for the current syntax is valid.
 
 ### Comments
 
@@ -101,10 +101,11 @@ productions.
 
 <x><pre>
 **ScssLoudComment**          ::= '/\*' (.\*¹ | Interpolation)\* '\*/'
-**IndentedLoudCommentNest**  ::= [IndentMore] ((.\*² | Interpolation)\*
-&#32;                            [IndentSame])\* (.\*² | Interpolation)\*
-**IndentedLoudComment**      ::= '/\*' (.\*² | Interpolation)\*
-&#32;                            IndentedLoudCommentNest?
+**InterpolatedCommentText**  ::= (.\*² | Interpolation)\*
+**IndentedLoudChildren**     ::= (InterpolatedCommentText [IndentSame])\*
+&#32;                            InterpolatedCommentText
+**IndentedLoudComment**      ::= '/\*' InterpolatedCommentText
+&#32;                            ([IndentMore] IndentedLoudChildren)?
 **LoudComment**              ::= (ScssLoudComment | IndentedLoudComment)³
 </pre></x>
 
@@ -140,14 +141,12 @@ productions.
 ### Whitespace
 
 <x><pre>
-**LineBreak**               ::= CarriageReturn | LineFeed | FormFeed
-**ScssWhitespace**          ::= LineBreak | Space | Tab
-**IndentedWhitespace**      ::= Space | Tab
-**Whitespace**              ::= (ScssWhitespace | IndentedWhitespace)¹
-&#32;                         | [WhitespaceComment]
+**LineBreak**  ::= CarriageReturn | LineFeed | FormFeed
+**Whitespace** ::= LineBreak¹ | Space | Tab | [WhitespaceComment]
 </pre></x>
 
-1. Only the production for the current syntax is valid.
+1: This is not allowed in the indented syntax.
+1: Only the production for the current syntax is valid.
 
 [WhitespaceComment]: #whitespacecomment
 

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -119,14 +119,16 @@ productions.
 **ScssSilentComment**          ::= '//' .\*¹
 **CommentText**                ::= .\*²
 **IndentedSilentChildren**     ::= (CommentText [IndentSame])\* CommentText
-**IndentedSilentComment**      ::= '//' CommentText ([IndentMore]
-&#32;                              IndentedSilentChildren)?
+**IndentedSilentComment**      ::= '//' CommentText
+&#32;                              ([IndentMore] IndentedSilentChildren)?
 **SilentComment**              ::= (ScssSilentComment | IndentedSilentComment)³
 </pre></x>
 
 1. This may not contain newlines.
-2. This may not contain newlines outside of [IndentSame] productions.
+2. This may not contain newlines outside of [WhitespaceOnlyLine] productions.
 3. Only the production for the current syntax is valid.
+
+[WhitespaceOnlyLine]: #indentation
 
 #### WhitespaceComment
 

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -131,15 +131,13 @@ productions.
 #### WhitespaceComment
 
 <x><pre>
-**ScssWhitespaceComment**          ::= '//' .\*¹ | '/\*' .\*² '\*/'
-**IndentedWhitespaceComment**      ::= ('/\*' .\*¹˒² '\*/') | ('//' .\*¹)
-**WhitespaceComment**³             ::= ScssWhitespaceComment
-&#32;                                | IndentedWhitespaceComment
+**WhitespaceComment**³             ::= ('//' .\*¹) | ('/\*' .\*² '\*/')
 </pre></x>
 
 1. This may not contain newlines.
-2. This may not contain `*/`.
-3. Only the production for the current syntax is valid.
+2. This may not contain `*/`. In the indented syntax, this may not contain
+   newlines.
+
 
 ### Whitespace
 

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -21,50 +21,52 @@
 
 ### Current indentation level
 
-The `current indentation level` is the count of the [`documentation indentation
-character`] between a new line and any non-whitespace characters of the last
-consumed statement. Lines that only contain whitespace or do not start a
-statement do not impact the `current indentation level`.
+The *current indentation level* is the number of [documentation indentation
+characters] before the first non-whitespace character of the last consumed
+statement. The initial current indentation level for any document is 0.
 
-A document parsed in the indented syntax may not begin with whitespace, and the
-initial `current indentation level` for any document is `0`.
+> Lines that only contain whitespace or do not start a statement do not impact
+> the current indentation level. Changes in the indentation level are used by
+> the indented syntax to start and end blocks of statements.
 
-> Changes in the indentation level are used by the indented syntax to start and
-> end blocks of statements.
-
-[`documentation indentation character`]: #document-indentation-character
+[documentation indentation characters]: #document-indentation-character
 
 ### Document indentation character
 
-The `document indentation character` is defined as the first tab or space
-character used in an [`IndentMore`] production in a document.
+The *document indentation character* is the first tab or space character used in
+an [`IndentMore`] production in a document.
 
 [`IndentMore`]: #indentation
 
-> The `document indentation character` is the character used for calculating the
-> [`current indentation level`]. In the indented syntax, no character other than
-> the `document indentation character` may be used for indentation.
+> This is the character used for calculating the [current indentation level]. In
+> the indented syntax, no character other than the document indentation
+> character may be used for indentation.
 
-[`current indentation level`]: #current-indentation-level
+[current indentation level]: #current-indentation-level
 
 ## Syntax
 
 ### ScssStatements
 
 <x><pre>
-**ScssStatements**      ::= (Statement ';'?¹)* Statement?
+**ScssStatements** ::= (Statement ';'?¹)* Statement?
 </pre></x>
 
 1: This production is mandatory unless the previous `Statement` is a
-`LoudComment`, `SilentComment`, or ends in a `Block`.
+[`LoudComment`], [`SilentComment`], or ends in a `Block`.
 
-If a `WhitespaceComment` would be ambiguous with a `Statement` in the
+[`LoudComment`]: #loudcomment
+[`SilentComment`]: #silentcomment
+
+If a [`WhitespaceComment`] would be ambiguous with a `Statement` in the
 `ScssStatements` rule, parse it preferentially as a `Statement`.
+
+[`WhitespaceComment`]: #whitespacecomment
 
 ### IndentedStatements
 
 <x><pre>
-**IndentedStatements**  ::= (Statement [IndentSame])* Statement
+**IndentedStatements** ::= (Statement [IndentSame])* Statement
 </pre></x>
 
 [IndentSame]: #indentation
@@ -75,7 +77,7 @@ productions.
 ### Stylesheet
 
 <x><pre>
-**Stylesheet**          ::= U+FEFF? ([ScssStatements] | [IndentedStatements])¹
+**Stylesheet** ::= U+FEFF? ([ScssStatements] | [IndentedStatements])¹
 </pre></x>
 
 [ScssStatements]: #scssstatements
@@ -86,9 +88,9 @@ productions.
 ### Block
 
 <x><pre>
-**ScssBlock**      ::= '{' [ScssStatements] '}'
-**IndentedBlock**  ::= [IndentMore] [IndentedStatements]
-**Block**          ::= (ScssBlock | IndentedBlock)¹
+**ScssBlock**     ::= '{' [ScssStatements] '}'
+**IndentedBlock** ::= [IndentMore] [IndentedStatements]
+**Block**         ::= (ScssBlock | IndentedBlock)¹
 </pre></x>
 
 [IndentMore]: #indentation
@@ -100,13 +102,13 @@ productions.
 #### LoudComment
 
 <x><pre>
-**ScssLoudComment**          ::= '/\*' (.\*¹ | Interpolation)\* '\*/'
-**InterpolatedCommentText**  ::= (.\*² | Interpolation)\*
-**IndentedLoudChildren**     ::= (InterpolatedCommentText [IndentSame])\*
-&#32;                            InterpolatedCommentText
-**IndentedLoudComment**      ::= '/\*' InterpolatedCommentText
-&#32;                            ([IndentMore] IndentedLoudChildren)?
-**LoudComment**              ::= (ScssLoudComment | IndentedLoudComment)³
+**ScssLoudComment**         ::= '/\*' (.\*¹ | Interpolation)\* '\*/'
+**InterpolatedCommentText** ::= (.\*² | Interpolation)\*
+**IndentedLoudChildren**    ::= (InterpolatedCommentText [IndentSame])\*
+&#32;                           InterpolatedCommentText
+**IndentedLoudComment**     ::= '/\*' InterpolatedCommentText
+&#32;                           ([IndentMore] IndentedLoudChildren)?
+**LoudComment**             ::= (ScssLoudComment | IndentedLoudComment)³
 </pre></x>
 
 1: This may not contain `#{` or `*/`.
@@ -118,12 +120,12 @@ productions.
 #### SilentComment
 
 <x><pre>
-**ScssSilentComment**          ::= '//' .\*¹
-**CommentText**                ::= .\*¹
-**IndentedSilentChildren**     ::= (CommentText [IndentSame])\* CommentText
-**IndentedSilentComment**      ::= '//' CommentText
-&#32;                              ([IndentMore] IndentedSilentChildren)?
-**SilentComment**              ::= (ScssSilentComment | IndentedSilentComment)²
+**ScssSilentComment**      ::= '//' .\*¹
+**CommentText**            ::= .\*¹
+**IndentedSilentChildren** ::= (CommentText [IndentSame])\* CommentText
+**IndentedSilentComment**  ::= '//' CommentText
+&#32;                          ([IndentMore] IndentedSilentChildren)?
+**SilentComment**          ::= (ScssSilentComment | IndentedSilentComment)²
 </pre></x>
 
 1: This may not contain newlines.
@@ -133,7 +135,7 @@ productions.
 #### WhitespaceComment
 
 <x><pre>
-**WhitespaceComment**              ::= ('//' .\*¹) | ('/\*' .\*² '\*/')
+**WhitespaceComment** ::= ('//' .\*¹) | ('/\*' .\*² '\*/')
 </pre></x>
 
 1: This may not contain newlines.
@@ -155,12 +157,12 @@ productions.
 ### Indentation
 
 <x><pre>
-**WhitespaceOnlyLine**          ::= [Whitespace]\* [LineBreak]
-**IndentSame**                  ::= [LineBreak] WhitespaceOnlyLine\*
-&#32;                               IndentCharacter{ Current }
-**IndentCharacter**             ::= Space | Tab
-**IndentMore**                  ::= WhitespaceOnlyLine\* [LineBreak]
-&#32;                               IndentCharacter{ ≥ Current + 1 }
+**WhitespaceOnlyLine** ::= [Whitespace]\* [LineBreak]
+**IndentSame**         ::= [LineBreak] WhitespaceOnlyLine\*
+&#32;                      IndentCharacter{ Current }
+**IndentCharacter**    ::= Space | Tab
+**IndentMore**         ::= WhitespaceOnlyLine\* [LineBreak]
+&#32;                      IndentCharacter{ ≥ Current + 1 }
 </pre></x>
 
 [Whitespace]: #whitespace
@@ -173,5 +175,3 @@ The IndentCharacter must be the [document indentation character].
 `Current` is the [current indentation level] for a document. After consuming an
 `IndentSame` or `IndentMore` production, the [current indentation level] is set
 to the number of IndentCharacters found.
-
-[current indentation level]: #current-indentation-level

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -100,10 +100,10 @@ productions.
 #### LoudComment
 
 <x><pre>
-**ScssLoudComment**          ::= '/\*' (.\*¹ | Interpolation)*'\*/'
-**IndentedLoudCommentNest**  ::= [IndentMore] ((.\*² | Interpolation)*
-&#32;                            [IndentSame])*(.\*² | Interpolation)*
-**IndentedLoudComment**      ::= '/\*' (.\*² | Interpolation)*
+**ScssLoudComment**          ::= '/\*' (.\*¹ | Interpolation)\* '\*/'
+**IndentedLoudCommentNest**  ::= [IndentMore] ((.\*² | Interpolation)\*
+&#32;                            [IndentSame])\* (.\*² | Interpolation)\*
+**IndentedLoudComment**      ::= '/\*' (.\*² | Interpolation)\*
 &#32;                            IndentedLoudCommentNest?
 **LoudComment**              ::= (ScssLoudComment | IndentedLoudComment)³
 </pre></x>

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -169,6 +169,6 @@ The IndentCharacter must be the [document indentation character].
 
 `Current` is the [current indentation level] for a document. After consuming an
 `IndentSame` or `IndentMore` production, the [current indentation level] is set
-to the number of [IndentCharacter]s found.
+to the number of IndentCharacters found.
 
 [current indentation level]: #current-indentation-level

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -146,9 +146,9 @@ If a `WhitespaceComment` would be ambiguous with a `Statement` in the
 <x><pre>
 **WhitespaceOnlyLine**          ::= IndentSame (Whitespace)*
 **IndentCharacter**             ::= Space | Tab
-**IndentSame**                  ::= [WhitespaceOnlyLine]* [LineBreak]
+**IndentSame**                  ::= WhitespaceOnlyLine* [LineBreak]
 &#32;                               [IndentCharacter]{ Current }
-**IndentMore**                  ::= [WhitespaceOnlyLine]* [LineBreak]
+**IndentMore**                  ::= WhitespaceOnlyLine* [LineBreak]
 &#32;                               [IndentCharacter]{ Current + 1, }
 </pre></x>
 

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -153,16 +153,16 @@ productions.
 ### Indentation
 
 <x><pre>
-**WhitespaceOnlyLine**          ::= IndentSame? Whitespace\* [LineBreak]
+**WhitespaceOnlyLine**          ::= IndentSame? [Whitespace]\* [LineBreak]
 **IndentSame**                  ::= [LineBreak] WhitespaceOnlyLine\*
-&#32;                               [IndentCharacter]{ Current }
+&#32;                               IndentCharacter{ Current }
 **IndentCharacter**             ::= Space | Tab
 **IndentMore**                  ::= WhitespaceOnlyLine\* [LineBreak]
-&#32;                               [IndentCharacter]{ ≥ Current + 1 }
+&#32;                               IndentCharacter{ ≥ Current + 1 }
 </pre></x>
 
+[Whitespace]: #whitespace
 [LineBreak]: #whitespace
-[IndentCharacter]: #whitespace
 
 The [IndentCharacter] must be the [document indentation character].
 

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -132,13 +132,13 @@ productions.
 
 <x><pre>
 **ScssWhitespaceComment**          ::= '//' .\*¹ | '/\*' .\*² '\*/'
-**IndentedWhitespaceComment**      ::= ('/\*' .\*² '\*/') | ('//' .\*¹)
+**IndentedWhitespaceComment**      ::= ('/\*' .\*¹˒² '\*/') | ('//' .\*¹)
 **WhitespaceComment**³             ::= ScssWhitespaceComment
 &#32;                                | IndentedWhitespaceComment
 </pre></x>
 
 1. This may not contain newlines.
-2. This may not contain `*/` or newlines.
+2. This may not contain `*/`.
 3. Only the production for the current syntax is valid.
 
 ### Whitespace

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -19,35 +19,36 @@
 
 The `current indentation level` is the count of the [`documentation indentation
 character`] between a new line and any non-whitespace characters of the last
-consumed line.
+consumed statement. Lines that only contain whitespace or do not start a
+statement do not impact the `current indentation level`.
 
 A document parsed in the indented syntax may not begin with whitespace, and the
 initial `current indentation level` for any document is `0`.
 
-Changes in the indentation level are used by the indented syntax to start and
-end blocks of statements.
+> Changes in the indentation level are used by the indented syntax to start and
+> end blocks of statements.
 
 [`documentation indentation character`]: #document-indentation-character
 
 ### Document indentation character
 
-The `document indentation character` is the character used for calculating the
-[`current indentation level`], and is either a space or tab character.
+The `document indentation character` is defined as the first tab or space
+character used as an [`IndentMore`] production in a document.
+
+[`IndentMore`]: #indentation
+
+> The `document indentation character` is the character used for calculating the
+> [`current indentation level`]. In the indented syntax, no character other than
+> the `document indentation character` may be used for indentation.
 
 [`current indentation level`]: #current-indentation-level
-
-It is defined as the first tab or space character used as an [IndentMore]
-production in a document.
-
-In the indented syntax, no character other than the `document indentation
-character` may be used for indentation.
 
 ## Syntax
 
 ### ScssStatements
 
 <x><pre>
-**ScssStatements**      ::= (Statement ';'?¹)*Statement?
+**ScssStatements**      ::= (Statement ';'?¹)* Statement?
 </pre></x>
 
 1: This production is mandatory unless the previous `Statement` is a
@@ -75,13 +76,13 @@ If a `WhitespaceComment` would be ambiguous with a `Statement` in the
 ### Statements
 
 <x><pre>
-**Statements**          ::= [ScssStatements] | [IndentedStatements]¹
+**Statements**¹          ::= [ScssStatements] | [IndentedStatements]
 </pre></x>
 
 [ScssStatements]: #scssstatements
 [IndentedStatements]: #indentedstatements
 
-Only the production for the current syntax is valid.
+1. Only the production for the current syntax is valid.
 
 ### Block
 
@@ -119,9 +120,9 @@ Only the production for the current syntax is valid.
 [LineBreak]: #whitespace
 [IndentCharacter]: #whitespace
 
-The [IndentCharacter] must be the [Document indentation character].
+The [IndentCharacter] must be the [document indentation character].
 
-[Document indentation character]: #document-indentation-character
+[document indentation character]: #document-indentation-character
 
 `Current` is the [current indentation level] for a document. After consuming an
 `IndentSame`, `IndentLess`, or `IndentMore` production, the [current indentation

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -163,7 +163,7 @@ productions.
 [Whitespace]: #whitespace
 [LineBreak]: #whitespace
 
-The [IndentCharacter] must be the [document indentation character].
+The IndentCharacter must be the [document indentation character].
 
 [document indentation character]: #document-indentation-character
 

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -119,20 +119,16 @@ productions.
 
 <x><pre>
 **ScssSilentComment**          ::= '//' .\*¹
-**CommentText**                ::= .\*²
+**CommentText**                ::= .\*¹
 **IndentedSilentChildren**     ::= (CommentText [IndentSame])\* CommentText
 **IndentedSilentComment**      ::= '//' CommentText
 &#32;                              ([IndentMore] IndentedSilentChildren)?
-**SilentComment**              ::= (ScssSilentComment | IndentedSilentComment)³
+**SilentComment**              ::= (ScssSilentComment | IndentedSilentComment)²
 </pre></x>
 
 1: This may not contain newlines.
 
-2: This may not contain newlines outside of [WhitespaceOnlyLine] productions.
-
-3: Only the production for the current syntax is valid.
-
-[WhitespaceOnlyLine]: #indentation
+2: Only the production for the current syntax is valid.
 
 #### WhitespaceComment
 
@@ -159,7 +155,7 @@ productions.
 ### Indentation
 
 <x><pre>
-**WhitespaceOnlyLine**          ::= IndentSame? [Whitespace]\* [LineBreak]
+**WhitespaceOnlyLine**          ::= [Whitespace]\* [LineBreak]
 **IndentSame**                  ::= [LineBreak] WhitespaceOnlyLine\*
 &#32;                               IndentCharacter{ Current }
 **IndentCharacter**             ::= Space | Tab

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -133,7 +133,7 @@ productions.
 #### WhitespaceComment
 
 <x><pre>
-**WhitespaceComment**³             ::= ('//' .\*¹) | ('/\*' .\*² '\*/')
+**WhitespaceComment**              ::= ('//' .\*¹) | ('/\*' .\*² '\*/')
 </pre></x>
 
 1. This may not contain newlines.

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -117,7 +117,10 @@ productions.
 
 <x><pre>
 **ScssSilentComment**          ::= '//' .\*¹
-**IndentedSilentComment**      ::= '//' .\*²
+**CommentText**                ::= .\*²
+**IndentedSilentChildren**     ::= (CommentText [IndentSame])\* CommentText
+**IndentedSilentComment**      ::= '//' CommentText ([IndentMore]
+&#32;                              IndentedSilentChildren)?
 **SilentComment**              ::= (ScssSilentComment | IndentedSilentComment)³
 </pre></x>
 
@@ -129,13 +132,13 @@ productions.
 
 <x><pre>
 **ScssWhitespaceComment**          ::= '//' .\*¹ | '/\*' .\*² '\*/'
-**IndentedWhitespaceComment**      ::= '/\*' .\*² '\*/'
+**IndentedWhitespaceComment**      ::= ('/\*' .\*² '\*/') | ('//' .\*¹)
 **WhitespaceComment**³             ::= ScssWhitespaceComment
 &#32;                                | IndentedWhitespaceComment
 </pre></x>
 
 1. This may not contain newlines.
-2. This may not contain `*/`.
+2. This may not contain `*/` or newlines.
 3. Only the production for the current syntax is valid.
 
 ### Whitespace

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -146,8 +146,7 @@ productions.
 **Whitespace** ::= LineBreak¹ | Space | Tab | [WhitespaceComment]
 </pre></x>
 
-1. This is not allowed in the indented syntax.
-2. Only the production for the current syntax is valid.
+1: This is not allowed in the indented syntax.
 
 [WhitespaceComment]: #whitespacecomment
 

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -1,0 +1,131 @@
+# Statement
+
+## Table of Contents
+
+* [Definitions](#definitions)
+  * [Current indentation level](#current-indentation-level)
+  * [Document indentation character](#document-indentation-character)
+* [Syntax](#syntax)
+  * [ScssStatements](#scssstatements)
+  * [IndentedStatements](#indentedstatements)
+  * [Statements](#statements)
+  * [Block](#block)
+  * [Whitespace](#whitespace)
+  * [Indentation](#indentation)
+
+## Definitions
+
+### Current indentation level
+
+The `current indentation level` is the count of the [`documentation indentation
+character`] between a new line and any non-whitespace characters of the last
+consumed line.
+
+A document parsed in the indented syntax may not begin with whitespace, and the
+initial `current indentation level` for any document is `0`.
+
+Changes in the indentation level are used by the indented syntax to start and
+end blocks of statements.
+
+[`documentation indentation character`]: #document-indentation-character
+
+### Document indentation character
+
+The `document indentation character` is the character used for calculating the
+[`current indentation level`], and is either a space or tab character.
+
+[`current indentation level`]: #current-indentation-level
+
+It is defined as the first tab or space character used as an [IndentMore]
+production in a document.
+
+In the indented syntax, no character other than the `document indentation
+character` may be used for indentation.
+
+## Syntax
+
+### ScssStatements
+
+<x><pre>
+**ScssStatements**      ::= (Statement ';'?¹)*Statement?
+</pre></x>
+
+1: This production is mandatory unless the previous `Statement` is a
+`LoudComment` or `SilentComment`, or after the final production in a
+`ScssStatements` production, which is either at the end of a `Block` or the end
+of the document.
+
+If a `WhitespaceComment` would be ambiguous with a `Statement` in the
+`ScssStatements` rule, parse it preferentially as a `Statement`.
+
+### IndentedStatements
+
+<x><pre>
+**IndentedStatements**  ::= (Statement IndentedSame?¹)* Statement?
+</pre></x>
+
+1: This production is mandatory unless the previous `Statement` is a
+`LoudComment` or `SilentComment`, or after the final production in a
+`IndentedStatements` production, which is either at the end of a `Block` or the
+end of the document.
+
+If a `WhitespaceComment` would be ambiguous with a `Statement` in the
+`IndentedStatements` rule, parse it preferentially as a `Statement`.
+
+### Statements
+
+<x><pre>
+**Statements**          ::= [ScssStatements] | [IndentedStatements]¹
+</pre></x>
+
+[ScssStatements]: #scssstatements
+[IndentedStatements]: #indentedstatements
+
+Only the production for the current syntax is valid.
+
+### Block
+
+<x><pre>
+**ScssBlock**      ::= '{' [ScssStatements] '}'
+**IndentedBlock**  ::= [IndentMore] [IndentedStatements] [IndentLess]
+**Block**          ::= ScssBlock | IndentedBlock¹
+</pre></x>
+
+[IndentMore]: #indentation
+[IndentLess]: #indentation
+
+1: Only the production for the current syntax is valid.
+
+### Whitespace
+
+> Whitespace separates productions inside a statement when disambiguation is
+> necessary. The Whitespace productions do not separate Statements.
+
+<x><pre>
+**LineBreak**               ::= CarriageReturn | LineFeed | FormFeed
+**ScssWhitespace**          ::= LineBreak | Space | Tab
+**IndentedWhitespace**      ::= Space | Tab
+</pre></x>
+
+### Indentation
+
+<x><pre>
+**IndentCharacter**         ::= Space | Tab
+**IndentSame**              ::= [LineBreak] [IndentCharacter]{ Current }
+**IndentLess**              ::= [LineBreak] [IndentCharacter]{ 0, Current - 1 }
+**IndentMore**              ::= [LineBreak] [IndentCharacter]{ Current + 1, }
+</pre></x>
+
+[LineBreak]: #whitespace
+[IndentCharacter]: #whitespace
+
+The [IndentCharacter] must be the [Document indentation character].
+
+[Document indentation character]: #document-indentation-character
+
+`Current` is the [current indentation level] for a document. After consuming an
+`IndentSame`, `IndentLess`, or `IndentMore` production, the [current indentation
+level] is set to the number of [IndentCharacter]s found. At the end of a
+document, the [current indentation level] is set to 0.
+
+[current indentation level]: #current-indentation-level

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -109,9 +109,11 @@ productions.
 **LoudComment**              ::= (ScssLoudComment | IndentedLoudComment)³
 </pre></x>
 
-1. This may not contain `#{` or `*/`.
-2. This may not contain `#{` or newlines.
-3. Only the production for the current syntax is valid.
+1: This may not contain `#{` or `*/`.
+
+2: This may not contain `#{` or newlines.
+
+3: Only the production for the current syntax is valid.
 
 #### SilentComment
 
@@ -124,9 +126,11 @@ productions.
 **SilentComment**              ::= (ScssSilentComment | IndentedSilentComment)³
 </pre></x>
 
-1. This may not contain newlines.
-2. This may not contain newlines outside of [WhitespaceOnlyLine] productions.
-3. Only the production for the current syntax is valid.
+1: This may not contain newlines.
+
+2: This may not contain newlines outside of [WhitespaceOnlyLine] productions.
+
+3: Only the production for the current syntax is valid.
 
 [WhitespaceOnlyLine]: #indentation
 
@@ -136,8 +140,9 @@ productions.
 **WhitespaceComment**              ::= ('//' .\*¹) | ('/\*' .\*² '\*/')
 </pre></x>
 
-1. This may not contain newlines.
-2. This may not contain `*/`. In the indented syntax, this may not contain
+1: This may not contain newlines.
+
+2: This may not contain `*/`. In the indented syntax, this may not contain
    newlines.
 
 ### Whitespace

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -154,11 +154,11 @@ productions.
 ### Indentation
 
 <x><pre>
-**WhitespaceOnlyLine**          ::= IndentSame? (Whitespace)* [LineBreak]
-**IndentCharacter**             ::= Space | Tab
-**IndentSame**                  ::= [LineBreak] WhitespaceOnlyLine*
+**WhitespaceOnlyLine**          ::= IndentSame? Whitespace\* [LineBreak]
+**IndentSame**                  ::= [LineBreak] WhitespaceOnlyLine\*
 &#32;                               [IndentCharacter]{ Current }
-**IndentMore**                  ::= WhitespaceOnlyLine* [LineBreak]
+**IndentCharacter**             ::= Space | Tab
+**IndentMore**                  ::= WhitespaceOnlyLine\* [LineBreak]
 &#32;                               [IndentCharacter]{ ≥ Current + 1 }
 </pre></x>
 

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -8,7 +8,7 @@
 * [Syntax](#syntax)
   * [ScssStatements](#scssstatements)
   * [IndentedStatements](#indentedstatements)
-  * [Statements](#statements)
+  * [Stylesheet](#stylesheet)
   * [Block](#block)
   * [Comments](#comments)
     * [LoudComment](#loudcomment)
@@ -37,7 +37,7 @@ initial `current indentation level` for any document is `0`.
 ### Document indentation character
 
 The `document indentation character` is defined as the first tab or space
-character used as an [`IndentMore`] production in a document.
+character used in an [`IndentMore`] production in a document.
 
 [`IndentMore`]: #indentation
 
@@ -55,7 +55,7 @@ character used as an [`IndentMore`] production in a document.
 **ScssStatements**      ::= (Statement ';'?¹)* Statement?
 </pre></x>
 
-1: This production is mandatory unless the previous `Statement` is a
+1. This production is mandatory unless the previous `Statement` is a
 `LoudComment`, `SilentComment`, or ends in a `Block`.
 
 If a `WhitespaceComment` would be ambiguous with a `Statement` in the
@@ -69,10 +69,13 @@ If a `WhitespaceComment` would be ambiguous with a `Statement` in the
 
 [IndentSame]: #indentation
 
-### Statements
+The `Statement` productions may not include newlines outside of `IndentSame`
+productions.
+
+### Stylesheet
 
 <x><pre>
-**Statements**          ::= ([ScssStatements] | [IndentedStatements])¹
+**Stylesheet**          ::= U+FEFF? ([ScssStatements] | [IndentedStatements])¹
 </pre></x>
 
 [ScssStatements]: #scssstatements
@@ -90,42 +93,49 @@ If a `WhitespaceComment` would be ambiguous with a `Statement` in the
 
 [IndentMore]: #indentation
 
-1: Only the production for the current syntax is valid.
+1. Only the production for the current syntax is valid.
 
 ### Comments
 
 #### LoudComment
 
 <x><pre>
-**ScssLoudComment**          ::= '/*' '!'? (.* | Interpolation)*'*/'
-**IndentedLoudComment**      ::= '/*' '!'? (.* | Interpolation)*
-**LoudComment**              ::= (ScssLoudComment | IndentedLoudComment)¹
+**ScssLoudComment**          ::= '/\*' (.\*¹ | Interpolation)*'\*/'
+**IndentedLoudCommentNest**  ::= [IndentMore] ((.\*² | Interpolation)*
+&#32;                            [IndentSame])*(.\*² | Interpolation)*
+**IndentedLoudComment**      ::= '/\*' (.\*² | Interpolation)*
+&#32;                            IndentedLoudCommentNest?
+**LoudComment**              ::= (ScssLoudComment | IndentedLoudComment)³
 </pre></x>
 
-> TODO: Wildcard and character set regex syntax conflict with markdown.
-
-1: Only the production for the current syntax is valid.
+1. This may not contain `#{` or `*/`.
+2. This may not contain `#{` or newlines.
+3. Only the production for the current syntax is valid.
 
 #### SilentComment
 
 <x><pre>
-**ScssSilentComment**          ::= '//' .*
-**IndentedSilentComment**      ::= '//' .*
-**SilentComment**              ::= (ScssSilentComment | IndentedSilentComment)¹
+**ScssSilentComment**          ::= '//' .\*¹
+**IndentedSilentComment**      ::= '//' .\*²
+**SilentComment**              ::= (ScssSilentComment | IndentedSilentComment)³
 </pre></x>
 
-1: Only the production for the current syntax is valid.
+1. This may not contain newlines.
+2. This may not contain newlines outside of [IndentSame] productions.
+3. Only the production for the current syntax is valid.
 
 #### WhitespaceComment
 
 <x><pre>
-**ScssWhitespaceComment**          ::= '//' .*'//' | '/*' .*'*/'
-**IndentedWhitespaceComment**      ::= '/*' .* '*/'
-**WhitespaceComment*¹              ::= ScssWhitespaceComment
+**ScssWhitespaceComment**          ::= '//' .\*¹ | '/\*' .\*² '\*/'
+**IndentedWhitespaceComment**      ::= '/\*' .\*² '\*/'
+**WhitespaceComment**³             ::= ScssWhitespaceComment
 &#32;                                | IndentedWhitespaceComment
 </pre></x>
 
-1: Only the production for the current syntax is valid.
+1. This may not contain newlines.
+2. This may not contain `*/`.
+3. Only the production for the current syntax is valid.
 
 ### Whitespace
 
@@ -137,19 +147,19 @@ If a `WhitespaceComment` would be ambiguous with a `Statement` in the
 &#32;                         | [WhitespaceComment]
 </pre></x>
 
-1: Only the production for the current syntax is valid.
+1. Only the production for the current syntax is valid.
 
 [WhitespaceComment]: #whitespacecomment
 
 ### Indentation
 
 <x><pre>
-**WhitespaceOnlyLine**          ::= IndentSame (Whitespace)*
+**WhitespaceOnlyLine**          ::= IndentSame? (Whitespace)* [LineBreak]
 **IndentCharacter**             ::= Space | Tab
-**IndentSame**                  ::= WhitespaceOnlyLine* [LineBreak]
+**IndentSame**                  ::= [LineBreak] WhitespaceOnlyLine*
 &#32;                               [IndentCharacter]{ Current }
 **IndentMore**                  ::= WhitespaceOnlyLine* [LineBreak]
-&#32;                               [IndentCharacter]{ Current + 1, }
+&#32;                               [IndentCharacter]{ ≥ Current + 1 }
 </pre></x>
 
 [LineBreak]: #whitespace

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -138,7 +138,6 @@ productions.
 2. This may not contain `*/`. In the indented syntax, this may not contain
    newlines.
 
-
 ### Whitespace
 
 <x><pre>

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -146,8 +146,8 @@ productions.
 **Whitespace** ::= LineBreak¹ | Space | Tab | [WhitespaceComment]
 </pre></x>
 
-1: This is not allowed in the indented syntax.
-1: Only the production for the current syntax is valid.
+1. This is not allowed in the indented syntax.
+2. Only the production for the current syntax is valid.
 
 [WhitespaceComment]: #whitespacecomment
 

--- a/spec/statement.md
+++ b/spec/statement.md
@@ -52,9 +52,7 @@ character used as an [`IndentMore`] production in a document.
 </pre></x>
 
 1: This production is mandatory unless the previous `Statement` is a
-`LoudComment` or `SilentComment`, or after the final production in a
-`ScssStatements` production, which is either at the end of a `Block` or the end
-of the document.
+`LoudComment`, `SilentComment`, or ends in a `Block`.
 
 If a `WhitespaceComment` would be ambiguous with a `Statement` in the
 `ScssStatements` rule, parse it preferentially as a `Statement`.
@@ -62,21 +60,13 @@ If a `WhitespaceComment` would be ambiguous with a `Statement` in the
 ### IndentedStatements
 
 <x><pre>
-**IndentedStatements**  ::= (Statement IndentedSame?¹)* Statement?
+**IndentedStatements**  ::= (Statement IndentedSame)* Statement
 </pre></x>
-
-1: This production is mandatory unless the previous `Statement` is a
-`LoudComment` or `SilentComment`, or after the final production in a
-`IndentedStatements` production, which is either at the end of a `Block` or the
-end of the document.
-
-If a `WhitespaceComment` would be ambiguous with a `Statement` in the
-`IndentedStatements` rule, parse it preferentially as a `Statement`.
 
 ### Statements
 
 <x><pre>
-**Statements**¹          ::= [ScssStatements] | [IndentedStatements]
+**Statements**          ::= ([ScssStatements] | [IndentedStatements])¹
 </pre></x>
 
 [ScssStatements]: #scssstatements
@@ -89,11 +79,46 @@ If a `WhitespaceComment` would be ambiguous with a `Statement` in the
 <x><pre>
 **ScssBlock**      ::= '{' [ScssStatements] '}'
 **IndentedBlock**  ::= [IndentMore] [IndentedStatements] [IndentLess]
-**Block**          ::= ScssBlock | IndentedBlock¹
+**Block**          ::= (ScssBlock | IndentedBlock)¹
 </pre></x>
 
 [IndentMore]: #indentation
 [IndentLess]: #indentation
+
+1: Only the production for the current syntax is valid.
+
+### Comments
+
+#### LoudComment
+
+<x><pre>
+**ScssLoudComment**          ::= '/*' '!'? (.* | Interpolation)* '*/'
+**IndentedLoudComment**      ::= '/*' '!'? ([^IndentedLess] | Interpolation)*
+**LoudComment**              ::= (ScssLoudComment | IndentedLoudComment)¹
+</pre></x>
+
+> TODO: Wildcard and character set regex syntax conflict with markdown.
+
+1: Only the production for the current syntax is valid.
+
+#### SilentComment
+
+<x><pre>
+**ScssSilentComment**          ::= '//' [^LineBreak]*
+**IndentedSilentComment**      ::= '//' [^IndentedLess]*
+**SilentComment**              ::= (ScssSilentComment | IndentedSilentComment)¹
+</pre></x>
+
+1: Only the production for the current syntax is valid.
+
+#### WhitespaceComment
+
+<x><pre>
+**ScssWhitespaceComment**          ::= '//' .* '//' | '/*' .* '*/'
+**IndentedWhitespaceComment**      ::= '/*' .* '*/'
+**WhitespaceComment*¹              ::= ScssWhitespaceComment 
+&#32;                                | IndentedWhitespaceComment
+</pre></x>
 
 1: Only the production for the current syntax is valid.
 
@@ -106,7 +131,13 @@ If a `WhitespaceComment` would be ambiguous with a `Statement` in the
 **LineBreak**               ::= CarriageReturn | LineFeed | FormFeed
 **ScssWhitespace**          ::= LineBreak | Space | Tab
 **IndentedWhitespace**      ::= Space | Tab
+**Whitespace**              ::= (ScssWhitespace | IndentedWhitespace)¹ 
+&#32;                         | [WhitespaceComment]
 </pre></x>
+
+1: Only the production for the current syntax is valid.
+
+[WhitespaceComment]: #whitespacecomment
 
 ### Indentation
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -95,13 +95,12 @@ No whitespace is allowed between components of an `InterpolatedUnquotedUrlConten
 > a normal SassScript expression.
 
 <x><pre>
-**SpecialFunctionExpression** ::= SpecialFunctionName [InterpolatedDeclarationValue] ')'
+**SpecialFunctionExpression** ::= SpecialFunctionName InterpolatedDeclarationValue ')'
 **SpecialFunctionName**¹      ::= VendorPrefix? ('element(' | 'expression(')
 &#32;                           | VendorPrefix 'calc('
 **VendorPrefix**¹             ::= '-' ([identifier-start code point] | [digit]) '-'
 </pre></x>
 
-[InterpolatedDeclarationValue]: ./declarations.md#syntax
 [digit]: https://drafts.csswg.org/css-syntax-3/#digit
 
 1: Both `SpecialFunctionName` and `VendorPrefix` are matched case-insensitively,

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -95,12 +95,13 @@ No whitespace is allowed between components of an `InterpolatedUnquotedUrlConten
 > a normal SassScript expression.
 
 <x><pre>
-**SpecialFunctionExpression** ::= SpecialFunctionName InterpolatedDeclarationValue ')'
+**SpecialFunctionExpression** ::= SpecialFunctionName [InterpolatedDeclarationValue] ')'
 **SpecialFunctionName**¹      ::= VendorPrefix? ('element(' | 'expression(')
 &#32;                           | VendorPrefix 'calc('
 **VendorPrefix**¹             ::= '-' ([identifier-start code point] | [digit]) '-'
 </pre></x>
 
+[InterpolatedDeclarationValue]: ./declarations.md#syntax
 [digit]: https://drafts.csswg.org/css-syntax-3/#digit
 
 1: Both `SpecialFunctionName` and `VendorPrefix` are matched case-insensitively,
@@ -148,8 +149,8 @@ parentheses.
 
 ### Parsing Text
 
-This algorithm takes a string `text` and a syntax `syntax` ("indented", "scss",
-or "sass"), and returns a Sass abstract syntax tree.
+This algorithm takes a string `text` and a syntax `syntax` ("indented", "css",
+or "scss"), and returns a Sass abstract syntax tree.
 
 * If `syntax` is "indented", return the result of parsing `text` as the indented
   syntax.

--- a/spec/types/list.md
+++ b/spec/types/list.md
@@ -1,4 +1,4 @@
-# Numbers
+# Lists
 
 ## Table of Contents
 


### PR DESCRIPTION
In preparation for proposing changes to the indented syntax, this documents existing behavior of the indented syntax, specifically around Statements.

In addition: 

- Explicit curly brace-wrapped Statements are replaced with a new `Block` production that supports both syntaxes.
- This also documents `InterpolatedDeclarationValue` production, which is somewhat orthogonal to the syntax, and those changes can be removed if it's easier.