### PR TITLE
Allow modules to be re-loaded with configs they don't use

### DIFF
--- a/spec/modules.md
+++ b/spec/modules.md
@@ -362,11 +362,17 @@ This algorithm takes a string `argument` and [configuration](#configuration)
 
   [executed]: spec.md#executing-a-file
 
-  * If `config` is not empty and has a different ID than the configuration that
-    was passed the first time `file` was executed by the [Loading a Module]
-    procedure, throw an error.
+  * If `config` has a different ID than the configuration that was passed the
+    first time `file` was executed by the [Loading a Module] procedure and
+    `module` contains at least one variable with a `!default` flag whose name
+    appears in `config`, throw an error.
 
-    > An ID may be reused in a new configuration via [`@forward ... with`].
+    > An ID may be reused in a new configuration via [`@forward ... with`]. It's
+    > valid to load a module with a configuration it doesn't use, but all module
+    > loads (`@use`, `@forward`, and `meta.load-css()`) verify that all
+    > configured variables are used, so in practice this only avoids errors for
+    > `@forward`ed modules that happen to have configurations passed "past"
+    > them.
 
   * Otherwise, return the module that execution produced.
 


### PR DESCRIPTION
This is a fast-track proposal. It introduces no breaking changes, and
in fact reduces the surface area of specified errors. (Note that these
errors weren't being consistently applied previously.)

See sass/dart-sass#2598