### PR TITLE
Add deprecation entry for case-insensitive function names

### DIFF
--- a/spec/deprecations.yaml
+++ b/spec/deprecations.yaml
@@ -180,3 +180,9 @@ if-function:
   dart-sass:
     status: active
     deprecated: 1.95.0
+
+case-insensitive-function:
+  description: Function names whose name differ from reserved names.
+  dart-sass:
+    status: active
+    deprecated: 1.96.0


### PR DESCRIPTION
Part of case-insensitive function deprecation:

- Dart Sass emits the warning: https://github.com/sass/dart-sass/pull/2716
- Tests in sass-spec: https://github.com/sass/sass-spec/pull/2100