### PR TITLE
Further improve documentation around importers in the entrypoint

### DIFF
--- a/js-api-doc/options.d.ts
+++ b/js-api-doc/options.d.ts
@@ -231,11 +231,25 @@ export interface Options<sync extends 'sync' | 'async'> {
    *
    * Loads are resolved by trying, in order:
    *
-   * - The importer that was used to load the current stylesheet, with the
-   *   loaded URL resolved relative to the current stylesheet's canonical URL.
-   *   With {@link compileString} or {@link compileStringAsync}, relative loads
-   *   in the entrypoint stylesheet are resolved relative to {@link
-   *   StringOptions.url} and loaded with {@link StringOptions.importer}.
+   * - **For relative URLs only:** the URL resolved relative to the current
+   *   stylesheet's canonical URL, passed to the importer that loaded the current
+   *   stylesheet.
+   *
+   *   When calling {@link compileString} or {@link compileStringAsync}, the
+   *   entrypoint file isn't "loaded" in the same sense as other files. In that
+   *   case:
+   *
+   *   - {@link StringOptions.url} is the canonical URL and {@link
+   *     StringOptions.importer} is the importer that loaded it.
+   *
+   *   - If {@link StringOptions.importer} isn't passed and {@link
+   *     StringOptions.url} is a `file:` URL, the URL is loaded from the
+   *     filesystem by default. (You can disable this by passing `{canonicalize:
+   *     url => null}` as {@link StringOptions.importer}.)
+   *
+   *   - If {@link StringOptions.url} isn't passed but {@link
+   *     StringOptions.importer} is, the relative URL is passed to {@link
+   *     StringOptions.importer} as-is.
    *
    * - Each {@link Importer}, {@link FileImporter}, or
    *   {@link NodePackageImporter} in {@link importers}, in order.
@@ -414,18 +428,11 @@ export interface StringOptions<sync extends 'sync' | 'async'>
   syntax?: Syntax;
 
   /**
-   * The importer to use to handle loads that are relative to the entrypoint
-   * stylesheet.
+   * The importer to use to handle relative URL loads in the entrypoint
+   * stylesheet and stylesheets loaded relative to the entrypoint stylesheet.
    *
-   * A relative load's URL is first resolved relative to {@link url}, then
-   * passed to {@link importer}. (It's passed as-is if {@link url} isn't
-   * passed.) If the importer doesn't recognize it, it's then passed to {@link
-   * importers} and {@link loadPaths}.
-   *
-   * In most cases, if `importer` is passed, {@link url} should be passed as
-   * well, since any situation in which relative loads are meaningful is
-   * expected to be a situation in which the entrypoint has a location for those
-   * loads to be relative to.
+   * See {@link Options.importers} for details on how loads are resolved for the
+   * entrypoint stylesheet.
    *
    * @category Input
    */
@@ -434,10 +441,8 @@ export interface StringOptions<sync extends 'sync' | 'async'>
   /**
    * The canonical URL of the entrypoint stylesheet.
    *
-   * A relative load's URL is first resolved relative to {@link url}, then
-   * resolved to a file on disk if it's a `file://` URL. If it can't be resolved
-   * to a file on disk, it's then passed to {@link importers} and {@link
-   * loadPaths}.
+   * See {@link Options.importers} for details on how loads are resolved for the
+   * entrypoint stylesheet.
    *
    * @category Input
    * @compatibility feature: "Undefined URL with importer", dart: "1.75.0", node: false

--- a/spec/deprecations.yaml
+++ b/spec/deprecations.yaml
@@ -153,3 +153,9 @@ type-function:
   dart-sass:
     status: active
     deprecated: 1.86.0
+
+compile-string-relative-url:
+  description: 'Passing a relative url to compileString().'
+  dart-sass:
+    status: active
+    deprecated: 1.88.0

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -158,16 +158,6 @@ It runs as follows:
 
 * Let `ast` be the result of [parsing] `text` as `syntax`.
 
-* If `url` is null:
-
-  * If `importer` is not null, throw an error.
-
-  * Set `url` to a unique value.
-
-    > This ensures that all source files have a valid URL. When displaying this
-    > value, implementations should help users understand the source of the string
-    > if possible.
-
 * If `importer` is null:
 
   * If `url` is a `file:` URL, set `importer` to be a [filesystem importer] with an


### PR DESCRIPTION
This also updates the spec to match the changes in
sass/dart-sass#2208. This behavior is already largely the actual
behavior of both the JS and Dart APIs, so it doesn't need a full
proposal process. The only difference is that Dart Sass (but not the
JS API) currently accepts relative `url` arguments to
`compileString()`, but because the URL was already as a canonical URL,
we consider it implicitly expected to be absolute anyway.