### PR TITLE
Migrate from bufbuild/buf-setup-action to bufbuild/buf-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: bufbuild/buf-setup-action@v1.50.0
-        with: {github_token: "${{ github.token }}"}
+      - uses: bufbuild/buf-action@v1
+        with:
+          setup_only: true
       - name: Generate protobuf code
         run: buf generate
 


### PR DESCRIPTION
`buf-setup-action` has been deprecated: https://github.com/bufbuild/buf-action#migrating-from-individual-buf-actions