### PR TITLE
Deprecate configuring private variables when loading Sass modules

### DIFF
--- a/spec/deprecations.yaml
+++ b/spec/deprecations.yaml
@@ -147,3 +147,9 @@ global-builtin:
   dart-sass:
     status: active
     deprecated: 1.80.0
+
+private-identifier-module-config:
+  description: Private identifiers as configuration keys in `@use`, `@forward`, or `load-css()` are deprecated.
+  dart-sass:
+    status: active
+    deprecated: 1.85.2

--- a/spec/deprecations.yaml
+++ b/spec/deprecations.yaml
@@ -153,3 +153,9 @@ private-identifier-module-config:
   dart-sass:
     status: active
     deprecated: 1.85.2
+
+private-default-variable:
+  description: Using `!default` with private variables is deprecated.
+  dart-sass:
+    status: active
+    deprecated: 1.85.2

--- a/spec/deprecations.yaml
+++ b/spec/deprecations.yaml
@@ -148,13 +148,13 @@ global-builtin:
     status: active
     deprecated: 1.80.0
 
-private-identifier-module-config:
-  description: Private identifiers as configuration keys in `@use`, `@forward`, or `load-css()` are deprecated.
+private-variable-module-config:
+  description: Private variables as configuration keys in `@use`, `@forward`, or `load-css()` are deprecated.
   dart-sass:
     status: active
     deprecated: 1.85.2
 
-private-default-variable:
+private-variable-default:
   description: Using `!default` with private variables is deprecated.
   dart-sass:
     status: active


### PR DESCRIPTION
- Deprecate `!default` in private sass variables
- Deprecate configuration map keys for private variables (e.g. `$-foo`)

https://github.com/sass/sass/issues/4034