### PR TITLE
Specify syntax for argument and parameter lists

### DIFF
--- a/spec/at-rules/function.md
+++ b/spec/at-rules/function.md
@@ -8,13 +8,14 @@
 ## Syntax
 
 <x><pre>
-**FunctionRule** ::= '@function' [\<ident-token>] ArgumentDeclaration '{' Statements '}'
+**FunctionRule** ::= '@function' [\<ident-token>] [ParameterList] '{' Statements '}'
 </pre></x>
 
+[ParameterList]: ../syntax.md#parameterlist
 [\<ident-token>]: https://drafts.csswg.org/css-syntax-3/#ident-token-diagram
 
-No whitespace is allowed between the `Identifier` and the `ArgumentDeclaration`
-in `FunctionRule`.
+No whitespace is allowed between the `Identifier` and the `ParameterList` in
+`FunctionRule`.
 
 ## Semantics
 
@@ -41,7 +42,7 @@ To execute a `@function` rule `rule`:
 
   * With the current scope set to an empty [scope] with `parent` as its parent:
 
-    * Evaluate `args` with `rule`'s `ArgumentDeclaration`.
+    * Evaluate `args` with `rule`'s `ParameterList`.
 
     * Execute each statement in `rule`.
 

--- a/spec/at-rules/mixin.md
+++ b/spec/at-rules/mixin.md
@@ -17,13 +17,14 @@
 ### Syntax
 
 <x><pre>
-**MixinRule** ::= '@mixin' [\<ident-token>] ArgumentDeclaration? [Block]
+**MixinRule** ::= '@mixin' [\<ident-token>] [ParameterList]? [Block]
 </pre></x>
 
 [\<ident-token>]: https://drafts.csswg.org/css-syntax-3/#ident-token-diagram
+[ParameterList]: ../syntax.md#parameterlist
 [Block]: ../statement.md#block
 
-No whitespace is allowed between the `Identifier` and the `ArgumentDeclaration`
+No whitespace is allowed between the `Identifier` and the `ParameterList`
 in `MixinRule`.
 
 ### Semantics
@@ -45,7 +46,7 @@ To execute a `@mixin` rule `rule`:
 
   * With the current scope set to an empty [scope] with `parent` as its parent:
 
-    * Evaluate `args` with `rule`'s `ArgumentDeclaration`.
+    * Evaluate `args` with `rule`'s `ParameterList`.
 
     * Execute each statement in `rule`.
 
@@ -74,16 +75,17 @@ To execute a `@mixin` rule `rule`:
 ### Syntax
 
 <x><pre>
-**IncludeRule**      ::= '@include' [NamespacedIdentifier] ArgumentInvocation?
+**IncludeRule**      ::= '@include' [NamespacedIdentifier] [ArgumentList]?
 &#32;                    ContentBlock?
 **ContentBlock**     ::= UsingDeclaration? [Block]
-**UsingDeclaration** ::= 'using' ArgumentDeclaration
+**UsingDeclaration** ::= 'using' [ParameterList]
 </pre></x>
 
 [NamespacedIdentifier]: ../modules.md#syntax
+[ArgumentList]: ../syntax.md#argumentlist
 
 No whitespace is allowed between the `NamespacedIdentifier` and the
-`ArgumentInvocation` in `IncludeRule`.
+`ArgumentList` in `IncludeRule`.
 
 ### Semantics
 
@@ -96,7 +98,7 @@ To execute an `@include` rule `rule`:
 
   [resolving a mixin]: ../modules.md#resolving-a-member
 
-* Execute `mixin` with `rule`'s `ArgumentInvocation`.
+* Execute `mixin` with `rule`'s `ArgumentList`.
 
 ## `@content`
 
@@ -106,7 +108,7 @@ current mixin.
 ### Syntax
 
 <x><pre>
-**ContentRule** ::= '@content' ArgumentInvocation?
+**ContentRule** ::= '@content' [ArgumentList]?
 </pre></x>
 
 As with all statements, a `ContentRule` must be separated from other statements
@@ -121,12 +123,12 @@ an `@include` rule `include`:
 > and mixins must be invoked using `@include`, so `include` is guaranted to
 > exist.
 
-* Let `invocation` be `content`'s `ArgumentInvocation`, or an invocation with no
-  arguments if `content` has no `ArgumentInvocation`.
+* Let `invocation` be `content`'s `ArgumentList`, or an invocation with no
+  arguments if `content` has no `ArgumentList`.
 
   > This means that `@content` and `@content()` are interpreted identically.
 
-* Let `declaration` be `include`'s `UsingDeclaration`'s `ArgumentDeclaration`,
+* Let `declaration` be `include`'s `UsingDeclaration`'s `ParameterList`,
   or a declaration with no arguments if `include` has no `UsingDeclaration`.
 
   > This means that `@include foo { ... }` and `@include foo using () { ... }`

--- a/spec/built-in-modules.md
+++ b/spec/built-in-modules.md
@@ -12,10 +12,11 @@ Each function and mixin defined in a built-in modules is specified with a
 signature of the form
 
 <x><pre>
-[\<ident-token>] ArgumentDeclaration
+[\<ident-token>] [ParameterList]
 </pre></x>
 
 [\<ident-token>]: https://drafts.csswg.org/css-syntax-3/#ident-token-diagram
+[ParameterList]: syntax.md#parameterlist
 
 followed by a procedure. It's available as a member (either function or mixin)
 in the module whose name is the value of the `<ident-token>`. When it's executed
@@ -25,7 +26,7 @@ with `args`:
 
   [current scope]: spec.md#scope
 
-  * Evaluate `args` with the signature's `ArgumentDeclaration`.
+  * Evaluate `args` with the signature's `ParameterList`.
 
   * Run the procedure, and return its result if this is a function.
 

--- a/spec/built-in-modules/meta.md
+++ b/spec/built-in-modules/meta.md
@@ -375,12 +375,14 @@ apply($mixin, $args...)
 * If the current `@include` rule has a `ContentBlock` and `$mixin` doesn't
   accept a block, throw an error.
 
-* Execute `$mixin` with the `ArgumentInvocation` `(...$args)`. Treat the
+* Execute `$mixin` with the [`ArgumentList`] `(...$args)`. Treat the
   `@include` rule that invoked `apply` as the `@include` rule that invoked
   `$mixin`.
 
   > This ensures that any `@content` rules in `$mixin` will use `apply()`'s
   > `ContentBlock`.
+
+[`ArgumentList`]: ../syntax.md#argumentlist
 
 ### `load-css()`
 

--- a/spec/functions.md
+++ b/spec/functions.md
@@ -57,11 +57,12 @@ matching is case-insensitive.
 &#32;                     | EmptyFallbackVar
 &#32;                     | FunctionCall
 **EmptyFallbackVar**²   ::= 'var(' Expression ',' ')'
-**FunctionCall**⁴       ::= [NamespacedIdentifier] ArgumentInvocation
+**FunctionCall**⁴       ::= [NamespacedIdentifier] [ArgumentList]
 </pre></x>
 
 [SpecialFunctionExpression]: syntax.md#specialfunctionexpression
 [NamespacedIdentifier]: modules.md#syntax
+[ArgumentList]: syntax.md#argumentlist
 
 1: Both `CssMinMax` and `EmptyFallbackVar` take precedence over `FunctionCall`
    if either could be consumed.
@@ -69,17 +70,17 @@ matching is case-insensitive.
 2: `'var('` is matched case-insensitively.
 
 4: `FunctionCall` may not have any whitespace between the `NamespacedIdentifier`
-   and the `ArgumentInvocation`. It may not start with [`SpecialFunctionName`],
+   and the `ArgumentList`. It may not start with [`SpecialFunctionName`],
    `'calc('`, or `'clamp('` (case-insensitively).
 
 [`SpecialFunctionName`]: syntax.md#specialfunctionexpression
 
 <x><pre>
-**FunctionCall** ::= [NamespacedIdentifier] ArgumentInvocation
+**FunctionCall** ::= [NamespacedIdentifier] [ArgumentList]
 </pre></x>
 
 No whitespace is allowed between the `NamespacedIdentifier` and the
-`ArgumentInvocation` in `FunctionCall`.
+`ArgumentList` in `FunctionCall`.
 
 ## Semantics
 
@@ -110,9 +111,9 @@ To evaluate a `FunctionCall` `call`:
 * If `function` is null and `name` is not a plain `Identifier`, throw an error.
 
 * If `function` is null; `name` is case-insensitively equal to `"min"`, `"max"`,
-  `"round"`, or `"abs"`; `call`'s `ArgumentInvocation` doesn't have any
+  `"round"`, or `"abs"`; `call`'s `ArgumentList` doesn't have any
   `KeywordArgument`s or `RestArgument`s; and all arguments in `call`'s
-  `ArgumentInvocation` are [calculation-safe], return the result of evaluating
+  `ArgumentList` are [calculation-safe], return the result of evaluating
   `call` [as a calculation].
 
   [calculation-safe]: types/calculation.md#calculation-safe-expression
@@ -133,14 +134,14 @@ To evaluate a `FunctionCall` `call`:
 
 * If `function` is still null:
 
-  * Let `list` be the result of evaluating `call`'s `ArgumentInvocation`.
+  * Let `list` be the result of evaluating `call`'s `ArgumentList`.
 
   * If `list` has keywords, throw an error.
 
   * Return an unquoted string representing a CSS function call with name `name`
     and arguments `list`.
 
-* Execute `call`'s `ArgumentInvocation` with `function`'s `ArgumentDeclaration`
+* Execute `call`'s `ArgumentList` with `function`'s [`ParameterList`]
   in `function`'s scope.
 
 * Execute each statement in `function` until a `ReturnRule` `return` that's
@@ -148,6 +149,8 @@ To evaluate a `FunctionCall` `call`:
   statement is encountered, throw an error.
 
 * Evaluate `return`'s `Expression` and return the result.
+
+[`ParameterList`]: syntax.md#parameterlist
 
 ## Global Functions
 

--- a/spec/js-api/options.d.ts.md
+++ b/spec/js-api/options.d.ts.md
@@ -151,8 +151,8 @@ Before beginning compilation:
 
 * For each key/value pair `signature`/`function` in this record:
 
-  * If `signature` isn't an [<ident-token>] followed immediately by an
-    `ArgumentDeclaration`, throw an error.
+  * If `signature` isn't an [<ident-token>] followed immediately by a
+    [`ParameterList`], throw an error.
 
   * Let `name` be `signature`'s <ident-token>.
 
@@ -182,6 +182,7 @@ Before beginning compilation:
       contains (including the return value itself if it's a calculation)
       replaced with the result of [simplifying] those calculations.
 
+[`ParameterList`]: ../syntax.md#parameterlist
 [<ident-token>]: https://drafts.csswg.org/css-syntax-3/#ident-token-diagram
 [underscore-insensitively]: ../modules.md#underscore-insensitive
 [`SassFunction`]: value/function.d.ts.md

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -6,12 +6,14 @@
   * [Source File](#source-file)
   * [Vendor Prefix](#vendor-prefix)
 * [Syntax](#syntax-1)
+  * [`ArgumentList`](#argumentlist)
   * [`InterpolatedIdentifier`](#interpolatedidentifier)
   * [`InterpolatedUrl`](#interpolatedurl)
   * [`Name`](#name)
-  * [`SpecialFunctionExpression`](#specialfunctionexpression)
-  * [`PseudoSelector`](#pseudoselector)
+  * [`ParameterList`](#parameterlist)
   * [`ProductExpression`](#productexpression)
+  * [`PseudoSelector`](#pseudoselector)
+  * [`SpecialFunctionExpression`](#specialfunctionexpression)
 * [Procedures](#procedures)
   * [Parsing Text](#parsing-text)
   * [Parsing Text as CSS](#parsing-text-as-css)
@@ -57,6 +59,19 @@ representation of the intermediate production.
 > `Foo` wrapper is removed. (The `Bar` wrapper is *not* removed because
 > `<ident-token>` is a CSS production, not a Sass production.)
 
+### `ArgumentList`
+
+<x><pre>
+**ArgumentList**  ::= '(' Expression (',' Expression)\*
+&#32;                 (',' NamedArgument)\* (',' RestArgument){0,2} ','? ')'
+&#32;               | '(' NamedArgument (',' NamedArgument)\*
+&#32;                 (',' RestArgument){0,2} ','? ')'
+&#32;               | '(' RestArgument (',' RestArgument)? ','? ')'
+&#32;               | '(' ')'
+**NamedArgument** ::= [PlainVariable] ':' Expression
+**RestArgument**  ::= Expression '...'
+</pre></x>
+
 ### `InterpolatedIdentifier`
 
 <x><pre>
@@ -88,23 +103,24 @@ No whitespace is allowed between components of an `InterpolatedUnquotedUrlConten
 [identifier code point]: https://drafts.csswg.org/css-syntax-3/#identifier-code-point
 [escape]: https://drafts.csswg.org/css-syntax-3/#escape-diagram
 
-### `SpecialFunctionExpression`
-
-> These functions are "special" in the sense that their arguments don't use the
-> normal CSS expression-level syntax, and so have to be parsed more broadly than
-> a normal SassScript expression.
+### `ParameterList`
 
 <x><pre>
-**SpecialFunctionExpression** ::= SpecialFunctionName InterpolatedDeclarationValue ')'
-**SpecialFunctionName**¹      ::= VendorPrefix? ('element(' | 'expression(')
-&#32;                           | VendorPrefix 'calc('
-**VendorPrefix**¹             ::= '-' ([identifier-start code point] | [digit]) '-'
+**ParameterList** ::= '(' Parameter (',' Parameter)\* ','? ')'
+&#32;               | '(' Parameter (',' Parameter)\* (',' RestParameter)? ')'
+&#32;               | '(' RestParameter ')'
+&#32;               | '(' ')'
+**Parameter**     ::= [PlainVariable] (':' Expression)?
+**RestParameter** ::= [PlainVariable] '...'
 </pre></x>
 
-[digit]: https://drafts.csswg.org/css-syntax-3/#digit
+[PlainVariable]: variables.md#syntax
 
-1: Both `SpecialFunctionName` and `VendorPrefix` are matched case-insensitively,
-   and neither may contain whitespace.
+### `ProductExpression`
+
+<x><pre>
+**ProductExpression** ::= (ProductExpression ('*' | '%'))? UnaryPlusExpression
+</pre></x>
 
 ### `PseudoSelector`
 
@@ -138,11 +154,23 @@ followed by a parenthesis, it must be parsed as a `SelectorPseudo` or an
 No whitespace is allowed anywhere in a `PseudoSelector` except within
 parentheses.
 
-### `ProductExpression`
+### `SpecialFunctionExpression`
+
+> These functions are "special" in the sense that their arguments don't use the
+> normal CSS expression-level syntax, and so have to be parsed more broadly than
+> a normal SassScript expression.
 
 <x><pre>
-**ProductExpression** ::= (ProductExpression ('*' | '%'))? UnaryPlusExpression
+**SpecialFunctionExpression** ::= SpecialFunctionName InterpolatedDeclarationValue ')'
+**SpecialFunctionName**¹      ::= VendorPrefix? ('element(' | 'expression(')
+&#32;                           | VendorPrefix 'calc('
+**VendorPrefix**¹             ::= '-' ([identifier-start code point] | [digit]) '-'
 </pre></x>
+
+[digit]: https://drafts.csswg.org/css-syntax-3/#digit
+
+1: Both `SpecialFunctionName` and `VendorPrefix` are matched case-insensitively,
+   and neither may contain whitespace.
 
 ## Procedures
 

--- a/spec/types/functions.md
+++ b/spec/types/functions.md
@@ -10,8 +10,10 @@
 ## Types
 
 The value type known as a "function" is a procedure that takes an
-`ArgumentInvocation` `args` and returns a SassScript value. Each function has a
+[`ArgumentList`] `args` and returns a SassScript value. Each function has a
 string name.
+
+[`ArgumentList`]: ../syntax.md#argumentlist
 
 > The specific details of executing this procedure differ depending on where and
 > how the function is defined.

--- a/spec/types/mixins.md
+++ b/spec/types/mixins.md
@@ -9,9 +9,11 @@
 
 ## Types
 
-The value type known as a "mixin" is a procedure that takes an
-`ArgumentInvocation` `args` and returns nothing. Each mixin has a string name
-and a boolean that indicates whether or not it accepts a content block.
+The value type known as a "mixin" is a procedure that takes an [`ArgumentList`]
+`args` and returns nothing. Each mixin has a string name and a boolean that
+indicates whether or not it accepts a content block.
+
+[`ArgumentList`]: ../syntax.md#argumentlist
 
 > The specific details of executing this procedure differ depending on where and
 > how the mixin is defined. A mixin will typically add nodes to the CSS


### PR DESCRIPTION
Also change the terminology from "argument declarations" and "argument
invocations" to the more standard "parameters" and "arguments",
respectively. This sets the stage for sass/sass#3994.