### PR TITLE
Specify support for CSS numbers with complex units

### DIFF
--- a/spec/types/calculation.md
+++ b/spec/types/calculation.md
@@ -130,13 +130,9 @@ To serialize a `CalculationOperation`:
 
 To serialize a `Number` within a `CalculationExpression`:
 
-* If the number is [degenerate]:
-
-  * If the number has more than one numerator unit, or more than zero denominator
-    units, throw an error.
-
-  * Otherwise, [convert the number to a calculation], then serialize the
-    resulting calculation's sole argument.
+* If the number has more than one numerator unit, more than zero denominator
+  units, of if it's [degenerate], [convert the number to a calculation], then
+  serialize the resulting calculation's sole argument.
 
   [degenerate]: number.md#degenerate-number
   [convert the number to a calculation]: number.md#converting-a-number-to-a-calculation

--- a/spec/types/number.md
+++ b/spec/types/number.md
@@ -347,12 +347,11 @@ units are the same as `number`'s.
 
 To serialize a number to CSS:
 
-* If the number has more than one numerator unit, or more than zero denominator
-  units, throw an error.
+* If the number has more than one numerator unit, more than zero denominator
+  units, or if it's [degenerate], [convert it to a calculation] then serialize
+  that to CSS.
 
-* If the number is degenerate, [convert it to a calculation] then serialize that
-  to CSS.
-
+  [degenerate]: #degenerate-number
   [convert it to a calculation]: #converting-a-number-to-a-calculation
 
 * Otherwise:


### PR DESCRIPTION
Closes #4156

This is a fast-track proposal, since it adds no backwards-incompatibilities and involves few modifications to the specification.