### PR TITLE
Allow the Node.js pkg importer to return the same URL multiple times

### DIFF
--- a/spec/modules.md
+++ b/spec/modules.md
@@ -707,9 +707,10 @@ This algorithm takes a package.json value `packageManifest`, a directory URL
   "style"])` as defined in the [Node resolution algorithm specification], with
   each `subpathIndexVariants` as `subpathVariant`.
 
-* If `resolvedIndexPaths` contains more than one resolved URL, throw an error.
+* If `resolvedIndexPaths` contains more than one distinct resolved URL (compared
+  using string equality), throw an error.
 
-* If `resolvedIndexPaths` contains exactly one resolved URL, return it.
+* If `resolvedIndexPaths` contains exactly one distinct resolved URL, return it.
 
 * Return null.
 


### PR DESCRIPTION
Previously, if multiple URLs were found by this importer, it would
throw an error even if every URL was identical (for example if there
were multiple routes to the same file). This now allows multiple URLs
as long as they're not distinct.

This is a fast-track proposal.

Closes #4080